### PR TITLE
[MIST-134] Support primitive types for source/sink configuration in LogicalPlan

### DIFF
--- a/src/main/avro/client_to_task_msg.avpr
+++ b/src/main/avro/client_to_task_msg.avpr
@@ -33,7 +33,9 @@
                             {"name": "SourceType", "type": {
                                 "name": "SourceTypeEnum", "type": "enum", "symbols": ["REEF_NETWORK_SOURCE"]
                             }},
-                            {"name": "SourceConfiguration", "type": {"type": "map", "values": "bytes"}}
+                            {"name": "SourceConfiguration", "type": {"type": "map", "values": [
+                                "bytes", "int", "string", "float", "boolean"
+                            ]}}
                         ]},
                         {"name": "InstantOperatorInfo", "type": "record", "fields": [
                             {"name": "InstantOperatorType", "type": {
@@ -61,7 +63,9 @@
                             {"name": "SinkType", "type": {
                                 "name": "SinkTypeEnum", "type": "enum", "symbols": ["REEF_NETWORK_SOURCE"]
                             }},
-                            {"name": "SinkConfiguration", "type": {"type": "map", "values": "bytes"}}
+                            {"name": "SinkConfiguration", "type": {"type": "map", "values": [
+                                "bytes", "int", "string", "float", "boolean"
+                            ]}}
                         ]}
                     ]}
                 ]}
@@ -75,10 +79,10 @@
             {"name": "IsSuccessful", "type": "boolean"},
             {"name": "FailDescription", "type": "string"}
         ]}
-    ]},
+    ],
     "messages": {
        "sendQueries": {
-           "request": "LogicalPlan",
+           "request":  [{"name": "logicalPlan", "type": "LogicalPlan"}],
            "response": "QuerySubmissionResult"
        }
     }


### PR DESCRIPTION
This PR is for supporting primitive types other than `bytes` (e.g. `int`, `boolean`, `string`, ...) in avro `LogicalPlan` schema.

Closes #134.
