### PR TITLE
[MIST-13] Implement KAFKA source & sink API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ limitations under the License.
         <project.build.directory>target</project.build.directory>
         <maven-checkstyle-plugin.version>2.15</maven-checkstyle-plugin.version>
         <checkstyle.version>6.6</checkstyle.version>
-        <avro.version>1.7.7</avro.version>
+        <avro.version>1.8.0</avro.version>
     </properties>
 
     <organization>

--- a/src/main/avro/client_to_task_msg.avpr
+++ b/src/main/avro/client_to_task_msg.avpr
@@ -66,7 +66,7 @@
                             "type": "enum",
                             "symbols":
                             [
-                              "REEF_NETWORK_SOURCE","TEXT_SOCKET_SOURCE"
+                              "REEF_NETWORK_SOURCE", "TEXT_SOCKET_SOURCE", "TEXT_KAFKA_SOURCE"
                             ]
                           }
                         },
@@ -172,7 +172,7 @@
                             "type": "enum",
                             "symbols":
                             [
-                              "REEF_NETWORK_SINK", "TEXT_SOCKET_SINK"
+                              "REEF_NETWORK_SINK", "TEXT_SOCKET_SINK", "TEXT_KAFKA_SINK"
                             ]
                           }
                         },

--- a/src/main/avro/physical_plan.avsc
+++ b/src/main/avro/physical_plan.avsc
@@ -89,7 +89,7 @@
                               "type": "enum",
                               "symbols":
                               [
-                                "REEF_NETWORK_SOURCE","TEXT_SOCKET_SOURCE"
+                                "REEF_NETWORK_SOURCE","TEXT_SOCKET_SOURCE","TEXT_KAFKA_SOURCE"
                               ]
                             }
                           },
@@ -195,7 +195,7 @@
                               "type": "enum",
                               "symbols":
                               [
-                                "REEF_NETWORK_SINK", "TEXT_SOCKET_SINK"
+                                "REEF_NETWORK_SINK", "TEXT_SOCKET_SINK", "TEXT_KAFKA_SINK"
                               ]
                             }
                           },

--- a/src/main/java/edu/snu/mist/api/ContinuousStream.java
+++ b/src/main/java/edu/snu/mist/api/ContinuousStream.java
@@ -104,4 +104,11 @@ public interface ContinuousStream<T> extends MISTStream<T> {
    * @return new sink for the current stream
    */
   Sink textSocketOutput(SinkConfiguration sinkConfiguration);
+
+  /**
+   * It defines a text Kafka output Sink for the current stream according to the SinkConfiguration.
+   * @param sinkConfiguration
+   * @return new sink for the current stream
+   */
+  Sink textKafkaOutput(SinkConfiguration sinkConfiguration);
 }

--- a/src/main/java/edu/snu/mist/api/ContinuousStreamImpl.java
+++ b/src/main/java/edu/snu/mist/api/ContinuousStreamImpl.java
@@ -106,4 +106,9 @@ public abstract class ContinuousStreamImpl<T> extends MISTStreamImpl<T> implemen
   public Sink textSocketOutput(final SinkConfiguration sinkConfiguration) {
     return new SinkImpl(this, StreamType.SinkType.TEXT_SOCKET_SINK, sinkConfiguration);
   }
+
+  @Override
+  public Sink textKafkaOutput(final SinkConfiguration sinkConfiguration) {
+    return new SinkImpl(this, StreamType.SinkType.TEXT_KAFKA_SINK, sinkConfiguration);
+  }
 }

