### PR TITLE
[MIST-250] Change the name of QuerySubmitter and parameterize NumSubmitterThreads to TaskConfigs

### DIFF
--- a/src/main/java/edu/snu/mist/Mist.java
+++ b/src/main/java/edu/snu/mist/Mist.java
@@ -22,6 +22,7 @@ import edu.snu.mist.driver.parameters.NumTasks;
 import edu.snu.mist.driver.parameters.TaskMemorySize;
 import edu.snu.mist.launcher.DriverRuntimeType;
 import edu.snu.mist.launcher.MistLauncher;
+import edu.snu.mist.task.parameters.NumQueryReceiverThreads;
 import edu.snu.mist.task.parameters.NumThreads;
 import org.apache.reef.client.LauncherStatus;
 import org.apache.reef.tang.Configuration;
@@ -48,6 +49,7 @@ public final class Mist {
         .registerShortNameOfClass(NumTaskCores.class)
         .registerShortNameOfClass(NumThreads.class)
         .registerShortNameOfClass(NumTasks.class)
+        .registerShortNameOfClass(NumQueryReceiverThreads.class)
         .registerShortNameOfClass(RPCServerPort.class)
         .registerShortNameOfClass(TaskMemorySize.class)
         .processCommandLine(args);

--- a/src/main/java/edu/snu/mist/driver/MistTaskConfigs.java
+++ b/src/main/java/edu/snu/mist/driver/MistTaskConfigs.java
@@ -24,6 +24,7 @@ import edu.snu.mist.driver.parameters.TempFolderPath;
 import edu.snu.mist.formats.avro.ClientToTaskMessage;
 import edu.snu.mist.task.DefaultClientToTaskMessageImpl;
 import edu.snu.mist.task.TaskSpecificResponderWrapper;
+import edu.snu.mist.task.parameters.NumQueryReceiverThreads;
 import edu.snu.mist.task.parameters.NumThreads;
 import org.apache.avro.ipc.Server;
 import org.apache.avro.ipc.specific.SpecificResponder;
@@ -57,6 +58,11 @@ final class MistTaskConfigs {
   private final int numTaskThreads;
 
   /**
+   * The number of threads for receiving queries in MistTask.
+   */
+  private final int numReceiverThreads;
+
+  /**
    * The number of cores of a MistTask.
    */
   private final int numTaskCores;
@@ -77,12 +83,14 @@ final class MistTaskConfigs {
                           @Parameter(NumThreads.class) final int numTaskThreads,
                           @Parameter(NumTaskCores.class) final int numTaskCores,
                           @Parameter(RPCServerPort.class) final int rpcServerPort,
+                          @Parameter(NumQueryReceiverThreads.class) final int numReceiverThreads,
                           @Parameter(TempFolderPath.class) final String tempFolderPath) {
     this.numTasks = numTasks;
     this.numTaskThreads = numTaskThreads;
     this.taskMemSize = taskMemSize;
     this.numTaskCores = numTaskCores;
     this.tempFolderPath = tempFolderPath;
+    this.numReceiverThreads = numReceiverThreads;
     this.rpcServerPort = rpcServerPort + 10 > MAX_PORT_NUM ? rpcServerPort - 10 : rpcServerPort + 10;
   }
 
@@ -110,6 +118,10 @@ final class MistTaskConfigs {
     return tempFolderPath;
   }
 
+  public int getNumReceiverThreads() {
+    return numReceiverThreads;
+  }
+
   public Configuration getConfiguration() {
     final JavaConfigurationBuilder jcb = Tang.Factory.getTang().newConfigurationBuilder();
 
@@ -120,6 +132,7 @@ final class MistTaskConfigs {
     jcb.bindNamedParameter(NumTaskCores.class, Integer.toString(numTaskCores));
     jcb.bindNamedParameter(RPCServerPort.class, Integer.toString(rpcServerPort));
     jcb.bindNamedParameter(TempFolderPath.class, tempFolderPath);
+    jcb.bindNamedParameter(NumQueryReceiverThreads.class, Integer.toString(numReceiverThreads));
 
     // Implementation
     jcb.bindImplementation(ClientToTaskMessage.class, DefaultClientToTaskMessageImpl.class);

--- a/src/main/java/edu/snu/mist/task/DefaultClientToTaskMessageImpl.java
+++ b/src/main/java/edu/snu/mist/task/DefaultClientToTaskMessageImpl.java
@@ -26,14 +26,14 @@ import javax.inject.Inject;
 /**
  * This class implements the RPC protocol of ClientToTaskMessage.
  * It creates the query id and returns it to users.
- * Also, it submits the tuple of queryId and logical plan to QuerySubmitter in order to execute the query.
+ * Also, it submits the tuple of queryId and logical plan to QueryReceiver in order to execute the query.
  */
 public final class DefaultClientToTaskMessageImpl implements ClientToTaskMessage {
 
   /**
-   * A query submitter which runs the submitted query.
+   * A query receiver which receives the submitted query.
    */
-  private final QuerySubmitter querySubmitter;
+  private final QueryReceiver queryReceiver;
 
   /**
    * A generator of query id.
@@ -42,15 +42,15 @@ public final class DefaultClientToTaskMessageImpl implements ClientToTaskMessage
 
   @Inject
   private DefaultClientToTaskMessageImpl(final QueryIdGenerator queryIdGenerator,
-                                         final QuerySubmitter querySubmitter) {
+                                         final QueryReceiver queryReceiver) {
     this.queryIdGenerator = queryIdGenerator;
-    this.querySubmitter = querySubmitter;
+    this.queryReceiver = queryReceiver;
   }
 
   @Override
   public QuerySubmissionResult sendQueries(final LogicalPlan logicalPlan) throws AvroRemoteException {
     final String queryId = queryIdGenerator.generate(logicalPlan);
-    querySubmitter.onNext(new Tuple<>(queryId, logicalPlan));
+    queryReceiver.onNext(new Tuple<>(queryId, logicalPlan));
     // Return the query Id
     final QuerySubmissionResult querySubmissionResult = new QuerySubmissionResult();
     querySubmissionResult.setQueryId(queryId);

--- a/src/main/java/edu/snu/mist/task/DefaultQueryReceiverImpl.java
+++ b/src/main/java/edu/snu/mist/task/DefaultQueryReceiverImpl.java
@@ -19,7 +19,7 @@ import edu.snu.mist.common.DAG;
 import edu.snu.mist.common.GraphUtils;
 import edu.snu.mist.formats.avro.LogicalPlan;
 import edu.snu.mist.task.operators.Operator;
-import edu.snu.mist.task.parameters.NumSubmitterThreads;
+import edu.snu.mist.task.parameters.NumQueryReceiverThreads;
 import edu.snu.mist.task.sources.Source;
 import org.apache.reef.io.Tuple;
 import org.apache.reef.io.network.util.StringIdentifierFactory;
@@ -35,7 +35,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * DefaultQuerySubmitterImpl does the following things:
+ * DefaultQueryReceiverImpl does the following things:
  * 1) receives logical plans from clients and converts the logical plans to physical plans,
  * 2) chains the physical operators and make PartitionedQuery,
  * 3) inserts the PartitionedQueries' queues to PartitionedQueryQueueManager,
@@ -44,9 +44,9 @@ import java.util.logging.Logger;
  * 5) starts to receive input data stream from the source of the query.
  */
 @SuppressWarnings("unchecked")
-final class DefaultQuerySubmitterImpl implements QuerySubmitter {
+final class DefaultQueryReceiverImpl implements QueryReceiver {
 
-  private static final Logger LOG = Logger.getLogger(DefaultQuerySubmitterImpl.class.getName());
+  private static final Logger LOG = Logger.getLogger(DefaultQueryReceiverImpl.class.getName());
   /**
    * Thread pool stage for executing the query submission logic.
    */
@@ -68,20 +68,20 @@ final class DefaultQuerySubmitterImpl implements QuerySubmitter {
   private final ThreadManager threadManager;
 
   /**
-   * Default query submitter in MistTask.
+   * Default query receiver in MistTask.
    * @param queryPartitioner the converter which chains operators and makes PartitionedQueries
    * @param physicalPlanGenerator the physical plan generator which generates physical plan from logical paln
    * @param idfactory identifier factory
    * @param threadManager thread manager
-   * @param numThreads the number of threads for the query submitter
+   * @param numThreads the number of threads for the query receiver
    */
   @Inject
-  private DefaultQuerySubmitterImpl(final QueryPartitioner queryPartitioner,
-                                    final PhysicalPlanGenerator physicalPlanGenerator,
-                                    final StringIdentifierFactory idfactory,
-                                    final ThreadManager threadManager,
-                                    final PartitionedQueryQueueManager queueManager,
-                                    @Parameter(NumSubmitterThreads.class) final int numThreads) {
+  private DefaultQueryReceiverImpl(final QueryPartitioner queryPartitioner,
+                                   final PhysicalPlanGenerator physicalPlanGenerator,
+                                   final StringIdentifierFactory idfactory,
+                                   final ThreadManager threadManager,
+                                   final PartitionedQueryQueueManager queueManager,
+                                   @Parameter(NumQueryReceiverThreads.class) final int numThreads) {
     this.physicalPlanMap = new ConcurrentHashMap<>();
     this.queueManager = queueManager;
     this.threadManager = threadManager;

--- a/src/main/java/edu/snu/mist/task/MistTask.java
+++ b/src/main/java/edu/snu/mist/task/MistTask.java
@@ -26,7 +26,7 @@ import java.util.logging.Logger;
 
 /**
  * A runtime engine running mist queries.
- * The actual query submission logic is performed by QuerySubmitter.
+ * The submitted queries are handled by QueryReceiver.
  */
 public final class MistTask implements Task {
   private static final Logger LOG = Logger.getLogger(MistTask.class.getName());

--- a/src/main/java/edu/snu/mist/task/QueryReceiver.java
+++ b/src/main/java/edu/snu/mist/task/QueryReceiver.java
@@ -13,11 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.mist.task.parameters;
+package edu.snu.mist.task;
 
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
+import edu.snu.mist.formats.avro.LogicalPlan;
+import org.apache.reef.io.Tuple;
+import org.apache.reef.tang.annotations.DefaultImplementation;
+import org.apache.reef.wake.EStage;
 
-@NamedParameter(doc = "The number of threads of QuerySubmitter", default_value = "10")
-public final class NumSubmitterThreads implements Name<Integer> {
+/**
+ * This interface receives a tuple of queryId and logical plan,
+ * converts the logical plan to the physical plan,
+ * chains operators, allocates the chains into Executors,
+ * and starts to receive input data stream of the query.
+ */
+@DefaultImplementation(DefaultQueryReceiverImpl.class)
+public interface QueryReceiver extends EStage<Tuple<String, LogicalPlan>> {
+
 }

--- a/src/main/java/edu/snu/mist/task/parameters/NumQueryReceiverThreads.java
+++ b/src/main/java/edu/snu/mist/task/parameters/NumQueryReceiverThreads.java
@@ -13,20 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.mist.task;
+package edu.snu.mist.task.parameters;
 
-import edu.snu.mist.formats.avro.LogicalPlan;
-import org.apache.reef.io.Tuple;
-import org.apache.reef.tang.annotations.DefaultImplementation;
-import org.apache.reef.wake.EStage;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
 
-/**
- * This interface receives a tuple of queryId and logical plan,
- * converts the logical plan to the physical plan,
- * chains operators, allocates the chains into Executors,
- * and starts to receive input data stream of the query.
- */
-@DefaultImplementation(DefaultQuerySubmitterImpl.class)
-public interface QuerySubmitter extends EStage<Tuple<String, LogicalPlan>> {
-
+@NamedParameter(doc = "The number of threads of QueryReceiver",
+    short_name = "num_receiver_threads", default_value = "10")
+public final class NumQueryReceiverThreads implements Name<Integer> {
 }


### PR DESCRIPTION
This PR addressed the issue #250 by
- changing `QuerySubmitter` to `QueryReceiver`
- changing `NumSubmitterThreads` to `NumQueryReceiverThreads`
- parameterizing `NumQueryReceiverThreads` 

Closes #250 
