### PR TITLE
[MIST-145] Change the name of PhysicalToChainedPlan to OperatorChainer

### DIFF
--- a/src/main/java/edu/snu/mist/task/DefaultOperatorChainerImpl.java
+++ b/src/main/java/edu/snu/mist/task/DefaultOperatorChainerImpl.java
@@ -20,15 +20,15 @@ import edu.snu.mist.task.operators.Operator;
 import javax.inject.Inject;
 
 // TODO[MIST-69]: Partitioning physical plans into OperatorChains by chaining operators
-final class DefaultPhysicalToChainedPlanImpl implements PhysicalToChainedPlan {
+final class DefaultOperatorChainerImpl implements OperatorChainer {
 
   @Inject
-  private DefaultPhysicalToChainedPlanImpl() {
+  private DefaultOperatorChainerImpl() {
 
   }
 
   @Override
-  public PhysicalPlan<OperatorChain> convertToChainedPlan(final PhysicalPlan<Operator> plan) {
+  public PhysicalPlan<OperatorChain> chainOperators(final PhysicalPlan<Operator> plan) {
     throw new RuntimeException("DefaultPhysicalToChainedPlanImpl.convertToChainedPlan is not implemented yet");
   }
 }

--- a/src/main/java/edu/snu/mist/task/MistTask.java
+++ b/src/main/java/edu/snu/mist/task/MistTask.java
@@ -53,14 +53,14 @@ public final class MistTask implements Task {
   /**
    * Default constructor of MistTask.
    * @param chainAllocator an allocator, which allocates a OperatorChain to a MistExecutor
-   * @param physicalToChainedPlan a converter, which chains operators and makes OperatorChains
+   * @param operatorChainer a converter, which chains operators and makes OperatorChains
    * @param receiver logical plan receiver, which converts the logical plans to physical plans
    * @param executorListProvider executor list provider, which returns the list of executors
    * @throws InjectionException
    */
   @Inject
   private MistTask(final OperatorChainAllocator chainAllocator,
-                   final PhysicalToChainedPlan physicalToChainedPlan,
+                   final OperatorChainer operatorChainer,
                    final LogicalPlanReceiver receiver,
                    final ExecutorListProvider executorListProvider) throws InjectionException {
     this.countDownLatch = new CountDownLatch(1);
@@ -71,7 +71,7 @@ public final class MistTask implements Task {
     receiver.setHandler(physicalPlan -> {
       // 3) Chains the physical operators and make OperatorChain.
       final PhysicalPlan<OperatorChain> chainedPlan =
-          physicalToChainedPlan.convertToChainedPlan(physicalPlan);
+          operatorChainer.chainOperators(physicalPlan);
 
       final DAG<OperatorChain> chainedOperators = chainedPlan.getOperators();
       // 4) Allocates the OperatorChains to the MistExecutors

--- a/src/main/java/edu/snu/mist/task/OperatorChainer.java
+++ b/src/main/java/edu/snu/mist/task/OperatorChainer.java
@@ -22,12 +22,12 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
  * This interface converts a PhysicalPlan<Operator> to a PhysicalPlan<OperatorChain>
  * by chaining the operators.
  */
-@DefaultImplementation(DefaultPhysicalToChainedPlanImpl.class)
-public interface PhysicalToChainedPlan {
+@DefaultImplementation(DefaultOperatorChainerImpl.class)
+public interface OperatorChainer {
   /**
-   * Converts the PhysicalPlan<Operator> to the PhysicalPlan<OperatorChain>.
+   * Chains the operators and converts the PhysicalPlan<Operator> to the PhysicalPlan<OperatorChain>.
    * @param plan a plan
-   * @return a chained physical plan
+   * @return a physical plan which contains OperatorChain.
    */
-  PhysicalPlan<OperatorChain> convertToChainedPlan(PhysicalPlan<Operator> plan);
+  PhysicalPlan<OperatorChain> chainOperators(PhysicalPlan<Operator> plan);
 }


### PR DESCRIPTION
This pull request addressed the issue #145 by
- changing the name of `PhysicalToChainedPlan` to `OperatorChainer`

Closes #145 
