### PR TITLE
[MIST-106] Define initial protocol for client-to-task messages

### DIFF
--- a/src/main/avro/client_to_task_msg.avpr
+++ b/src/main/avro/client_to_task_msg.avpr
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * This protocol defines the client message to mist tasks. The current implemented part is query submission action.
+ **/
+{"namespace": "edu.snu.mist.common.bridge.formats.avro", "protocol": "ClientToTaskMessage", "type": "record", "name": "ClientToTaskMessage", "fields": [
+    {"name": "MessageType", "type": "enum", "symbols": ["SUBMIT_QUERY"]},
+    {"name": "Contents", "type": [
+        {"type": "record", "name": "LogicalPlan", "fields": [
+            {"name": "Vertices", "type": "array", "value": {"name": "Vertex", "type": "record", "fields": [
+                {"name": "VertexType", "type": "enum", "symbols": ["SOURCE", "INSTANT_OPERATOR", "WINDOW_OPERATOR",
+                    "SINK"]},
+                {"name": "Attributes", "type": [
+                    {"name": "SourceInfo", "type": "record", "fields": [
+                        {"name": "SourceType", "type": "enum", "symbols": ["REEF_NETWORK_SOURCE"]},
+                        {"name": "SourceConfiguration", "type": "map", "value": "bytes"}
+                    ]},
+                    {"name": "InstantOperatorInfo", "type": "record", "fields": [
+                        {"name": "InstantOperatorType", "type": "enum", "symbols": [
+                            "APPLY_STATEFUL", "FILTER", "FLAT_MAP", "MAP", "REDUCE_BY_KEY", "REDUCE_BY_KEY_WINDOW"
+                        ]},
+                        {"name": "Functions", "type": "array", "value": "bytes"}
+                    ]},
+                    {"name": "WindowOperatorInfo", "type": "record", "fields": [
+                        {"name": "SizePolicyType", "type": "enum", "symbols": ["TIME"]},
+                        {"name": "SizePolicyInfo", "type": [
+                            {"name": "TimeDuration", "type": "integer"}
+                        ]},
+                        {"name": "EmitPolicyType", "type": "enum", "symbols": ["TIME"]},
+                        {"name": "EmitPolicyInfo", "type": [
+                            {"name": "TimeInterval", "type": "integer"}
+                        ]}
+                    ]},
+                    {"name": "SinkInfo", "type": "record", "fields": [
+                        {"name": "SinkType", "type": "enum", "symbols": ["REEF_NETWORK_SOURCE"]},
+                        {"name": "SinkConfiguration", "type": "map", "value": "bytes"}
+                    ]}
+                ]}
+            ]}},
+            {"name": "Edges", "type": "array", "value": {"name": "Edge", "type": "record", "fields": [
+                {"name": "From", "type": "integer"},
+                {"name": "To", "type": "integer"}
+            ]}}
+        ]}
+    ]}
+]}


### PR DESCRIPTION
This PR contains the code about defining protocols for client-to-task messages.

It now only supports one action, `SUBMIT_QUERY`, and implemented necessary information for the action.
