### PR TITLE
[MIST-221] Rename OperatorChain to PartitionedQuery

### DIFF
--- a/src/main/java/edu/snu/mist/task/DefaultPartitionedQuery.java
+++ b/src/main/java/edu/snu/mist/task/DefaultPartitionedQuery.java
@@ -24,12 +24,12 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * Default implementation of OperatorChain.
+ * Default implementation of PartitionedQuery.
  * It uses List to chain operators.
- * TODO[MIST-70]: Consider concurrency issue in execution of OperatorChain
+ * TODO[MIST-70]: Consider concurrency issue in execution of PartitionedQuery
  */
 @SuppressWarnings("unchecked")
-final class DefaultOperatorChain implements OperatorChain {
+final class DefaultPartitionedQuery implements PartitionedQuery {
 
   /**
    * A chain of operators.
@@ -37,17 +37,17 @@ final class DefaultOperatorChain implements OperatorChain {
   private final List<Operator> operators;
 
   /**
-   * An output emitter which forwards outputs to next OperatorChains.
+   * An output emitter which forwards outputs to next PartitionedQueries.
    */
   private OutputEmitter outputEmitter;
 
   /**
-   * An executor executing this OperatorChain.
+   * An executor executing this PartitionedQuery.
    */
   private MistExecutor mistExecutor;
 
   @Inject
-  DefaultOperatorChain() {
+  DefaultPartitionedQuery() {
     this.operators = new LinkedList<>();
   }
 
@@ -104,7 +104,7 @@ final class DefaultOperatorChain implements OperatorChain {
   @Override
   public void handle(final Object input) {
     if (outputEmitter == null) {
-      throw new RuntimeException("OutputEmitter should be set in OperatorChain");
+      throw new RuntimeException("OutputEmitter should be set in PartitionedQuery");
     }
     if (operators.size() == 0) {
       throw new RuntimeException("The number of operators should be greater than zero");
@@ -136,7 +136,7 @@ final class DefaultOperatorChain implements OperatorChain {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final DefaultOperatorChain that = (DefaultOperatorChain) o;
+    final DefaultPartitionedQuery that = (DefaultPartitionedQuery) o;
     if (!operators.equals(that.operators)) {
       return false;
     }

--- a/src/main/java/edu/snu/mist/task/DefaultPartitionedQueryAllocatorImpl.java
+++ b/src/main/java/edu/snu/mist/task/DefaultPartitionedQueryAllocatorImpl.java
@@ -24,10 +24,10 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
- * A default operator chain allocator,
- * which allocates OperatorChains to MistExecutors in round-robin way.
+ * A default partitioned query allocator,
+ * which allocates PartitionedQueries to MistExecutors in round-robin way.
  */
-final class DefaultOperatorChainAllocatorImpl implements OperatorChainAllocator {
+final class DefaultPartitionedQueryAllocatorImpl implements PartitionedQueryAllocator {
 
   /**
    * A list of MistExecutors.
@@ -40,22 +40,22 @@ final class DefaultOperatorChainAllocatorImpl implements OperatorChainAllocator 
   private int index;
 
   @Inject
-  private DefaultOperatorChainAllocatorImpl(
+  private DefaultPartitionedQueryAllocatorImpl(
       final ExecutorListProvider executorListProvider) {
     this.executors = executorListProvider.getExecutors();
     this.index = 0;
   }
 
   /**
-   * This allocates OperatorChains to MistExecutors in round-robin way.
-   * @param dag a DAG of OperatorChain
+   * This allocates PartitionedQueries to MistExecutors in round-robin way.
+   * @param dag a DAG of PartitionedQuery
    */
   @Override
-  public void allocate(final DAG<OperatorChain> dag) {
-    final Iterator<OperatorChain> operatorChainIterator = GraphUtils.topologicalSort(dag);
-    while (operatorChainIterator.hasNext()) {
-      final OperatorChain operatorChain = operatorChainIterator.next();
-      operatorChain.setExecutor(executors.get(index));
+  public void allocate(final DAG<PartitionedQuery> dag) {
+    final Iterator<PartitionedQuery> partitionedQueryIterator = GraphUtils.topologicalSort(dag);
+    while (partitionedQueryIterator.hasNext()) {
+      final PartitionedQuery partitionedQuery = partitionedQueryIterator.next();
+      partitionedQuery.setExecutor(executors.get(index));
       index = (index + 1) % executors.size();
     }
   }

--- a/src/main/java/edu/snu/mist/task/DefaultPartitionedQueryTask.java
+++ b/src/main/java/edu/snu/mist/task/DefaultPartitionedQueryTask.java
@@ -15,18 +15,33 @@
  */
 package edu.snu.mist.task;
 
-import edu.snu.mist.common.DAG;
-import org.apache.reef.tang.annotations.DefaultImplementation;
-
 /**
- * This interface allocates OperatorChains represented as a DAG to MistExecutors.
+ * This class is a default implementation of PartitionedQueryTask.
  */
-@DefaultImplementation(DefaultOperatorChainAllocatorImpl.class)
-public interface OperatorChainAllocator {
+final class DefaultPartitionedQueryTask implements PartitionedQueryTask {
 
   /**
-   * Allocates the OperatorChain represented as a DAG to MistExecutors.
-   * @param dag a DAG of OperatorChain
+   * A PartitionedQuery for computing inputs.
    */
-  void allocate(final DAG<OperatorChain> dag);
+  private PartitionedQuery partitionedQuery;
+
+  /**
+   * An input for the PartitionedQueryStage.
+   */
+  private Object input;
+
+  DefaultPartitionedQueryTask(final PartitionedQuery partitionedQuery,
+                              final Object input) {
+    this.partitionedQuery = partitionedQuery;
+    this.input = input;
+  }
+
+  /**
+   * Runs actual computation.
+   */
+  @SuppressWarnings("unchecked")
+  @Override
+  public void run() {
+    partitionedQuery.handle(input);
+  }
 }

--- a/src/main/java/edu/snu/mist/task/DefaultPhysicalPlanImpl.java
+++ b/src/main/java/edu/snu/mist/task/DefaultPhysicalPlanImpl.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 /**
  * A default implementation of physical plan.
- * @param <E> Operator or OperatorChain
+ * @param <E> Operator or PartitionedQuery
  */
 final class DefaultPhysicalPlanImpl<E> implements PhysicalPlan<E> {
 

--- a/src/main/java/edu/snu/mist/task/OperatorOutputEmitter.java
+++ b/src/main/java/edu/snu/mist/task/OperatorOutputEmitter.java
@@ -21,44 +21,44 @@ import edu.snu.mist.task.executor.MistExecutor;
 import java.util.Set;
 
 /**
- * This emitter forwards current OperatorChain's outputs as next OperatorChains' inputs.
+ * This emitter forwards current PartitionedQuery's outputs as next PartitionedQueries' inputs.
  */
 final class OperatorOutputEmitter implements OutputEmitter {
 
   /**
-   * Current OperatorChain.
+   * Current PartitionedQuery.
    */
-  private final OperatorChain currChain;
+  private final PartitionedQuery currChain;
 
   /**
-   * Next OperatorChains.
+   * Next PartitionedQueries.
    */
-  private final Set<OperatorChain> nextChains;
+  private final Set<PartitionedQuery> nextChains;
 
-  OperatorOutputEmitter(final OperatorChain currChain,
-                        final Set<OperatorChain> nextChains) {
+  OperatorOutputEmitter(final PartitionedQuery currChain,
+                        final Set<PartitionedQuery> nextChains) {
     this.currChain = currChain;
     this.nextChains = nextChains;
   }
 
   /**
-   * This method emits the outputs to next OperatorChains.
-   * If the Executor of the current OperatorChain is same as that of next OperatorChain,
-   * the OutputEmitter directly forwards outputs of the current OperatorChain
-   * as inputs of the next OperatorChain.
-   * Otherwise, the OutputEmitter submits a job to the Executor of the next OperatorChain.
+   * This method emits the outputs to next PartitionedQueries.
+   * If the Executor of the current PartitionedQuery is same as that of next PartitionedQuery,
+   * the OutputEmitter directly forwards outputs of the current PartitionedQuery
+   * as inputs of the next PartitionedQuery.
+   * Otherwise, the OutputEmitter submits a job to the Executor of the next PartitionedQuery.
    * @param output an output
    */
   @Override
   public void emit(final Object output) {
     final MistExecutor srcExecutor = currChain.getExecutor();
-    for (final OperatorChain nextChain : nextChains) {
+    for (final PartitionedQuery nextChain : nextChains) {
       final MistExecutor destExecutor = nextChain.getExecutor();
       if (srcExecutor.equals(destExecutor)) {
         nextChain.handle(output);
       } else {
-        final OperatorChainJob operatorChainJob = new DefaultOperatorChainJob(nextChain, output);
-        destExecutor.submit(operatorChainJob);
+        final PartitionedQueryTask partitionedQueryTask = new DefaultPartitionedQueryTask(nextChain, output);
+        destExecutor.submit(partitionedQueryTask);
       }
     }
   }

--- a/src/main/java/edu/snu/mist/task/PartitionedQuery.java
+++ b/src/main/java/edu/snu/mist/task/PartitionedQuery.java
@@ -24,11 +24,11 @@ import edu.snu.mist.task.operators.Operator;
  * This interface chains operators as a list and executes them in order
  * from the first to the last operator.
  *
- * OperatorChain is the unit of execution which is assigned to a mist executor by MistTask.
+ * PartitionedQuery is the unit of execution which is assigned to a mist executor by MistTask.
  * It receives inputs, performs computations through the list of operators,
- * and forwards final outputs to an OutputEmitter which sends the outputs to next OperatorChains.
+ * and forwards final outputs to an OutputEmitter which sends the outputs to next PartitionedQueries.
  */
-public interface OperatorChain extends InputHandler, OutputEmittable {
+public interface PartitionedQuery extends InputHandler, OutputEmittable {
 
   /**
    * Inserts an operator to the head of the chain.
@@ -55,7 +55,7 @@ public interface OperatorChain extends InputHandler, OutputEmittable {
   Operator removeFromHead();
 
   /**
-   * Sets a mist executor for executing this OperatorChain.
+   * Sets a mist executor for executing this PartitionedQuery.
    * @param executor an executor
    */
   void setExecutor(final MistExecutor executor);

--- a/src/main/java/edu/snu/mist/task/PartitionedQueryAllocator.java
+++ b/src/main/java/edu/snu/mist/task/PartitionedQueryAllocator.java
@@ -15,19 +15,18 @@
  */
 package edu.snu.mist.task;
 
-import edu.snu.mist.task.operators.Operator;
+import edu.snu.mist.common.DAG;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 /**
- * This interface converts a PhysicalPlan<Operator> to a PhysicalPlan<OperatorChain>
- * by chaining the operators.
+ * This interface allocates PartitionedQueries represented as a DAG to MistExecutors.
  */
-@DefaultImplementation(DefaultOperatorChainerImpl.class)
-public interface OperatorChainer {
+@DefaultImplementation(DefaultPartitionedQueryAllocatorImpl.class)
+public interface PartitionedQueryAllocator {
+
   /**
-   * Chains the operators and converts the PhysicalPlan<Operator> to the PhysicalPlan<OperatorChain>.
-   * @param plan a plan
-   * @return a physical plan which contains OperatorChain.
+   * Allocates the PartitionedQuery represented as a DAG to MistExecutors.
+   * @param dag a DAG of PartitionedQuery
    */
-  PhysicalPlan<OperatorChain> chainOperators(PhysicalPlan<Operator> plan);
+  void allocate(final DAG<PartitionedQuery> dag);
 }

--- a/src/main/java/edu/snu/mist/task/PartitionedQueryTask.java
+++ b/src/main/java/edu/snu/mist/task/PartitionedQueryTask.java
@@ -18,10 +18,10 @@ package edu.snu.mist.task;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 /**
- * OperatorChainJob executes a OperatorChain with an input.
+ * PartitionedQueryTask executes a PartitionedQuery with an input.
  * It calls operator.onNext(inputs) when .run() is called.
  */
-@DefaultImplementation(DefaultOperatorChainJob.class)
-public interface OperatorChainJob extends Runnable {
+@DefaultImplementation(DefaultPartitionedQueryTask.class)
+public interface PartitionedQueryTask extends Runnable {
 
 }

--- a/src/main/java/edu/snu/mist/task/PhysicalPlan.java
+++ b/src/main/java/edu/snu/mist/task/PhysicalPlan.java
@@ -24,9 +24,9 @@ import java.util.Set;
 
 /**
  * This interface represents a PhysicalPlan of a query.
- * PhysicalPlan can have two types: one is Operator and the other os OperatorChain.
+ * PhysicalPlan can have two types: one is Operator and the other os PartitionedQuery.
  * TODO[MIST-68]: Receive and deserialize logical plans into physical plans.
- * @param <E> Operator or OperatorChain
+ * @param <E> Operator or PartitionedQuery
  */
 public interface PhysicalPlan<E> {
 

--- a/src/main/java/edu/snu/mist/task/QueryPartitioner.java
+++ b/src/main/java/edu/snu/mist/task/QueryPartitioner.java
@@ -15,33 +15,19 @@
  */
 package edu.snu.mist.task;
 
+import edu.snu.mist.task.operators.Operator;
+import org.apache.reef.tang.annotations.DefaultImplementation;
+
 /**
- * This class is a default implementation of OperatorChainJob.
+ * This interface converts a PhysicalPlan<Operator> to a PhysicalPlan<PartitionedQuery>
+ * by chaining the operators.
  */
-final class DefaultOperatorChainJob implements OperatorChainJob {
-
+@DefaultImplementation(DefaultQueryPartitionerImpl.class)
+public interface QueryPartitioner {
   /**
-   * A OperatorChain for computing inputs.
+   * Chains the operators and converts the PhysicalPlan<Operator> to the PhysicalPlan<PartitionedQuery>.
+   * @param plan a plan
+   * @return a physical plan which contains PartitionedQuery.
    */
-  private OperatorChain operatorChain;
-
-  /**
-   * An input for the OperatorChainStage.
-   */
-  private Object input;
-
-  DefaultOperatorChainJob(final OperatorChain operatorChain,
-                          final Object input) {
-    this.operatorChain = operatorChain;
-    this.input = input;
-  }
-
-  /**
-   * Runs actual computation.
-   */
-  @SuppressWarnings("unchecked")
-  @Override
-  public void run() {
-    operatorChain.handle(input);
-  }
+  PhysicalPlan<PartitionedQuery> chainOperators(PhysicalPlan<Operator> plan);
 }

--- a/src/main/java/edu/snu/mist/task/SourceOutputEmitter.java
+++ b/src/main/java/edu/snu/mist/task/SourceOutputEmitter.java
@@ -21,28 +21,28 @@ import edu.snu.mist.task.executor.MistExecutor;
 import java.util.Set;
 
 /**
- * This emitter emits the outputs to the next OperatorChains that get inputs from the sources.
+ * This emitter emits the outputs to the next PartitionedQueries that get inputs from the sources.
  * It always submits jobs to MistExecutors.
  *  @param <I>
  */
 final class SourceOutputEmitter<I> implements OutputEmitter<I> {
 
   /**
-   * Next OperatorChains.
+   * Next PartitionedQueries.
    */
-  private final Set<OperatorChain> nextOps;
+  private final Set<PartitionedQuery> nextOps;
 
-  public SourceOutputEmitter(final Set<OperatorChain> nextOps) {
+  public SourceOutputEmitter(final Set<PartitionedQuery> nextOps) {
     this.nextOps = nextOps;
   }
 
   @Override
   public void emit(final I input) {
-    for (final OperatorChain nextOp : nextOps) {
+    for (final PartitionedQuery nextOp : nextOps) {
       final MistExecutor executor = nextOp.getExecutor();
-      final OperatorChainJob operatorChainJob = new DefaultOperatorChainJob(nextOp, input);
+      final PartitionedQueryTask partitionedQueryTask = new DefaultPartitionedQueryTask(nextOp, input);
       // Always submits a job to the MistExecutor when inputs are received.
-      executor.submit(operatorChainJob);
+      executor.submit(partitionedQueryTask);
     }
   }
 }

--- a/src/main/java/edu/snu/mist/task/executor/DefaultMistExecutor.java
+++ b/src/main/java/edu/snu/mist/task/executor/DefaultMistExecutor.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.mist.task.executor;
 
-import edu.snu.mist.task.OperatorChainJob;
+import edu.snu.mist.task.PartitionedQueryTask;
 import edu.snu.mist.task.executor.parameters.MistExecutorId;
 import edu.snu.mist.task.executor.queues.SchedulingQueue;
 import org.apache.reef.io.network.util.StringIdentifierFactory;
@@ -72,13 +72,13 @@ final class DefaultMistExecutor implements MistExecutor {
   }
 
   /**
-   * Submits a OperatorChainJob to the thread pool executor.
+   * Submits a PartitionedQueryTask to the thread pool executor.
    * The thread pool executor pushes the job into the queue and the job is scheduled.
-   * @param operatorChainJob a OperatorChainJob
+   * @param partitionedQueryTask a PartitionedQueryTask
    */
   @Override
-  public void submit(final OperatorChainJob operatorChainJob) {
-    tpExecutor.submit(operatorChainJob);
+  public void submit(final PartitionedQueryTask partitionedQueryTask) {
+    tpExecutor.submit(partitionedQueryTask);
   }
 
   /**

--- a/src/main/java/edu/snu/mist/task/executor/MistExecutor.java
+++ b/src/main/java/edu/snu/mist/task/executor/MistExecutor.java
@@ -15,21 +15,21 @@
  */
 package edu.snu.mist.task.executor;
 
-import edu.snu.mist.task.OperatorChainJob;
+import edu.snu.mist.task.PartitionedQueryTask;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.wake.Identifier;
 
 /**
- * Mist Executor runs OperatorChainJobs on a single thread.
+ * Mist Executor runs PartitionedQueryTasks on a single thread.
  */
 @DefaultImplementation(DefaultMistExecutor.class)
 public interface MistExecutor {
 
   /**
-   * Submits a OperatorChainJob, schedules the job, and runs the job.
-   * @param operatorChainJob a OperatorChain
+   * Submits a PartitionedQueryTask, schedules the job, and runs the job.
+   * @param partitionedQueryTask a PartitionedQuery
    */
-  void submit(OperatorChainJob operatorChainJob);
+  void submit(PartitionedQueryTask partitionedQueryTask);
 
   /**
    * Closes the executor releasing threads.

--- a/src/test/java/edu/snu/mist/task/PartitionedQueryTest.java
+++ b/src/test/java/edu/snu/mist/task/PartitionedQueryTest.java
@@ -29,22 +29,22 @@ import org.junit.Test;
 import java.util.LinkedList;
 import java.util.List;
 
-public final class OperatorChainTest {
-  // TODO[MIST-70]: Consider concurrency issue in execution of OperatorChain
+public final class PartitionedQueryTest {
+  // TODO[MIST-70]: Consider concurrency issue in execution of PartitionedQuery
 
   /**
-   * Tests whether the OperatorChain correctly executes the chained operators.
+   * Tests whether the PartitionedQuery correctly executes the chained operators.
    * @throws InjectionException
    */
   @SuppressWarnings("unchecked")
   @Test
-  public void operatorChainExecutionTest() throws InjectionException {
+  public void partitionedQueryExecutionTest() throws InjectionException {
 
     final List<Integer> result = new LinkedList<>();
     final Integer input = 3;
 
-    final OperatorChain operatorChain = new DefaultOperatorChain();
-    operatorChain.setOutputEmitter(output -> result.add((Integer) output));
+    final PartitionedQuery partitionedQuery = new DefaultPartitionedQuery();
+    partitionedQuery.setOutputEmitter(output -> result.add((Integer) output));
 
     final Injector injector = Tang.Factory.getTang().newInjector();
     final StringIdentifierFactory idFactory = injector.getInstance(StringIdentifierFactory.class);
@@ -59,34 +59,34 @@ public final class OperatorChainTest {
 
     // 2 * (input * input + 1)
     final Integer expected1 = 2 * (input * input + 1);
-    operatorChain.insertToHead(doubleOp);
-    operatorChain.insertToHead(incOp);
-    operatorChain.insertToHead(squareOp);
-    operatorChain.handle(input);
+    partitionedQuery.insertToHead(doubleOp);
+    partitionedQuery.insertToHead(incOp);
+    partitionedQuery.insertToHead(squareOp);
+    partitionedQuery.handle(input);
     Assert.assertEquals(expected1, result.remove(0));
 
     // 2 * (input + 1)
-    operatorChain.removeFromHead();
+    partitionedQuery.removeFromHead();
     final Integer expected2 = 2 * (input + 1);
-    operatorChain.handle(input);
+    partitionedQuery.handle(input);
     Assert.assertEquals(expected2, result.remove(0));
 
     // input + 1
-    operatorChain.removeFromTail();
+    partitionedQuery.removeFromTail();
     final Integer expected3 = input + 1;
-    operatorChain.handle(input);
+    partitionedQuery.handle(input);
     Assert.assertEquals(expected3, result.remove(0));
 
     // 2 * input + 1
-    operatorChain.insertToHead(doubleOp);
+    partitionedQuery.insertToHead(doubleOp);
     final Integer expected4 = 2 * input + 1;
-    operatorChain.handle(input);
+    partitionedQuery.handle(input);
     Assert.assertEquals(expected4, result.remove(0));
 
     // (2 * input + 1) * (2 * input + 1)
-    operatorChain.insertToTail(squareOp);
+    partitionedQuery.insertToTail(squareOp);
     final Integer expected5 = (2 * input + 1) * (2 * input + 1);
-    operatorChain.handle(input);
+    partitionedQuery.handle(input);
     Assert.assertEquals(expected5, result.remove(0));
   }
 

--- a/src/test/java/edu/snu/mist/task/executor/ExecutorJobSchedulingTest.java
+++ b/src/test/java/edu/snu/mist/task/executor/ExecutorJobSchedulingTest.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.mist.task.executor;
 
-import edu.snu.mist.task.OperatorChainJob;
+import edu.snu.mist.task.PartitionedQueryTask;
 import edu.snu.mist.task.executor.parameters.MistExecutorId;
 import edu.snu.mist.task.executor.queues.FIFOQueue;
 import edu.snu.mist.task.executor.queues.SchedulingQueue;
@@ -32,7 +32,7 @@ import java.util.List;
 public final class ExecutorJobSchedulingTest {
 
   /**
-   * A list storing outputs of OperatorChainJobs.
+   * A list storing outputs of PartitionedQueryTasks.
    */
   private List<Integer> outputs;
 
@@ -42,11 +42,11 @@ public final class ExecutorJobSchedulingTest {
   }
 
   /**
-   * This test submits multiple `OperatorChainJob`s to MistExecutor with FIFO queue
+   * This test submits multiple `PartitionedQueryTask`s to MistExecutor with FIFO queue
    * and checks the jobs are executed in FIFO order.
    *
-   * Submits 100 `OperatorChainJob`s and checks the jobs are executed in FIFO order.
-   * First `OperatorChainJob` executes while loop during 2 seconds,
+   * Submits 100 `PartitionedQueryTask`s and checks the jobs are executed in FIFO order.
+   * First `PartitionedQueryTask` executes while loop during 2 seconds,
    * to delay next 99 tasks and see the delayed tasks are scheduled in FIFO order.
    * @throws Exception
    */
@@ -58,7 +58,7 @@ public final class ExecutorJobSchedulingTest {
     jcb.bindNamedParameter(MistExecutorId.class, "MistTestExecutor");
     final Injector injector = Tang.Factory.getTang().newInjector(jcb.build());
     final MistExecutor executor = injector.getInstance(MistExecutor.class);
-    final OperatorChainJob firstJob = () -> {
+    final PartitionedQueryTask firstJob = () -> {
       final long startTime = System.currentTimeMillis();
       while (System.currentTimeMillis() - startTime < 2000) {
         // empty
@@ -70,7 +70,7 @@ public final class ExecutorJobSchedulingTest {
     executor.submit(firstJob);
     for (int i = 1; i < numTasks; i++) {
       final int input = i;
-      final OperatorChainJob simpleJob = () -> {
+      final PartitionedQueryTask simpleJob = () -> {
         outputs.add(input);
         System.out.println("simple-op-" + input);
       };


### PR DESCRIPTION
This pull request addressed the issue #221 by
- changing `OperatorChain` to `PartitionedQuery`
- changing `OperatorChainer` to `QueryPartitioner`
- changing `OperatorChainAllocator` to `PartitionedQueryAllocator`
- changing `OperatorChainJob` to `PartitionedQueryTask`

Closes #221 