--- a/src/main/java/edu/snu/mist/api/StreamType.java
+++ b/src/main/java/edu/snu/mist/api/StreamType.java
@@ -37,12 +37,12 @@ public final class StreamType {
   /**
    * The type of source stream.
    */
-  public static enum SourceType {REEF_NETWORK_SOURCE, TEXT_SOCKET_SOURCE}
+  public static enum SourceType {REEF_NETWORK_SOURCE, TEXT_SOCKET_SOURCE, TEXT_KAFKA_SOURCE}
 
   /**
    * The type of sink stream.
    */
-  public static enum SinkType {REEF_NETWORK_SINK, TEXT_SOCKET_SINK}
+  public static enum SinkType {REEF_NETWORK_SINK, TEXT_SOCKET_SINK, TEXT_KAFKA_SINK}
 
   /**
    * The type of operator stream.

--- a/src/main/java/edu/snu/mist/api/serialize/avro/SinkInfoProviderImpl.java
+++ b/src/main/java/edu/snu/mist/api/serialize/avro/SinkInfoProviderImpl.java
@@ -37,7 +37,7 @@ public final class SinkInfoProviderImpl implements SinkInfoProvider {
 
   @Inject
   private SinkInfoProviderImpl() {
-
+    // Not called.
   }
 
   @Override
@@ -48,6 +48,8 @@ public final class SinkInfoProviderImpl implements SinkInfoProvider {
       sinkInfoBuilder.setSinkType(SinkTypeEnum.REEF_NETWORK_SINK);
     } else if (sink.getSinkType() == StreamType.SinkType.TEXT_SOCKET_SINK) {
       sinkInfoBuilder.setSinkType(SinkTypeEnum.TEXT_SOCKET_SINK);
+    } else if (sink.getSinkType() == StreamType.SinkType.TEXT_KAFKA_SINK) {
+      sinkInfoBuilder.setSinkType(SinkTypeEnum.TEXT_KAFKA_SINK);
     } else {
       throw new IllegalStateException("Sink type is illegal!");
     }

--- a/src/main/java/edu/snu/mist/api/serialize/avro/SourceInfoProviderImpl.java
+++ b/src/main/java/edu/snu/mist/api/serialize/avro/SourceInfoProviderImpl.java
@@ -48,6 +48,8 @@ public final class SourceInfoProviderImpl implements SourceInfoProvider {
       sourceInfoBuilder.setSourceType(SourceTypeEnum.REEF_NETWORK_SOURCE);
     } else if (sourceStream.getSourceType() == StreamType.SourceType.TEXT_SOCKET_SOURCE) {
       sourceInfoBuilder.setSourceType(SourceTypeEnum.TEXT_SOCKET_SOURCE);
+    } else if (sourceStream.getSourceType() == StreamType.SourceType.TEXT_KAFKA_SOURCE) {
+      sourceInfoBuilder.setSourceType(SourceTypeEnum.TEXT_KAFKA_SOURCE);
     } else {
       throw new IllegalStateException("Source type is illegal!");
     }

--- a/src/main/java/edu/snu/mist/api/sink/builder/TextKafkaSinkConfigurationBuilderImpl.java
+++ b/src/main/java/edu/snu/mist/api/sink/builder/TextKafkaSinkConfigurationBuilderImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.api.sink.builder;
+
+import edu.snu.mist.api.StreamType;
+import edu.snu.mist.api.sink.parameters.TextKafkaSinkParameters;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+
+/**
+ * This class builds SinkConfiguration of TextKafkaStreamSink.
+ */
+public final class TextKafkaSinkConfigurationBuilderImpl extends SinkConfigurationBuilderImpl {
+
+  /**
+   * Required parameters for TextKafkaSink.
+   */
+  private final String[] textKafkaStreamSinkParameters = {
+      TextKafkaSinkParameters.KAFKA_HOST_ADDRESS,
+      TextKafkaSinkParameters.KAFKA_HOST_PORT,
+      TextKafkaSinkParameters.KAFKA_TOPIC_NAME,
+      TextKafkaSinkParameters.KAFKA_NUM_PARTITION
+  };
+
+  @Inject
+  public TextKafkaSinkConfigurationBuilderImpl() {
+    requiredParameters.addAll(Arrays.asList(textKafkaStreamSinkParameters));
+  }
+
+  @Override
+  public StreamType.SinkType getSinkType() {
+    return StreamType.SinkType.TEXT_KAFKA_SINK;
+  }
+}

--- a/src/main/java/edu/snu/mist/api/sink/parameters/SinkSerializeInfo.java
+++ b/src/main/java/edu/snu/mist/api/sink/parameters/SinkSerializeInfo.java
@@ -41,6 +41,10 @@ public final class SinkSerializeInfo {
           .put(REEFNetworkSinkParameters.RECEIVER_ID, SerializedType.AvroType.STRING)
           .put(TextSocketSinkParameters.SOCKET_HOST_ADDRESS, SerializedType.AvroType.STRING)
           .put(TextSocketSinkParameters.SOCKET_HOST_PORT, SerializedType.AvroType.INT)
+          .put(TextKafkaSinkParameters.KAFKA_HOST_ADDRESS, SerializedType.AvroType.STRING)
+          .put(TextKafkaSinkParameters.KAFKA_HOST_PORT, SerializedType.AvroType.INT)
+          .put(TextKafkaSinkParameters.KAFKA_TOPIC_NAME, SerializedType.AvroType.STRING)
+          .put(TextKafkaSinkParameters.KAFKA_NUM_PARTITION, SerializedType.AvroType.INT)
           .build();
 
   /**

--- a/src/main/java/edu/snu/mist/api/sink/parameters/TextKafkaSinkParameters.java
+++ b/src/main/java/edu/snu/mist/api/sink/parameters/TextKafkaSinkParameters.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.api.sink.parameters;
+
+/**
+ * This class contains the list of necessary parameters for TextKafkaSinkConfiguration.
+ */
+public final class TextKafkaSinkParameters {
+
+  private TextKafkaSinkParameters() {
+    // Not called.
+  }
+
+  /**
+   * The host address of the target KAFKA sink.
+   */
+  public static final String KAFKA_HOST_ADDRESS = "KafkaHostAddress";
+
+  /**
+   * The port of the target KAFKA sink.
+   */
+  public static final String KAFKA_HOST_PORT = "KafkaHostPort";
+
+  /**
+   * The topic name of target KAFKA sink.
+   */
+  public static final String KAFKA_TOPIC_NAME = "KafkaTopicName";
+
+  /**
+   * The number of partitions of target KAFKA sink. This will use the same number of threads in MISTTask.
+   */
+  public static final String KAFKA_NUM_PARTITION = "KafkaNumPartition";
+}

--- a/src/main/java/edu/snu/mist/api/sources/TextKafkaSourceStream.java
+++ b/src/main/java/edu/snu/mist/api/sources/TextKafkaSourceStream.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.api.sources;
+
+import edu.snu.mist.api.StreamType;
+import edu.snu.mist.api.sources.builder.SourceConfiguration;
+
+/**
+ * This class represents a Text SourceStream from Apache Kafka.
+ */
+public final class TextKafkaSourceStream extends SourceStream<String> {
+
+  public TextKafkaSourceStream(final SourceConfiguration sourceConfiguration) {
+    super(StreamType.SourceType.TEXT_KAFKA_SOURCE, sourceConfiguration);
+  }
+}

--- a/src/main/java/edu/snu/mist/api/sources/builder/TextKafkaSourceConfigurationBuilderImpl.java
+++ b/src/main/java/edu/snu/mist/api/sources/builder/TextKafkaSourceConfigurationBuilderImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.api.sources.builder;
+
+import edu.snu.mist.api.StreamType;
+import edu.snu.mist.api.sources.parameters.TextKafkaSourceParameters;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+
+/**
+ * This class builds SourceConfiguration of TextKafkaSourceStream.
+ */
+public final class TextKafkaSourceConfigurationBuilderImpl extends SourceConfigurationBuilderImpl {
+
+  /**
+   * Required parameters for TextKafkaSourceStream.
+   */
+  private final String[] textKafkaSourceParameters = {
+      TextKafkaSourceParameters.KAFKA_HOST_ADDRESS,
+      TextKafkaSourceParameters.KAFKA_HOST_PORT,
+      TextKafkaSourceParameters.KAFKA_TOPIC_NAME,
+      TextKafkaSourceParameters.KAFKA_NUM_PARTITION
+  };
+
+  @Inject
+  public TextKafkaSourceConfigurationBuilderImpl() {
+    requiredParameters.addAll(Arrays.asList(textKafkaSourceParameters));
+  }
+
+  @Override
+  public StreamType.SourceType getSourceType() {
+    return StreamType.SourceType.TEXT_KAFKA_SOURCE;
+  }
+}

--- a/src/main/java/edu/snu/mist/api/sources/parameters/SourceSerializeInfo.java
+++ b/src/main/java/edu/snu/mist/api/sources/parameters/SourceSerializeInfo.java
@@ -41,6 +41,10 @@ public final class SourceSerializeInfo {
           .put(REEFNetworkSourceParameters.SENDER_ID, SerializedType.AvroType.STRING)
           .put(TextSocketSourceParameters.SOCKET_HOST_ADDRESS, SerializedType.AvroType.STRING)
           .put(TextSocketSourceParameters.SOCKET_HOST_PORT, SerializedType.AvroType.INT)
+          .put(TextKafkaSourceParameters.KAFKA_HOST_ADDRESS, SerializedType.AvroType.STRING)
+          .put(TextKafkaSourceParameters.KAFKA_HOST_PORT, SerializedType.AvroType.INT)
+          .put(TextKafkaSourceParameters.KAFKA_TOPIC_NAME, SerializedType.AvroType.STRING)
+          .put(TextKafkaSourceParameters.KAFKA_NUM_PARTITION, SerializedType.AvroType.INT)
           .build();
 
   /**

--- a/src/main/java/edu/snu/mist/api/sources/parameters/TextKafkaSourceParameters.java
+++ b/src/main/java/edu/snu/mist/api/sources/parameters/TextKafkaSourceParameters.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.api.sources.parameters;
+
+/**
+ * This class contains the list of necessary parameters for TextKafkaSourceConfiguration.
+ */
+public final class TextKafkaSourceParameters {
+
+  private TextKafkaSourceParameters() {
+    // Not called.
+  }
+
+  /**
+   * The host address of the target KAFKA source.
+   */
+  public static final String KAFKA_HOST_ADDRESS = "KafkaHostAddress";
+
+  /**
+   * The port of the target KAFKA source.
+   */
+  public static final String KAFKA_HOST_PORT = "KafkaHostPort";
+
+  /**
+   * The topic name of target KAFKA source.
+   */
+  public static final String KAFKA_TOPIC_NAME = "KafkaTopicName";
+
+  /**
+   * The number of partitions of target KAFKA source. This will use the same number of threads in MISTTask.
+   */
+  public static final String KAFKA_NUM_PARTITION = "KafkaNumPartition";
+}

--- a/src/test/java/edu/snu/mist/api/APITestParameters.java
+++ b/src/test/java/edu/snu/mist/api/APITestParameters.java
@@ -17,13 +17,17 @@ package edu.snu.mist.api;
 
 import edu.snu.mist.api.sink.builder.REEFNetworkSinkConfigurationBuilderImpl;
 import edu.snu.mist.api.sink.builder.SinkConfiguration;
+import edu.snu.mist.api.sink.builder.TextKafkaSinkConfigurationBuilderImpl;
 import edu.snu.mist.api.sink.builder.TextSocketSinkConfigurationBuilderImpl;
 import edu.snu.mist.api.sink.parameters.REEFNetworkSinkParameters;
+import edu.snu.mist.api.sink.parameters.TextKafkaSinkParameters;
 import edu.snu.mist.api.sink.parameters.TextSocketSinkParameters;
 import edu.snu.mist.api.sources.builder.REEFNetworkSourceConfigurationBuilderImpl;
 import edu.snu.mist.api.sources.builder.SourceConfiguration;
+import edu.snu.mist.api.sources.builder.TextKafkaSourceConfigurationBuilderImpl;
 import edu.snu.mist.api.sources.builder.TextSocketSourceConfigurationBuilderImpl;
 import edu.snu.mist.api.sources.parameters.REEFNetworkSourceParameters;
+import edu.snu.mist.api.sources.parameters.TextKafkaSourceParameters;
 import edu.snu.mist.api.sources.parameters.TextSocketSourceParameters;
 import org.apache.reef.wake.remote.impl.StringCodec;
 
@@ -48,12 +52,20 @@ public final class APITestParameters {
   public static final SourceConfiguration LOCAL_TEXT_SOCKET_SOURCE_CONF =
       new TextSocketSourceConfigurationBuilderImpl()
       .set(TextSocketSourceParameters.SOCKET_HOST_ADDRESS, "localhost")
-      .set(TextSocketSourceParameters.SOCKET_HOST_PORT, 13666)
+      .set(TextSocketSourceParameters.SOCKET_HOST_PORT, 13667)
+      .build();
+
+  public static final SourceConfiguration LOCAL_TEXT_KAFKA_SOURCE_CONF =
+      new TextKafkaSourceConfigurationBuilderImpl()
+      .set(TextKafkaSourceParameters.KAFKA_HOST_ADDRESS, "localhost")
+      .set(TextKafkaSourceParameters.KAFKA_HOST_PORT, 13668)
+      .set(TextKafkaSourceParameters.KAFKA_TOPIC_NAME, "test_source_topic")
+      .set(TextKafkaSourceParameters.KAFKA_NUM_PARTITION, 1)
       .build();
 
   public static final SinkConfiguration LOCAL_REEF_NETWORK_SINK_CONF = new REEFNetworkSinkConfigurationBuilderImpl()
       .set(REEFNetworkSinkParameters.NAME_SERVER_HOSTNAME, "localhost")
-      .set(REEFNetworkSinkParameters.NAME_SERVICE_PORT, 13667)
+      .set(REEFNetworkSinkParameters.NAME_SERVICE_PORT, 13686)
       .set(REEFNetworkSinkParameters.CONNECTION_ID, "TestConn")
       .set(REEFNetworkSinkParameters.RECEIVER_ID, "TestReceiver")
       .set(REEFNetworkSinkParameters.CODEC, StringCodec.class)
@@ -61,6 +73,13 @@ public final class APITestParameters {
 
   public static final SinkConfiguration LOCAL_TEXT_SOCKET_SINK_CONF = new TextSocketSinkConfigurationBuilderImpl()
       .set(TextSocketSinkParameters.SOCKET_HOST_ADDRESS, "localhost")
-      .set(TextSocketSinkParameters.SOCKET_HOST_PORT, 13667)
+      .set(TextSocketSinkParameters.SOCKET_HOST_PORT, 13687)
+      .build();
+
+  public static final SinkConfiguration LOCAL_TEXT_KAFKA_SINK_CONF = new TextKafkaSinkConfigurationBuilderImpl()
+      .set(TextKafkaSinkParameters.KAFKA_HOST_ADDRESS, "localhost")
+      .set(TextKafkaSinkParameters.KAFKA_HOST_PORT, 13688)
+      .set(TextKafkaSinkParameters.KAFKA_TOPIC_NAME, "text_sink_topic")
+      .set(TextKafkaSinkParameters.KAFKA_NUM_PARTITION, 1)
       .build();
 }

--- a/src/test/java/edu/snu/mist/api/sources/SourceConfigurationTest.java
+++ b/src/test/java/edu/snu/mist/api/sources/SourceConfigurationTest.java
@@ -15,11 +15,9 @@
  */
 package edu.snu.mist.api.sources;
 
-import edu.snu.mist.api.sources.builder.REEFNetworkSourceConfigurationBuilderImpl;
-import edu.snu.mist.api.sources.builder.SourceConfigurationBuilder;
-import edu.snu.mist.api.sources.builder.SourceConfiguration;
-import edu.snu.mist.api.sources.builder.TextSocketSourceConfigurationBuilderImpl;
+import edu.snu.mist.api.sources.builder.*;
 import edu.snu.mist.api.sources.parameters.REEFNetworkSourceParameters;
+import edu.snu.mist.api.sources.parameters.TextKafkaSourceParameters;
 import edu.snu.mist.api.sources.parameters.TextSocketSourceParameters;
 import org.apache.reef.wake.remote.impl.StringCodec;
 import org.junit.Assert;
@@ -44,6 +42,14 @@ public class SourceConfigurationTest {
    */
   private final String socketHostName = "localhost2";
   private final int socketPort = 8088;
+
+  /**
+   * Configuration values for TextKafkaSource.
+   */
+  private final String kafkaHostName = "localhost3";
+  private final int kafkaPort = 8088;
+  private final String kafkaTopicName = "testTopic";
+  private final int kafkaNumPartition = 1;
 
   /**
    * Test for REEFNetworkSource configuration builder.
@@ -84,6 +90,28 @@ public class SourceConfigurationTest {
         textSocketSourceConfiguration.getConfigurationValue(TextSocketSourceParameters.SOCKET_HOST_ADDRESS));
     Assert.assertEquals(socketPort,
         textSocketSourceConfiguration.getConfigurationValue(TextSocketSourceParameters.SOCKET_HOST_PORT));
+  }
+
+  /**
+   * Test for TextKafkaSource configuration builder.
+   */
+  @Test
+  public void testTextKafkaSourceConfBuiler() {
+    final SourceConfiguration textKafkaSourceConfiguration = new TextKafkaSourceConfigurationBuilderImpl()
+        .set(TextKafkaSourceParameters.KAFKA_HOST_ADDRESS, kafkaHostName)
+        .set(TextKafkaSourceParameters.KAFKA_HOST_PORT, kafkaPort)
+        .set(TextKafkaSourceParameters.KAFKA_TOPIC_NAME, kafkaTopicName)
+        .set(TextKafkaSourceParameters.KAFKA_NUM_PARTITION, kafkaNumPartition)
+        .build();
+
+    Assert.assertEquals(textKafkaSourceConfiguration.getConfigurationValue(TextKafkaSourceParameters
+        .KAFKA_HOST_ADDRESS), kafkaHostName);
+    Assert.assertEquals(textKafkaSourceConfiguration.getConfigurationValue(TextKafkaSourceParameters
+        .KAFKA_HOST_PORT), kafkaPort);
+    Assert.assertEquals(textKafkaSourceConfiguration.getConfigurationValue(TextKafkaSourceParameters
+        .KAFKA_TOPIC_NAME), kafkaTopicName);
+    Assert.assertEquals(textKafkaSourceConfiguration.getConfigurationValue(TextKafkaSourceParameters
+        .KAFKA_NUM_PARTITION), kafkaNumPartition);
   }
 
   /**


### PR DESCRIPTION
This PR contains API support for KAFKA source & sink configuration
- Implement Source / Sink for KAFKA in MIST API
- Add serialization logic for KAFKA Source / Sink
- Add unit test for KAFKA API
- Update Avro version to 1.8.0
