### PR TITLE
[MIST-209] Submit client jar to the Task for serializing udf lambdas

### DIFF
--- a/src/main/avro/client_to_task_msg.avpr
+++ b/src/main/avro/client_to_task_msg.avpr
@@ -27,6 +27,14 @@
       "fields":
       [
         {
+          "name": "IsJarSerialized",
+          "type": "boolean"
+        },
+        {
+          "name": "Jar",
+          "type": "bytes"
+        },
+        {
           "name": "Vertices",
           "type":
           {

--- a/src/main/java/edu/snu/mist/api/MISTExecutionEnvironment.java
+++ b/src/main/java/edu/snu/mist/api/MISTExecutionEnvironment.java
@@ -18,11 +18,12 @@ package edu.snu.mist.api;
 import org.apache.reef.tang.exceptions.InjectionException;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 /**
  * Execution Environment for MIST.
  * MIST Client can submit queries via this class.
  */
 public interface MISTExecutionEnvironment {
-  APIQuerySubmissionResult submit(MISTQuery queryToSubmit) throws IOException, InjectionException;
+  APIQuerySubmissionResult submit(MISTQuery queryToSubmit) throws IOException, InjectionException, URISyntaxException;
 }

--- a/src/main/java/edu/snu/mist/api/MISTExecutionEnvironmentImpl.java
+++ b/src/main/java/edu/snu/mist/api/MISTExecutionEnvironmentImpl.java
@@ -25,6 +25,7 @@ import org.apache.reef.tang.exceptions.InjectionException;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentHashMap;
@@ -61,7 +62,7 @@ public final class MISTExecutionEnvironmentImpl implements MISTExecutionEnvironm
    * @return the result of the submitted query.
    */
   @Override
-  public APIQuerySubmissionResult submit(final MISTQuery queryToSubmit) throws IOException {
+  public APIQuerySubmissionResult submit(final MISTQuery queryToSubmit) throws IOException, URISyntaxException {
     // Step 2: Change the query to a LogicalPlan
     final LogicalPlan logicalPlan = querySerializer.queryToLogicalPlan(queryToSubmit);
 

--- a/src/main/java/edu/snu/mist/api/serialize/avro/MISTQuerySerializer.java
+++ b/src/main/java/edu/snu/mist/api/serialize/avro/MISTQuerySerializer.java
@@ -19,6 +19,9 @@ import edu.snu.mist.api.MISTQuery;
 import edu.snu.mist.formats.avro.LogicalPlan;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+
 /**
  * This interface contains necessary methods for serializing MISTQueries.
  */
@@ -30,5 +33,5 @@ public interface MISTQuerySerializer {
    * @param query a query which a user wants to serialize.
    * @return serialized LogicalPlan.
    */
-  LogicalPlan queryToLogicalPlan(MISTQuery query);
+  LogicalPlan queryToLogicalPlan(MISTQuery query) throws IOException, URISyntaxException;
 }

--- a/src/main/java/edu/snu/mist/common/ExternalJarObjectInputStream.java
+++ b/src/main/java/edu/snu/mist/common/ExternalJarObjectInputStream.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.common;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+
+/**
+ * This class is used for reading objects from external JARs.
+ */
+public final class ExternalJarObjectInputStream extends ObjectInputStream {
+
+  private ClassLoader classLoader;
+
+  public ExternalJarObjectInputStream(final ClassLoader classLoader, final byte[] bytes) throws IOException {
+    super(new ByteArrayInputStream(bytes));
+    this.classLoader = classLoader;
+  }
+
+  @Override
+  protected Class<?> resolveClass(final ObjectStreamClass desc) throws ClassNotFoundException {
+    String name = desc.getName();
+    try {
+      return Class.forName(name, false, classLoader);
+    } catch (ClassNotFoundException ex) {
+      throw ex;
+    }
+  }
+}

--- a/src/main/java/edu/snu/mist/examples/HelloMist.java
+++ b/src/main/java/edu/snu/mist/examples/HelloMist.java
@@ -32,6 +32,7 @@ import org.apache.commons.cli.*;
 import org.apache.reef.tang.exceptions.InjectionException;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 /**
  * Example client which submits a stateless query.
@@ -94,7 +95,7 @@ public final class HelloMist {
    * @throws IOException
    * @throws InjectionException
    */
-  public static APIQuerySubmissionResult submitQuery() throws IOException, InjectionException {
+  public static APIQuerySubmissionResult submitQuery() throws IOException, InjectionException, URISyntaxException {
     final SourceConfiguration localTextSocketSourceConf = new TextSocketSourceConfigurationBuilderImpl()
         .set(TextSocketSourceParameters.SOCKET_HOST_ADDRESS, sourceHost)
         .set(TextSocketSourceParameters.SOCKET_HOST_PORT, sourcePort)

--- a/src/main/java/edu/snu/mist/task/DefaultPhysicalPlanGeneratorImpl.java
+++ b/src/main/java/edu/snu/mist/task/DefaultPhysicalPlanGeneratorImpl.java
@@ -19,6 +19,7 @@ import edu.snu.mist.api.sink.parameters.TextSocketSinkParameters;
 import edu.snu.mist.api.sources.parameters.TextSocketSourceParameters;
 import edu.snu.mist.common.AdjacentListDAG;
 import edu.snu.mist.common.DAG;
+import edu.snu.mist.common.ExternalJarObjectInputStream;
 import edu.snu.mist.common.parameters.QueryId;
 import edu.snu.mist.formats.avro.*;
 import edu.snu.mist.task.common.parameters.SocketServerIp;
@@ -32,6 +33,7 @@ import edu.snu.mist.task.sinks.parameters.SinkId;
 import edu.snu.mist.task.sources.SourceGenerator;
 import edu.snu.mist.task.sources.TextSocketStreamGenerator;
 import edu.snu.mist.task.sources.parameters.SourceId;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.SerializationUtils;
 import org.apache.reef.io.Tuple;
 import org.apache.reef.tang.Injector;
@@ -40,11 +42,16 @@ import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.InjectionException;
 
 import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -104,17 +111,25 @@ final class DefaultPhysicalPlanGeneratorImpl implements PhysicalPlanGenerator {
   /*
    * This private method de-serializes byte-serialized lambdas
    */
-  private Object deserializeLambda(final ByteBuffer serializedLambda) {
+  private Object deserializeLambda(final ByteBuffer serializedLambda, final ClassLoader classLoader)
+      throws IOException, ClassNotFoundException {
     byte[] serializedByteArray = new byte[serializedLambda.remaining()];
     serializedLambda.get(serializedByteArray);
-    return SerializationUtils.deserialize(serializedByteArray);
+    if (classLoader == null) {
+      return SerializationUtils.deserialize(serializedByteArray);
+    } else {
+      ExternalJarObjectInputStream stream = new ExternalJarObjectInputStream(
+          classLoader, serializedByteArray);
+      return stream.readObject();
+    }
   }
 
   /*
    * This private method gets instant operator from the serialized instant operator info.
    */
-  private Operator getInstantOperator(final String queryId, final InstantOperatorInfo iOpInfo)
-      throws IllegalArgumentException, InjectionException {
+  private Operator getInstantOperator(final String queryId, final InstantOperatorInfo iOpInfo,
+                                      final ClassLoader classLoader)
+      throws IllegalArgumentException, InjectionException, IOException, ClassNotFoundException {
     final JavaConfigurationBuilder cb = Tang.Factory.getTang().newConfigurationBuilder();
     cb.bindNamedParameter(QueryId.class, queryId);
     cb.bindNamedParameter(OperatorId.class, operatorIdGenerator.generate());
@@ -124,26 +139,26 @@ final class DefaultPhysicalPlanGeneratorImpl implements PhysicalPlanGenerator {
         throw new IllegalArgumentException("MISTTask: ApplyStatefulOperator is currently not supported!");
       }
       case FILTER: {
-        final Predicate predicate = (Predicate) deserializeLambda(functionList.get(0));
+        final Predicate predicate = (Predicate) deserializeLambda(functionList.get(0), classLoader);
         final Injector injector = Tang.Factory.getTang().newInjector(cb.build());
         injector.bindVolatileInstance(Predicate.class, predicate);
         return injector.getInstance(FilterOperator.class);
       }
       case FLAT_MAP: {
-        final Function flatMapFunc = (Function) deserializeLambda(functionList.get(0));
+        final Function flatMapFunc = (Function) deserializeLambda(functionList.get(0), classLoader);
         final Injector injector = Tang.Factory.getTang().newInjector(cb.build());
         injector.bindVolatileInstance(Function.class, flatMapFunc);
         return injector.getInstance(FlatMapOperator.class);
       }
       case MAP: {
-        final Function mapFunc = (Function) deserializeLambda(functionList.get(0));
+        final Function mapFunc = (Function) deserializeLambda(functionList.get(0), classLoader);
         final Injector injector = Tang.Factory.getTang().newInjector(cb.build());
         injector.bindVolatileInstance(Function.class, mapFunc);
         return injector.getInstance(MapOperator.class);
       }
       case REDUCE_BY_KEY: {
         cb.bindNamedParameter(KeyIndex.class, iOpInfo.getKeyIndex().toString());
-        final BiFunction reduceFunc = (BiFunction) deserializeLambda(functionList.get(0));
+        final BiFunction reduceFunc = (BiFunction) deserializeLambda(functionList.get(0), classLoader);
         final Injector injector = Tang.Factory.getTang().newInjector(cb.build());
         injector.bindVolatileInstance(BiFunction.class, reduceFunc);
         return injector.getInstance(ReduceByKeyOperator.class);
@@ -166,6 +181,26 @@ final class DefaultPhysicalPlanGeneratorImpl implements PhysicalPlanGenerator {
     final Map<SourceGenerator, Set<Operator>> sourceMap = new HashMap<>();
     final DAG<Operator> operators = new AdjacentListDAG<>();
     final Map<Operator, Set<Sink>> sinkMap = new HashMap<>();
+
+    // Deserialize Jar
+    final ClassLoader userQueryClassLoader;
+    if (!queryIdAndLogicalPlan.getValue().getIsJarSerialized()) {
+      userQueryClassLoader = null;
+    } else {
+      final String jarFilePath;
+      jarFilePath = String.format("./%s.jar", queryId);
+      final ByteBuffer byteBufferJar = queryIdAndLogicalPlan.getValue().getJar();
+      final byte[] byteArrayJar = new byte[byteBufferJar.remaining()];
+      byteBufferJar.get(byteArrayJar);
+      try {
+        FileUtils.writeByteArrayToFile(new File(jarFilePath), byteArrayJar);
+        userQueryClassLoader = new URLClassLoader(new URL[]{new URL(jarFilePath)});
+      } catch (IOException e) {
+        LOG.log(Level.FINE, "Cannot save jar location ");
+        return null;
+      }
+    }
+
     // Deserialize vertices
     for (final Vertex vertex : logicalPlan.getVertices()) {
       switch (vertex.getVertexType()) {
@@ -189,10 +224,15 @@ final class DefaultPhysicalPlanGeneratorImpl implements PhysicalPlanGenerator {
         }
         case INSTANT_OPERATOR: {
           final InstantOperatorInfo iOpInfo = (InstantOperatorInfo) vertex.getAttributes();
-          final Operator operator = getInstantOperator(queryId, iOpInfo);
-          deserializedVertices.add(operator);
-          operators.addVertex(operator);
-          break;
+          try {
+            final Operator operator = getInstantOperator(queryId, iOpInfo, userQueryClassLoader);
+            deserializedVertices.add(operator);
+            operators.addVertex(operator);
+            break;
+          } catch (Exception e) {
+            LOG.log(Level.FINE, e.toString());
+            return null;
+          }
         }
         case WINDOW_OPERATOR: {
           throw new IllegalArgumentException("MISTTask: WindowOperator is currently not supported!");

--- a/src/test/java/edu/snu/mist/api/MISTExecutionEnvironmentImplTest.java
+++ b/src/test/java/edu/snu/mist/api/MISTExecutionEnvironmentImplTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 
 /**
@@ -59,7 +60,7 @@ public class MISTExecutionEnvironmentImplTest {
    * Test for MISTExecutionEnvironmentImpl.
    */
   @Test
-  public void testMISTExecutionEnvironment() throws IOException, InjectionException {
+  public void testMISTExecutionEnvironment() throws IOException, InjectionException, URISyntaxException {
     // Step 1: Launch mock RPC Server
     final Server driverServer = new NettyServer(new SpecificResponder(MistTaskProvider.class, new MockDriverServer()),
         new InetSocketAddress(driverPortNum));

--- a/src/test/java/edu/snu/mist/api/serialize/avro/MISTQuerySerializerTest.java
+++ b/src/test/java/edu/snu/mist/api/serialize/avro/MISTQuerySerializerTest.java
@@ -37,6 +37,8 @@ import org.apache.reef.tang.exceptions.InjectionException;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.function.BiFunction;
@@ -77,7 +79,7 @@ public final class MISTQuerySerializerTest {
    * @throws InjectionException
    */
   @Test
-  public void mistComplexQuerySerializeTest() throws InjectionException {
+  public void mistComplexQuerySerializeTest() throws InjectionException, IOException, URISyntaxException {
     final MISTQuery complexQuery = new REEFNetworkSourceStream<String>(reefNetworkSourceConf)
         .flatMap(expectedFlatMapFunc)
         .filter(expectedFilterPredicate)
@@ -216,7 +218,7 @@ public final class MISTQuerySerializerTest {
    * @throws InjectionException
    */
   @Test
-  public void mistTextSocketSerializeTest() throws InjectionException {
+  public void mistTextSocketSerializeTest() throws InjectionException, IOException, URISyntaxException {
     final MISTQuery textSocketQuery = new TextSocketSourceStream<String>(textSocketSourceConf)
         .flatMap(expectedFlatMapFunc)
         .textSocketOutput(textSocketSinkConf)

--- a/src/test/java/edu/snu/mist/task/DefaultPhysicalPlanGeneratorTest.java
+++ b/src/test/java/edu/snu/mist/task/DefaultPhysicalPlanGeneratorTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
@@ -77,7 +78,7 @@ public final class DefaultPhysicalPlanGeneratorTest {
    * @throws InjectionException
    */
   @Test
-  public void testPhysicalPlanGenerator() throws InjectionException {
+  public void testPhysicalPlanGenerator() throws InjectionException, IOException, URISyntaxException {
     final MISTQuery query = new TextSocketSourceStream<String>(APITestParameters.LOCAL_TEXT_SOCKET_SOURCE_CONF)
         .flatMap(s -> Arrays.asList(s.split(" ")))
         .filter(s -> s.startsWith("A"))


### PR DESCRIPTION
This commit fixes bug #209 by sending client jars to Task and loading them dynamically when deserializing user query.
