### PR TITLE
[MIST-228] Fix null return in PhysicalPlanGenerator.generate and improve Exception handling

### DIFF
--- a/src/main/java/edu/snu/mist/api/serialize/avro/MISTQuerySerializerImpl.java
+++ b/src/main/java/edu/snu/mist/api/serialize/avro/MISTQuerySerializerImpl.java
@@ -66,7 +66,6 @@ public final class MISTQuerySerializerImpl implements MISTQuerySerializer {
     this.instantOperatorInfoProvider = injector.getInstance(InstantOperatorInfoProvider.class);
     final String jarPathCandidate = MISTQuerySerializerImpl.class.getProtectionDomain().getCodeSource().getLocation()
         .toURI().toString();
-    System.out.println("Hey~ Hey~:" + jarPathCandidate);
     if (!jarPathCandidate.endsWith(".jar")) {
       this.runningJarPathString = null;
     } else {

--- a/src/main/java/edu/snu/mist/driver/MistDriver.java
+++ b/src/main/java/edu/snu/mist/driver/MistDriver.java
@@ -15,15 +15,8 @@
  */
 package edu.snu.mist.driver;
 
-import edu.snu.mist.common.rpc.AvroRPCNettyServerWrapper;
-import edu.snu.mist.common.rpc.RPCServerPort;
-import edu.snu.mist.formats.avro.ClientToTaskMessage;
-import edu.snu.mist.task.DefaultClientToTaskMessageImpl;
 import edu.snu.mist.task.MistTask;
-import edu.snu.mist.task.TaskSpecificResponderWrapper;
-import edu.snu.mist.task.parameters.NumExecutors;
 import org.apache.avro.ipc.Server;
-import org.apache.avro.ipc.specific.SpecificResponder;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.context.ContextConfiguration;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
@@ -35,8 +28,6 @@ import org.apache.reef.io.network.naming.NameResolverConfiguration;
 import org.apache.reef.io.network.naming.NameServer;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Configurations;
-import org.apache.reef.tang.JavaConfigurationBuilder;
-import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.annotations.Unit;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.remote.address.LocalAddressProvider;
@@ -161,15 +152,9 @@ public final class MistDriver {
           .set(TaskConfiguration.IDENTIFIER, taskId)
           .set(TaskConfiguration.TASK, MistTask.class)
           .build();
-      final JavaConfigurationBuilder jcb = Tang.Factory.getTang().newConfigurationBuilder();
-      jcb.bindNamedParameter(NumExecutors.class, mistTaskConfigs.getNumTaskExecutors()+"");
-      jcb.bindImplementation(ClientToTaskMessage.class, DefaultClientToTaskMessageImpl.class);
-      jcb.bindConstructor(Server.class, AvroRPCNettyServerWrapper.class);
-      jcb.bindConstructor(SpecificResponder.class, TaskSpecificResponderWrapper.class);
-      jcb.bindNamedParameter(RPCServerPort.class, mistTaskConfigs.getRpcServerPort()+"");
       // submit a task
       activeContext.submitTask(
-          Configurations.merge(nameResolverConf, taskConfiguration, jcb.build()));
+          Configurations.merge(nameResolverConf, taskConfiguration, mistTaskConfigs.getConfiguration()));
     }
   }
 

--- a/src/main/java/edu/snu/mist/driver/MistTaskConfigs.java
+++ b/src/main/java/edu/snu/mist/driver/MistTaskConfigs.java
@@ -15,11 +15,21 @@
  */
 package edu.snu.mist.driver;
 
+import edu.snu.mist.common.rpc.AvroRPCNettyServerWrapper;
 import edu.snu.mist.common.rpc.RPCServerPort;
 import edu.snu.mist.driver.parameters.NumTaskCores;
 import edu.snu.mist.driver.parameters.NumTasks;
 import edu.snu.mist.driver.parameters.TaskMemorySize;
+import edu.snu.mist.driver.parameters.TempFolderPath;
+import edu.snu.mist.formats.avro.ClientToTaskMessage;
+import edu.snu.mist.task.DefaultClientToTaskMessageImpl;
+import edu.snu.mist.task.TaskSpecificResponderWrapper;
 import edu.snu.mist.task.parameters.NumExecutors;
