### PR TITLE
[MIST-254] Make tuples to string before put to textSocketOutput in examples

### DIFF
--- a/src/main/java/edu/snu/mist/examples/UnionMist.java
+++ b/src/main/java/edu/snu/mist/examples/UnionMist.java
@@ -125,6 +125,7 @@ public final class UnionMist {
     final Sink sink = sourceStream1
         .union(sourceStream2)
         .reduceByKey(0, String.class, reduceFunction)
+        .map(s -> s.toString())
         .textSocketOutput(localTextSocketSinkConf);
 
     final MISTQuery query = sink.getQuery();

--- a/src/main/java/edu/snu/mist/examples/WordCount.java
+++ b/src/main/java/edu/snu/mist/examples/WordCount.java
@@ -114,6 +114,7 @@ public final class WordCount {
         .filter(s -> isAlpha(s))
         .map(s -> new Tuple2(s, 1))
         .reduceByKey(0, String.class, reduceFunction)
+        .map(s -> s.toString())
         .textSocketOutput(localTextSocketSinkConf);
     final MISTQuery query = sink.getQuery();
 


### PR DESCRIPTION
This pull request addressed the issue #254 by
- add map to change tuples into string before `textSocketOutput` in examples

Closes #254 
