### PR TITLE
[MIST-262] Remove topologicalSort from DefaultQueryReceiver

### DIFF
--- a/src/main/java/edu/snu/mist/common/AdjacentListDAG.java
+++ b/src/main/java/edu/snu/mist/common/AdjacentListDAG.java
@@ -161,7 +161,7 @@ public final class AdjacentListDAG<V> implements DAG<V> {
   }
 
   @Override
-  public Iterator<V> getIterator() {
+  public Iterator<V> iterator() {
     return vertices.iterator();
   }
 }

--- a/src/main/java/edu/snu/mist/common/DAG.java
+++ b/src/main/java/edu/snu/mist/common/DAG.java
@@ -15,14 +15,13 @@
  */
 package edu.snu.mist.common;
 
-import java.util.Iterator;
 import java.util.Set;
 
 /**
  * This interface represents Directed Acyclic Graph (DAG).
  * @param <V> vertex
  */
-public interface DAG<V> {
+public interface DAG<V> extends Iterable<V> {
 
   /**
    * Gets root vertices for graph traversal.
@@ -85,10 +84,4 @@ public interface DAG<V> {
    * @throws java.util.NoSuchElementException if the vertex v does not exist.
    */
   int getInDegree(V v);
-
-  /**
-   * Returns the iterator of vertices.
-   * @return iterator
-   */
-  Iterator<V> getIterator();
 }

--- a/src/main/java/edu/snu/mist/task/DefaultQueryReceiverImpl.java
+++ b/src/main/java/edu/snu/mist/task/DefaultQueryReceiverImpl.java
@@ -102,7 +102,7 @@ final class DefaultQueryReceiverImpl implements QueryReceiver {
       final DAG<PartitionedQuery> chainedOperators = chainedPlan.getOperators();
 
       // 3) Inserts the PartitionedQueries' queues to PartitionedQueueManager.
-      final Iterator<PartitionedQuery> partitionedQueryIterator = chainedOperators.getIterator();
+      final Iterator<PartitionedQuery> partitionedQueryIterator = chainedOperators.iterator();
       while (partitionedQueryIterator.hasNext()) {
         final PartitionedQuery partitionedQuery = partitionedQueryIterator.next();
         queueManager.insert(partitionedQuery.getQueue());
@@ -132,7 +132,7 @@ final class DefaultQueryReceiverImpl implements QueryReceiver {
   private void start(final PhysicalPlan<PartitionedQuery> chainPhysicalPlan) {
     final DAG<PartitionedQuery> chainedOperators = chainPhysicalPlan.getOperators();
     // 4) Sets output emitters
-    final Iterator<PartitionedQuery> iterator = chainedOperators.getIterator();
+    final Iterator<PartitionedQuery> iterator = chainedOperators.iterator();
     while (iterator.hasNext()) {
       final PartitionedQuery partitionedQuery = iterator.next();
       final Set<PartitionedQuery> neighbors = chainedOperators.getNeighbors(partitionedQuery);

--- a/src/test/java/edu/snu/mist/common/AdjacentListDAGTest.java
+++ b/src/test/java/edu/snu/mist/common/AdjacentListDAGTest.java
@@ -104,7 +104,7 @@ public final class AdjacentListDAGTest {
     expected.addAll(Arrays.asList(1, 2, 3, 5));
 
     final Set<Integer> result = new HashSet<>();
-    final Iterator<Integer> iterator = dag.getIterator();
+    final Iterator<Integer> iterator = dag.iterator();
     while (iterator.hasNext()) {
       result.add(iterator.next());
     }


### PR DESCRIPTION
This PR addressed the issue #262 by
- removing topologicalSort from DefaultQueryReceiver
- adding `getIterator` to `DAG`

Closes #262 