+import org.apache.avro.ipc.Server;
+import org.apache.avro.ipc.specific.SpecificResponder;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.JavaConfigurationBuilder;
+import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
@@ -56,16 +66,23 @@ final class MistTaskConfigs {
    */
   private final int rpcServerPort;
 
+  /**
+   * Temporary folder path for storing temporay jar files.
+   */
+  private final String tempFolderPath;
+
   @Inject
   private MistTaskConfigs(@Parameter(NumTasks.class) final int numTasks,
                           @Parameter(TaskMemorySize.class) final int taskMemSize,
                           @Parameter(NumExecutors.class) final int numTaskExecutors,
                           @Parameter(NumTaskCores.class) final int numTaskCores,
-                          @Parameter(RPCServerPort.class) final int rpcServerPort) {
+                          @Parameter(RPCServerPort.class) final int rpcServerPort,
+                          @Parameter(TempFolderPath.class) final String tempFolderPath) {
     this.numTasks = numTasks;
     this.numTaskExecutors = numTaskExecutors;
     this.taskMemSize = taskMemSize;
     this.numTaskCores = numTaskCores;
+    this.tempFolderPath = tempFolderPath;
     this.rpcServerPort = rpcServerPort + 10 > MAX_PORT_NUM ? rpcServerPort - 10 : rpcServerPort + 10;
   }
 
@@ -87,5 +104,27 @@ final class MistTaskConfigs {
 
   public int getRpcServerPort() {
     return rpcServerPort;
+  }
+
+  public String getTempFolderPath() {
+    return tempFolderPath;
+  }
+
+  public Configuration getConfiguration() {
+    final JavaConfigurationBuilder jcb = Tang.Factory.getTang().newConfigurationBuilder();
+
+    // Parameter
+    jcb.bindNamedParameter(NumTasks.class, Integer.toString(numTasks));
+    jcb.bindNamedParameter(TaskMemorySize.class, Integer.toString(taskMemSize));
+    jcb.bindNamedParameter(NumExecutors.class, Integer.toString(numTaskExecutors));
+    jcb.bindNamedParameter(NumTaskCores.class, Integer.toString(numTaskCores));
+    jcb.bindNamedParameter(RPCServerPort.class, Integer.toString(rpcServerPort));
+    jcb.bindNamedParameter(TempFolderPath.class, tempFolderPath);
+
+    // Implementation
+    jcb.bindImplementation(ClientToTaskMessage.class, DefaultClientToTaskMessageImpl.class);
+    jcb.bindConstructor(Server.class, AvroRPCNettyServerWrapper.class);
+    jcb.bindConstructor(SpecificResponder.class, TaskSpecificResponderWrapper.class);
+    return jcb.build();
   }
 }

--- a/src/main/java/edu/snu/mist/driver/parameters/TempFolderPath.java
+++ b/src/main/java/edu/snu/mist/driver/parameters/TempFolderPath.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.driver.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Temporary folder path", short_name = "tmp", default_value = "/tmp/")
+public final class TempFolderPath implements Name<String> {
+  // empty
+}

--- a/src/main/java/edu/snu/mist/task/DefaultQuerySubmitterImpl.java
+++ b/src/main/java/edu/snu/mist/task/DefaultQuerySubmitterImpl.java
@@ -24,7 +24,6 @@ import edu.snu.mist.task.sources.Source;
 import org.apache.reef.io.Tuple;
 import org.apache.reef.io.network.util.StringIdentifierFactory;
 import org.apache.reef.tang.annotations.Parameter;
-import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.wake.impl.ThreadPoolStage;
 
 import javax.inject.Inject;
@@ -91,8 +90,9 @@ final class DefaultQuerySubmitterImpl implements QuerySubmitter {
       try {
         // 1) Converts the logical plan to the physical plan
         physicalPlan = physicalPlanGenerator.generate(tuple);
-      } catch (final InjectionException e) {
-        LOG.log(Level.INFO, "Injection Exception occurred during de-serializing LogicalPlans!");
+      } catch (final Exception e) {
+        e.printStackTrace();
+        LOG.log(Level.SEVERE,  "Injection Exception occurred during de-serializing LogicalPlans");
         return;
       }
 

--- a/src/main/java/edu/snu/mist/task/PhysicalPlanGenerator.java
+++ b/src/main/java/edu/snu/mist/task/PhysicalPlanGenerator.java
@@ -21,6 +21,8 @@ import org.apache.reef.io.Tuple;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.tang.exceptions.InjectionException;
 
+import java.io.IOException;
+
 /**
  * This interface is for generating physical plan from logical plan.
  * This deserializes the logical plan and creates physical plan.
@@ -32,5 +34,6 @@ public interface PhysicalPlanGenerator {
    * @param queryIdAndLogicalPlan the tuple of queryId and logical plan
    * @return physical plan
    */
-  PhysicalPlan<Operator> generate(Tuple<String, LogicalPlan> queryIdAndLogicalPlan) throws InjectionException;
+  PhysicalPlan<Operator> generate(Tuple<String, LogicalPlan> queryIdAndLogicalPlan)
+      throws InjectionException, IOException, ClassNotFoundException;
 }

--- a/src/test/java/edu/snu/mist/task/DefaultPhysicalPlanGeneratorTest.java
+++ b/src/test/java/edu/snu/mist/task/DefaultPhysicalPlanGeneratorTest.java
@@ -78,7 +78,8 @@ public final class DefaultPhysicalPlanGeneratorTest {
    * @throws InjectionException
    */
   @Test
-  public void testPhysicalPlanGenerator() throws InjectionException, IOException, URISyntaxException {
+  public void testPhysicalPlanGenerator()
+      throws InjectionException, IOException, URISyntaxException, ClassNotFoundException {
     final MISTQuery query = new TextSocketSourceStream<String>(APITestParameters.LOCAL_TEXT_SOCKET_SOURCE_CONF)
         .flatMap(s -> Arrays.asList(s.split(" ")))
         .filter(s -> s.startsWith("A"))


### PR DESCRIPTION
This PR addressed the issue #228 by 
- creating a named parameter: `TempFolderPath`
- throwing exceptions in `PhysicalPlanGenerator` and handling the exceptions in `QuerySubmitter`. 
- moving `.bindImplementation` codes for Task into `MistTaskConfigs`
