### PR TITLE
[MIST-244] Gracefully shutdown MistTask

### DIFF
--- a/src/main/java/edu/snu/mist/driver/MistDriver.java
+++ b/src/main/java/edu/snu/mist/driver/MistDriver.java
@@ -151,6 +151,7 @@ public final class MistDriver {
       final Configuration taskConfiguration = TaskConfiguration.CONF
           .set(TaskConfiguration.IDENTIFIER, taskId)
           .set(TaskConfiguration.TASK, MistTask.class)
+          .set(TaskConfiguration.ON_CLOSE, MistTask.TaskCloseHandler.class)
           .build();
       // submit a task
       activeContext.submitTask(

--- a/src/main/java/edu/snu/mist/launcher/MistLauncher.java
+++ b/src/main/java/edu/snu/mist/launcher/MistLauncher.java
@@ -93,7 +93,7 @@ public final class MistLauncher {
   /**
    * @return the configuration of the Mist driver.
    */
-  private static Configuration getDriverConfiguration(final Configuration conf) {
+  public static Configuration getDriverConfiguration(final Configuration conf) {
     final JavaConfigurationBuilder jcb = Tang.Factory.getTang().newConfigurationBuilder(conf);
     jcb.bindImplementation(NameResolver.class, LocalNameResolverImpl.class);
     jcb.bindImplementation(IdentifierFactory.class, StringIdentifierFactory.class);

--- a/src/test/java/edu/snu/mist/launcher/MistLauncherTest.java
+++ b/src/test/java/edu/snu/mist/launcher/MistLauncherTest.java
@@ -33,7 +33,7 @@ public class MistLauncherTest {
   public void testMistLauncher() throws InjectionException {
     final LauncherStatus status = MistLauncher
         .getLauncher(MistLauncher.RuntimeType.LOCAL)
-        .setTimeout(1000)
+        .setTimeout(4000)
         .run(1, 1, 1, 7777, 2048);
     Assert.assertEquals(LauncherStatus.FORCE_CLOSED, status);
   }


### PR DESCRIPTION
This PR addressed the issue #244 by 
- Increasing the timeOut in MistLauncherTask
- Adding the TaskCloseHandler which closes Task gracefully

Closes #244 
