### PR TITLE
[MIST-198] Driver returns hostname of the tasks instead of IP address

### DIFF
--- a/src/main/java/edu/snu/mist/driver/DefaultTaskSelectorImpl.java
+++ b/src/main/java/edu/snu/mist/driver/DefaultTaskSelectorImpl.java
@@ -105,7 +105,7 @@ final class DefaultTaskSelectorImpl implements TaskSelector {
     for (final Tuple<InetSocketAddress, Connection<DriverTaskMessage>> value : taskAddrAndConnMap.values()) {
       final IPAddress ipAddress = new IPAddress();
       final InetSocketAddress inetSocketAddress = value.getKey();
-      ipAddress.setHostAddress(inetSocketAddress.getAddress().getHostAddress());
+      ipAddress.setHostAddress(inetSocketAddress.getHostName());
       ipAddress.setPort(rpcServerPort);
       taskLists.add(ipAddress);
     }


### PR DESCRIPTION
This pull request addressed the issue #198 by making the task selector in the driver return the hostname of the tasks instead of their IP address.

**Note**: We may still  need to map the hostname to the external IP address of a machine which executes the tasks in the OS or network level (e.g., modify `/etc/hosts` of the client's machine).

Closes #198 
