### PR TITLE
[MIST-157] Generate a query correctly in MISTQueryImplTest

### DIFF
--- a/src/test/java/edu/snu/mist/api/MISTQueryImplTest.java
+++ b/src/test/java/edu/snu/mist/api/MISTQueryImplTest.java
@@ -17,33 +17,33 @@
 package edu.snu.mist.api;
 
 import edu.snu.mist.api.sink.Sink;
-import edu.snu.mist.api.sink.SinkImpl;
-import edu.snu.mist.api.sink.builder.DefaultSinkConfigurationImpl;
-import edu.snu.mist.api.sink.builder.SinkConfiguration;
+import edu.snu.mist.api.sources.REEFNetworkSourceStream;
+import edu.snu.mist.api.types.Tuple2;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
 /**
  * The test class for SourceConfiguration.
  */
-public class MISTQueryImplTest {
+public final class MISTQueryImplTest {
 
   /**
    * Test for MISTQueryImpl.
    */
   @Test
   public void testMISTQuery() {
-    final SinkConfiguration sinkConfiguration = new DefaultSinkConfigurationImpl(new HashMap<>());
-    final Sink sink = new SinkImpl(new MISTStreamImpl(StreamType.BasicType.CONTINUOUS),
-        StreamType.SinkType.REEF_NETWORK_SINK, sinkConfiguration);
-    final MISTQuery singleSinkQuery = new MISTQueryImpl(sink);
+    final Sink sink = new REEFNetworkSourceStream<String>(APITestParameters.TEST_REEF_NETWORK_SOURCE_CONF)
+        .flatMap(s -> Arrays.asList(s.split(" ")))
+        .map(s -> new Tuple2<>(s, 1))
+        .reduceByKey(0, String.class, (Integer x, Integer y) -> x + y)
+        .reefNetworkOutput(APITestParameters.TEST_REEF_NETWORK_SINK_CONF);
+    final MISTQuery query = sink.getQuery();
 
-    Assert.assertTrue(singleSinkQuery.getQuerySinks().contains(sink));
+    Assert.assertTrue(query.getQuerySinks().contains(sink));
 
     final Set<Sink> sinkSet = new HashSet<>(Arrays.asList(sink));
     final MISTQuery sinkSetQuery = new MISTQueryImpl(sinkSet);


### PR DESCRIPTION
This pull request addressed the issue #157 by generating a query correctly in MISTQueryImplTest.

Closes #157
