### PR TITLE
Add exclude lists in rat config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,25 @@ limitations under the License.
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>.gitattributes</exclude>
+                        <exclude>.gitignore</exclude>
+                        <exclude>.git/**</exclude>
+                        <!-- Intellij idea project files -->
+                        <exclude>lang/java/.idea/**</exclude>
+                        <exclude>**/*.iml</exclude>
+                        <exclude>**/target/**</exclude>
+                        <!-- ReadMe files -->
+                        <exclude>**/README.*</exclude>
+                        <exclude>**/*.md</exclude>
+                        <!-- The below are sometimes created during tests -->
+                        <exclude>REEF_LOCAL_RUNTIME/**</exclude>
+                        <exclude>REEF_MESOS_RUNTIME/**</exclude>
+                        <!-- JVM error logs, especially troublesome on CI servers -->
+                        <exclude>**/hs_err_*.log</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <id>validate</id>


### PR DESCRIPTION
This PR addresses missing excludes list for apache rat configuration in pom.xml in PR #30.

Closes #29
