### PR TITLE
[MIST-53] Make MISTExecutionEnvironment for submitting queries

### DIFF
--- a/src/main/java/edu/snu/mist/api/APIQuerySubmissionResult.java
+++ b/src/main/java/edu/snu/mist/api/APIQuerySubmissionResult.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.api;
+
+/**
+ * This interface is the basic representation of query result.
+ */
+public interface APIQuerySubmissionResult {
+  String getQueryId();
+}

--- a/src/main/java/edu/snu/mist/api/APIQuerySubmissionResultImpl.java
+++ b/src/main/java/edu/snu/mist/api/APIQuerySubmissionResultImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.api;
+
+/**
+ * Basic Implementation of APIQuerySubmissionResult.
+ */
+public class APIQuerySubmissionResultImpl implements APIQuerySubmissionResult {
+
+  private final String queryId;
+
+  public APIQuerySubmissionResultImpl(final String queryId) {
+    this.queryId = queryId;
+  }
+
+  public APIQuerySubmissionResultImpl(final CharSequence queryId) {
+    this.queryId = queryId.toString();
+  }
+
+  @Override
+  public String getQueryId() {
+    return this.queryId;
+  }
+}

--- a/src/main/java/edu/snu/mist/api/MISTExecutionEnvironment.java
+++ b/src/main/java/edu/snu/mist/api/MISTExecutionEnvironment.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.api;
+
+import org.apache.reef.tang.exceptions.InjectionException;
+
+import java.io.IOException;
+
+/**
+ * Execution Environment for MIST.
+ * MIST Client can submit queries via this class.
+ */
+public interface MISTExecutionEnvironment {
+  APIQuerySubmissionResult submit(MISTQuery queryToSubmit) throws IOException, InjectionException;
+}

--- a/src/main/java/edu/snu/mist/api/MISTExecutionEnvironmentImpl.java
+++ b/src/main/java/edu/snu/mist/api/MISTExecutionEnvironmentImpl.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.api;
+
+import edu.snu.mist.api.serialize.avro.MISTQuerySerializer;
+import edu.snu.mist.formats.avro.ClientToTaskMessage;
+import edu.snu.mist.formats.avro.LogicalPlan;
+import edu.snu.mist.formats.avro.QuerySubmissionResult;
+import mist.MistTaskProvider;
+import org.apache.avro.ipc.NettyTransceiver;
+import org.apache.avro.ipc.specific.SpecificRequestor;
+import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+/**
+ * The basic implementation class for MISTExecutionEnvironment.
+ * It uses avro RPC for communication with the Driver and the Task.
+ * It gets a task list from Driver, change the query to a LogicalPlan,
+ * send the LogicalPlan to one of the tasks and get QuerySubmissionResult,
+ * transform QuerySubmissionResult to APIQuerySubmissionResult and return it.
+ */
+public final class MISTExecutionEnvironmentImpl implements MISTExecutionEnvironment {
+  private final String serverAddr;
+  private final int serverPort;
+  private final MISTQuerySerializer querySerializer;
+  private final Injector injector;
+
+  public MISTExecutionEnvironmentImpl(final String serverAddr,
+                                      final int serverPort) throws InjectionException {
+    this.serverAddr = serverAddr;
+    this.serverPort = serverPort;
+    injector = Tang.Factory.getTang().newInjector();
+    querySerializer = injector.getInstance(MISTQuerySerializer.class);
+  }
+
+  /**
+   * Submit the query to a task.
+   * @param queryToSubmit the query to submit.
+   * @return the result of the submitted query.
+   */
+  @Override
+  public APIQuerySubmissionResult submit(final MISTQuery queryToSubmit) throws IOException {
+    // Step 1: Get a task list from Driver
+    final NettyTransceiver clientToDriver = new NettyTransceiver(new InetSocketAddress(serverAddr, serverPort));
+    final MistTaskProvider proxyToDriver =
+        SpecificRequestor.getClient(MistTaskProvider.class, clientToDriver);
+    final mist.TaskList taskList = proxyToDriver.getTasks(new mist.QueryInfo());
+    final java.util.List<mist.IPAddress> tasks = taskList.getTasks();
+
+    // Step 2: Change the query to a LogicalPlan
+    final LogicalPlan logicalPlan = querySerializer.queryToLogicalPlan(queryToSubmit);
+
+    // Step 3: Send the LogicalPlan to one of the tasks and get QuerySubmissionResult
+    final mist.IPAddress task = tasks.get(0);
+    final NettyTransceiver clientToTask = new NettyTransceiver(
+        new InetSocketAddress(task.getHostAddress().toString(), task.getPort()));
+    final ClientToTaskMessage proxyToTask =
+        SpecificRequestor.getClient(ClientToTaskMessage.class, clientToTask);
+    final QuerySubmissionResult querySubmissionResult = proxyToTask.sendQueries(logicalPlan);
+
+    // Step 4: Transform QuerySubmissionResult to APIQuerySubmissionResult
+    APIQuerySubmissionResult apiQuerySubmissionResult =
+        new APIQuerySubmissionResultImpl(querySubmissionResult.getQueryId());
+    return apiQuerySubmissionResult;
+  }
+}

