### PR TITLE
[MIST-286] Disable TypeChecker in Union operation

### DIFF
--- a/src/main/java/edu/snu/mist/api/ContinuousStreamImpl.java
+++ b/src/main/java/edu/snu/mist/api/ContinuousStreamImpl.java
@@ -100,15 +100,12 @@ public abstract class ContinuousStreamImpl<T> extends MISTStreamImpl<T> implemen
 
   @Override
   public UnionOperatorStream<T> union(final ContinuousStream<T> inputStream) throws StreamTypeMismatchException {
-    if (TypeChecker.checkTypesEqual(this, inputStream)) {
-      final UnionOperatorStream<T> downStream = new UnionOperatorStream<>(dag);
-      dag.addVertex(downStream);
-      dag.addEdge(this, downStream, StreamType.Direction.LEFT);
-      dag.addEdge(inputStream, downStream, StreamType.Direction.RIGHT);
-      return downStream;
-    } else {
-      throw new StreamTypeMismatchException("Cannot perform union between streams having different data types!");
-    }
+    // TODO[MIST-245]: Improve type checking.
+    final UnionOperatorStream<T> downStream = new UnionOperatorStream<>(dag);
+    dag.addVertex(downStream);
+    dag.addEdge(this, downStream, StreamType.Direction.LEFT);
+    dag.addEdge(inputStream, downStream, StreamType.Direction.RIGHT);
+    return downStream;
   }
 
   @Override

--- a/src/main/java/edu/snu/mist/api/TypeChecker.java
+++ b/src/main/java/edu/snu/mist/api/TypeChecker.java
@@ -38,6 +38,7 @@ public final class TypeChecker {
    */
   public static <T1, T2> boolean checkTypesEqual(final MISTStream<T1> stream1, final MISTStream<T2> stream2) {
     // TODO[MIST-245]: Improve type checking. Type checking in below checks only generic type's name.
+    // It can return false even though two types are equal, so we disable it (MIST-286)
     final Type[] types1 = getStreamType(stream1);
     final Type[] types2 = getStreamType(stream2);
 


### PR DESCRIPTION
This PR addressed the issue #286 by
- removing type checking mechanism from union operation.

Closes #286 
