### PR TITLE
[MIST-189] Launcher: Fix bugs in occurred while trying to run MIST driver through command line

### DIFF
--- a/src/main/java/edu/snu/mist/Mist.java
+++ b/src/main/java/edu/snu/mist/Mist.java
@@ -49,8 +49,11 @@ public final class Mist {
         .registerShortNameOfClass(NumExecutors.class)
         .registerShortNameOfClass(NumTasks.class)
         .registerShortNameOfClass(RPCServerPort.class)
-        .registerShortNameOfClass(TaskMemorySize.class);
-    commandLine.processCommandLine(args);
+        .registerShortNameOfClass(TaskMemorySize.class)
+        .processCommandLine(args);
+    if (commandLine == null) { // Option '?' was entered and processCommandLine printed the help.
+      return null;
+    }
     return jcb.build();
   }
 
@@ -60,7 +63,12 @@ public final class Mist {
    */
   public static void main(final String[] args) throws Exception {
     final Configuration commandLineConf = getCommandLineConf(args);
-    final LauncherStatus status = MistLauncher.getLauncherFromConf(commandLineConf).runFromConf(commandLineConf);
+    if (commandLineConf == null) {
+      return;
+    }
+    final LauncherStatus status = MistLauncher
+        .getLauncherFromConf(commandLineConf)
+        .runFromConf(commandLineConf);
     LOG.log(Level.INFO, "Mist completed: {0}", status);
   }
 

--- a/src/main/java/edu/snu/mist/launcher/MistLauncher.java
+++ b/src/main/java/edu/snu/mist/launcher/MistLauncher.java
@@ -166,9 +166,8 @@ public final class MistLauncher {
     jcb.bindNamedParameter(NumTasks.class, Integer.toString(numTasks));
     jcb.bindNamedParameter(RPCServerPort.class, Integer.toString(rpcServerPort));
     jcb.bindNamedParameter(TaskMemorySize.class, Integer.toString(taskMemorySize));
-    final Configuration driverConf = getDriverConfiguration(jcb.build());
 
-    return runFromConf(driverConf);
+    return runFromConf(jcb.build());
   }
 
   /**
@@ -179,7 +178,8 @@ public final class MistLauncher {
    */
   public LauncherStatus runFromConf(final Configuration driverConf) throws InjectionException {
     final DriverLauncher launcher = DriverLauncher.getLauncher(mistRuntimeConf);
-    final LauncherStatus status = timeOut == 0 ? launcher.run(driverConf) : launcher.run(driverConf, timeOut);
+    final Configuration mistDriverConf = getDriverConfiguration(driverConf);
+    final LauncherStatus status = timeOut == 0 ? launcher.run(mistDriverConf) : launcher.run(mistDriverConf, timeOut);
 
     LOG.log(Level.INFO, "Mist completed: {0}", status);
 


### PR DESCRIPTION
This pull request addressed the issue #189 by
- Shutting down the client when `-?` is entered (`Mist.java`)
- Pass driver configuration correctly (`MistLauncher.java`)

Closes #189