--- a/src/test/java/edu/snu/mist/api/MISTExecutionEnvironmentImplTest.java
+++ b/src/test/java/edu/snu/mist/api/MISTExecutionEnvironmentImplTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.snu.mist.api;
+
+import edu.snu.mist.api.sources.REEFNetworkSourceStream;
+import edu.snu.mist.api.types.Tuple2;
+import edu.snu.mist.formats.avro.ClientToTaskMessage;
+import edu.snu.mist.formats.avro.LogicalPlan;
+import edu.snu.mist.formats.avro.QuerySubmissionResult;
+import mist.MistTaskProvider;
+import mist.QueryInfo;
+import mist.TaskList;
+import org.apache.avro.AvroRemoteException;
+import org.apache.avro.ipc.NettyServer;
+import org.apache.avro.ipc.Server;
+import org.apache.avro.ipc.specific.SpecificResponder;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+
+/**
+ * The test class for MISTExecutionEnvironmentImpl.
+ */
+public class MISTExecutionEnvironmentImplTest {
+
+  private final String hostName = "localhost";
+  private final int driverPortNum = 65111;
+  private final int taskPortNum = 65110;
+  private final String testQueryResult = "TestQueryResult";
+
+  private class MockDriverServer implements MistTaskProvider {
+    @Override
+    public TaskList getTasks(final QueryInfo queryInfo) throws AvroRemoteException {
+      return new TaskList(Arrays.asList(new mist.IPAddress(hostName, taskPortNum)));
+    }
+  }
+
+  private class MockTaskServer implements  ClientToTaskMessage {
+    @Override
+    public QuerySubmissionResult sendQueries(final LogicalPlan logicalPlan) throws AvroRemoteException {
+      return new QuerySubmissionResult(testQueryResult);
+    }
+  }
+
+  /**
+   * Test for MISTExecutionEnvironmentImpl.
+   */
+  @Test
+  public void testMISTExecutionEnvironment() throws IOException, InjectionException {
+    // Step 1: Launch mock RPC Server
+    final Server driverServer = new NettyServer(new SpecificResponder(MistTaskProvider.class, new MockDriverServer()),
+        new InetSocketAddress(driverPortNum));
+    final Server taskServer = new NettyServer(new SpecificResponder(ClientToTaskMessage.class, new MockTaskServer()),
+        new InetSocketAddress(taskPortNum));
+
+    // Step 2: Generate a new query
+    final MISTQuery query = new REEFNetworkSourceStream<String>(APITestParameters.TEST_REEF_NETWORK_SOURCE_CONF)
+        .flatMap(s -> Arrays.asList(s.split(" ")))
+        .map(s -> new Tuple2<>(s, 1))
+        .reduceByKey(0, String.class, (Integer x, Integer y) -> x + y)
+        .reefNetworkOutput(APITestParameters.TEST_REEF_NETWORK_SINK_CONF)
+        .getQuery();
+
+    // Step 3: Send a query and check whether the query comes to the task correctly
+    final MISTExecutionEnvironment executionEnvironment = new MISTExecutionEnvironmentImpl(hostName, driverPortNum);
+    final APIQuerySubmissionResult result = executionEnvironment.submit(query);
+    Assert.assertEquals(result.getQueryId(), testQueryResult);
+  }
+}


### PR DESCRIPTION
This pull request addressed the issue #53 by
- connect to the driver and get the list of the tasks (currently MIST contains one task).
- connect to the first task, send the query to the task, return the result.
- Implement `APIQuerySubmissionResult`

Closes #53.
