### PR TITLE
[MIST-247] Add MISTExampleUtils to refactor MIST examples

### DIFF
--- a/src/main/java/edu/snu/mist/examples/HelloMist.java
+++ b/src/main/java/edu/snu/mist/examples/HelloMist.java
@@ -17,13 +17,16 @@
 package edu.snu.mist.examples;
 
 import edu.snu.mist.api.APIQuerySubmissionResult;
-import edu.snu.mist.api.MISTExecutionEnvironment;
 import edu.snu.mist.api.MISTQuery;
 import edu.snu.mist.api.MISTQueryBuilder;
 import edu.snu.mist.api.sink.builder.TextSocketSinkConfiguration;
 import edu.snu.mist.api.sources.builder.TextSocketSourceConfiguration;
-import org.apache.commons.cli.*;
+import edu.snu.mist.examples.parameters.SourceAddress;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.JavaConfigurationBuilder;
+import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.tang.formats.CommandLine;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -32,55 +35,6 @@ import java.net.URISyntaxException;
  * Example client which submits a stateless query.
  */
 public final class HelloMist {
-
-  private static String driverHost = "localhost";
-  private static int driverPort = 20332;
-  private static String sourceHost = "localhost";
-  private static int sourcePort = 20331;
-  private static final String SINK_HOST = "localhost";
-  private static final int SINK_PORT = 20330;
-
-  /**
-   * Print command line options.
-   * @param options command line options
-   * @param reason how the user use the options incorrectly
-   */
-  private static void printHelp(final Options options, final String reason) {
-    if (reason != null) {
-      System.out.println(reason);
-    }
-    new HelpFormatter().printHelp("HelloMist", options);
-    System.exit(1);
-  }
-
-  /**
-   * Generate an Option from the parameters.
-   * @param shortArg short name of the argument
-   * @param longArg long name of the argument
-   * @param description description of the argument
-   * @return an Option from the names and description
-   */
-  private static Option setOption(final String shortArg, final String longArg, final String description) {
-    final Option option = new Option(shortArg, longArg, true, description);
-    option.setOptionalArg(true);
-    return option;
-  }
-
-  /**
-   * Bundle options for MIST.
-   * @return the bundled Options
-   */
-  private static Options setOptions() {
-    final Options options = new Options();
-    final Option helpOption = new Option("?", "help", false, "Print help");
-    options.addOption(helpOption);
-    options.addOption(setOption("d", "driver", "Address of running MIST driver" +
-        " in the form of hostname:port (Default: localhost:20332)."));
-    options.addOption(setOption("s", "source", "Address of running source server" +
-        " in the form of hostname:port (Default: localhost:20331)."));
-    return options;
-  }
-
   /**
    * Submit a stateless query.
    * The query reads strings from a source server, filter strings which start with "HelloMist:",
@@ -89,16 +43,12 @@ public final class HelloMist {
    * @throws IOException
    * @throws InjectionException
    */
-  public static APIQuerySubmissionResult submitQuery() throws IOException, InjectionException, URISyntaxException {
-    final TextSocketSourceConfiguration localTextSocketSourceConf = TextSocketSourceConfiguration.newBuilder()
-        .setHostAddress(sourceHost)
-        .setHostPort(sourcePort)
-        .build();
-
-    final TextSocketSinkConfiguration localTextSocketSinkConf = TextSocketSinkConfiguration.newBuilder()
-        .setHostAddress(SINK_HOST)
-        .setHostPort(SINK_PORT)
-        .build();
+  public static APIQuerySubmissionResult submitQuery(final Configuration configuration)
+      throws IOException, InjectionException, URISyntaxException {
+    final String sourceSocket = Tang.Factory.getTang().newInjector(configuration).getNamedInstance(SourceAddress.class);
+    final TextSocketSourceConfiguration localTextSocketSourceConf =
+        MISTExampleUtils.getLocalTextSocketSourceConf(sourceSocket);
+    final TextSocketSinkConfiguration localTextSocketSinkConf = MISTExampleUtils.getLocalTextSocketSinkConf();
 
     final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
     queryBuilder.socketTextStream(localTextSocketSourceConf)
@@ -107,8 +57,7 @@ public final class HelloMist {
         .textSocketOutput(localTextSocketSinkConf);
     final MISTQuery query = queryBuilder.build();
 
-    final MISTExecutionEnvironment executionEnvironment = new MISTTestExecutionEnvironmentImpl(driverHost, driverPort);
-    return executionEnvironment.submit(query);
+    return MISTExampleUtils.submit(query, configuration);
   }
 
   /**
@@ -117,32 +66,27 @@ public final class HelloMist {
    * @throws Exception
    */
   public static void main(final String[] args) throws Exception {
-    final Options options = setOptions();
-    final Parser parser = new GnuParser();
-    final CommandLine cl = parser.parse(options, args);
-    if (cl.hasOption("?")) {
-      printHelp(options, null);
+    final JavaConfigurationBuilder jcb = Tang.Factory.getTang().newConfigurationBuilder();
+
+    final CommandLine commandLine = MISTExampleUtils.getDefaultCommandLine(jcb)
+        .registerShortNameOfClass(SourceAddress.class) // Additional parameter
+        .processCommandLine(args);
+
+    if (commandLine == null) {  // Option '?' was entered and processCommandLine printed the help.
+      return;
     }
 
-    if (cl.hasOption("d")) {
-      final String[] driverAddr = cl.getOptionValue("d", "localhost:20332").split(":");
-      driverHost = driverAddr[0];
-      driverPort = Integer.parseInt(driverAddr[1]);
-    }
-
-    if (cl.hasOption("s")) {
-      final String[] sourceAddr = cl.getOptionValue("s", "localhost:20331").split(":");
-      sourceHost = sourceAddr[0];
-      sourcePort = Integer.parseInt(sourceAddr[1]);
-    }
-
-    Thread sinkServer = new Thread(new SinkServer(SINK_PORT));
+    Thread sinkServer = new Thread(MISTExampleUtils.getSinkServer());
     sinkServer.start();
 
-    final APIQuerySubmissionResult result = submitQuery();
+    final APIQuerySubmissionResult result = submitQuery(jcb.build());
+
     System.out.println("Query submission result: " + result.getQueryId());
   }
 
+  /**
+   * Must not be instantiated.
+   */
   private HelloMist(){
   }
 }

--- a/src/main/java/edu/snu/mist/examples/MISTExampleUtils.java
+++ b/src/main/java/edu/snu/mist/examples/MISTExampleUtils.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.snu.mist.examples;
+
+import edu.snu.mist.api.APIQuerySubmissionResult;
+import edu.snu.mist.api.MISTExecutionEnvironment;
+import edu.snu.mist.api.MISTQuery;
+import edu.snu.mist.api.sink.builder.TextSocketSinkConfiguration;
+import edu.snu.mist.api.sources.builder.TextSocketSourceConfiguration;
+import edu.snu.mist.examples.parameters.DriverAddress;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.JavaConfigurationBuilder;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.tang.formats.CommandLine;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+/**
+ * Common behavior and basic defaults for MIST examples.
+ */
+public final class MISTExampleUtils {
+  /**
+   * TCP endpoint for sink server.
+   */
+  public static final String SINK_HOSTNAME = "localhost";
+  public static final int SINK_PORT = 20330;
+
+  /**
+   * Get a new sink server.
+   */
+  public static SinkServer getSinkServer() {
+    return new SinkServer(SINK_PORT);
+  }
+
+  /**
+   * Get socket configuration for local text source.
+   */
+  public static TextSocketSourceConfiguration getLocalTextSocketSourceConf(final String socket) {
+    final String[] sourceSocket = socket.split(":");
+    final String sourceHostname = sourceSocket[0];
+    final int sourcePort = Integer.parseInt(sourceSocket[1]);
+    return TextSocketSourceConfiguration.newBuilder()
+        .setHostAddress(sourceHostname)
+        .setHostPort(sourcePort)
+        .build();
+  }
+
+  /**
+   * Get socket configuration for local text sink.
+   */
+  public static TextSocketSinkConfiguration getLocalTextSocketSinkConf() {
+    return TextSocketSinkConfiguration.newBuilder()
+        .setHostAddress(SINK_HOSTNAME)
+        .setHostPort(SINK_PORT)
+        .build();
+  }
+
+  /**
+   * Submit query to MIST driver.
+   */
+  public static APIQuerySubmissionResult submit(final MISTQuery query, final Configuration configuration)
+      throws IOException, URISyntaxException, InjectionException {
+    final String[] driverSocket =
+        Tang.Factory.getTang().newInjector(configuration).getNamedInstance(DriverAddress.class).split(":");
+    final String driverHostname = driverSocket[0];
+    final int driverPort = Integer.parseInt(driverSocket[1]);
+    final MISTExecutionEnvironment executionEnvironment =
+        new MISTTestExecutionEnvironmentImpl(driverHostname, driverPort);
+    return executionEnvironment.submit(query);
+  }
+
+  public static CommandLine getDefaultCommandLine(final JavaConfigurationBuilder jcb) {
+    return new CommandLine(jcb)
+        .registerShortNameOfClass(DriverAddress.class);
+  }
+
+  /**
+   * Must not be instantiated.
+   */
+  private MISTExampleUtils() {
+  }
+}

--- a/src/main/java/edu/snu/mist/examples/QueryDeletion.java
+++ b/src/main/java/edu/snu/mist/examples/QueryDeletion.java
@@ -21,8 +21,12 @@ import edu.snu.mist.api.functions.MISTBiFunction;
 import edu.snu.mist.api.sink.builder.TextSocketSinkConfiguration;
 import edu.snu.mist.api.sources.builder.TextSocketSourceConfiguration;
 import edu.snu.mist.api.types.Tuple2;
-import org.apache.commons.cli.*;
+import edu.snu.mist.examples.parameters.SourceAddress;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.JavaConfigurationBuilder;
+import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.tang.formats.CommandLine;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -35,54 +39,6 @@ import static org.apache.commons.lang3.StringUtils.isAlpha;
  */
 public final class QueryDeletion {
 
-  private static String driverHost = "localhost";
-  private static int driverPort = 20332;
-  private static String sourceHost = "localhost";
-  private static int sourcePort = 20331;
-  private static final String SINK_HOST = "localhost";
-  private static final int SINK_PORT = 20330;
-
-  /**
-   * Print command line options.
-   * @param options command line options
-   * @param reason how the user use the options incorrectly
-   */
-  private static void printHelp(final Options options, final String reason) {
-    if (reason != null) {
-      System.out.println(reason);
-    }
-    new HelpFormatter().printHelp("QueryDeletion", options);
-    System.exit(1);
-  }
-
-  /**
-   * Generate an Option from the parameters.
-   * @param shortArg short name of the argument
-   * @param longArg long name of the argument
-   * @param description description of the argument
-   * @return an Option from the names and description
-   */
-  private static Option setOption(final String shortArg, final String longArg, final String description) {
-    final Option option = new Option(shortArg, longArg, true, description);
-    option.setOptionalArg(true);
-    return option;
-  }
-
-  /**
-   * Bundle options for MIST.
-   * @return the bundled Options
-   */
-  private static Options setOptions() {
-    final Options options = new Options();
-    final Option helpOption = new Option("?", "help", false, "Print help");
-    options.addOption(helpOption);
-    options.addOption(setOption("d", "driver", "Address of running MIST driver" +
-        " in the form of hostname:port (Default: localhost:20332)."));
-    options.addOption(setOption("s", "source", "Address of running source server" +
-        " in the form of hostname:port (Default: localhost:20331)."));
-    return options;
-  }
-
   /**
    * Submit a query containing reduce-by-key operator.
    * The query reads strings from a source server, filters alphabetical words,
@@ -91,16 +47,12 @@ public final class QueryDeletion {
    * @throws IOException
    * @throws InjectionException
    */
-  public static APIQuerySubmissionResult submitQuery() throws IOException, InjectionException, URISyntaxException {
-    final TextSocketSourceConfiguration localTextSocketSourceConf = TextSocketSourceConfiguration.newBuilder()
-        .setHostAddress(sourceHost)
-        .setHostPort(sourcePort)
-        .build();
-
-    final TextSocketSinkConfiguration localTextSocketSinkConf = TextSocketSinkConfiguration.newBuilder()
-        .setHostAddress(SINK_HOST)
-        .setHostPort(SINK_PORT)
-        .build();
+  public static APIQuerySubmissionResult submitQuery(final Configuration configuration)
+      throws IOException, InjectionException, URISyntaxException {
+    final String sourceSocket = Tang.Factory.getTang().newInjector(configuration).getNamedInstance(SourceAddress.class);
+    final TextSocketSourceConfiguration localTextSocketSourceConf =
+        MISTExampleUtils.getLocalTextSocketSourceConf(sourceSocket);
+    final TextSocketSinkConfiguration localTextSocketSinkConf = MISTExampleUtils.getLocalTextSocketSinkConf();
 
     // Simple reduce function.
     final MISTBiFunction<Integer, Integer, Integer> reduceFunction = (v1, v2) -> { return v1 + v2; };
@@ -113,8 +65,7 @@ public final class QueryDeletion {
         .textSocketOutput(localTextSocketSinkConf);
     final MISTQuery query = queryBuilder.build();
 
-    final MISTExecutionEnvironment executionEnvironment = new MISTTestExecutionEnvironmentImpl(driverHost, driverPort);
-    return executionEnvironment.submit(query);
+    return MISTExampleUtils.submit(query, configuration);
   }
 
   public static boolean deleteQuery(final APIQuerySubmissionResult result) throws IOException {
@@ -127,29 +78,20 @@ public final class QueryDeletion {
    * @throws Exception
    */
   public static void main(final String[] args) throws Exception {
-    final Options options = setOptions();
-    final Parser parser = new GnuParser();
-    final CommandLine cl = parser.parse(options, args);
-    if (cl.hasOption("?")) {
-      printHelp(options, null);
+    final JavaConfigurationBuilder jcb = Tang.Factory.getTang().newConfigurationBuilder();
+
+    final CommandLine commandLine = MISTExampleUtils.getDefaultCommandLine(jcb)
+        .registerShortNameOfClass(SourceAddress.class) // Additional parameter
+        .processCommandLine(args);
+
+    if (commandLine == null) {  // Option '?' was entered and processCommandLine printed the help.
+      return;
     }
 
-    if (cl.hasOption("d")) {
-      final String[] driverAddr = cl.getOptionValue("d", "localhost:20332").split(":");
-      driverHost = driverAddr[0];
-      driverPort = Integer.parseInt(driverAddr[1]);
-    }
-
-    if (cl.hasOption("s")) {
-      final String[] sourceAddr = cl.getOptionValue("s", "localhost:20331").split(":");
-      sourceHost = sourceAddr[0];
-      sourcePort = Integer.parseInt(sourceAddr[1]);
-    }
-
-    Thread sinkServer = new Thread(new SinkServer(SINK_PORT));
+    Thread sinkServer = new Thread(MISTExampleUtils.getSinkServer());
     sinkServer.start();
 
-    final APIQuerySubmissionResult result = submitQuery();
+    final APIQuerySubmissionResult result = submitQuery(jcb.build());
     System.out.println("Query submission result: " + result.getQueryId());
 
     Thread.sleep(10000);

--- a/src/main/java/edu/snu/mist/examples/WordCount.java
+++ b/src/main/java/edu/snu/mist/examples/WordCount.java
@@ -17,15 +17,18 @@
 package edu.snu.mist.examples;
 
 import edu.snu.mist.api.APIQuerySubmissionResult;
-import edu.snu.mist.api.MISTExecutionEnvironment;
 import edu.snu.mist.api.MISTQuery;
 import edu.snu.mist.api.MISTQueryBuilder;
 import edu.snu.mist.api.functions.MISTBiFunction;
 import edu.snu.mist.api.sink.builder.TextSocketSinkConfiguration;
 import edu.snu.mist.api.sources.builder.TextSocketSourceConfiguration;
 import edu.snu.mist.api.types.Tuple2;
-import org.apache.commons.cli.*;
+import edu.snu.mist.examples.parameters.SourceAddress;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.JavaConfigurationBuilder;
+import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.tang.formats.CommandLine;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -37,54 +40,6 @@ import static org.apache.commons.lang3.StringUtils.isAlpha;
  */
 public final class WordCount {
 
-  private static String driverHost = "localhost";
-  private static int driverPort = 20332;
-  private static String sourceHost = "localhost";
-  private static int sourcePort = 20331;
-  private static final String SINK_HOST = "localhost";
-  private static final int SINK_PORT = 20330;
-
-  /**
-   * Print command line options.
-   * @param options command line options
-   * @param reason how the user use the options incorrectly
-   */
-  private static void printHelp(final Options options, final String reason) {
-    if (reason != null) {
-      System.out.println(reason);
-    }
-    new HelpFormatter().printHelp("WordCount", options);
-    System.exit(1);
-  }
-
-  /**
-   * Generate an Option from the parameters.
-   * @param shortArg short name of the argument
-   * @param longArg long name of the argument
-   * @param description description of the argument
-   * @return an Option from the names and description
-   */
-  private static Option setOption(final String shortArg, final String longArg, final String description) {
-    final Option option = new Option(shortArg, longArg, true, description);
-    option.setOptionalArg(true);
-    return option;
-  }
-
-  /**
-   * Bundle options for MIST.
-   * @return the bundled Options
-   */
-  private static Options setOptions() {
-    final Options options = new Options();
-    final Option helpOption = new Option("?", "help", false, "Print help");
-    options.addOption(helpOption);
-    options.addOption(setOption("d", "driver", "Address of running MIST driver" +
-        " in the form of hostname:port (Default: localhost:20332)."));
-    options.addOption(setOption("s", "source", "Address of running source server" +
-        " in the form of hostname:port (Default: localhost:20331)."));
-    return options;
-  }
-
   /**
    * Submit a query containing reduce-by-key operator.
    * The query reads strings from a source server, filters alphabetical words,
@@ -93,16 +48,12 @@ public final class WordCount {
    * @throws IOException
    * @throws InjectionException
    */
-  public static APIQuerySubmissionResult submitQuery() throws IOException, InjectionException, URISyntaxException {
-    final TextSocketSourceConfiguration localTextSocketSourceConf = TextSocketSourceConfiguration.newBuilder()
-        .setHostAddress(sourceHost)
-        .setHostPort(sourcePort)
-        .build();
-
-    final TextSocketSinkConfiguration localTextSocketSinkConf = TextSocketSinkConfiguration.newBuilder()
-        .setHostAddress(SINK_HOST)
-        .setHostPort(SINK_PORT)
-        .build();
+  public static APIQuerySubmissionResult submitQuery(final Configuration configuration)
+      throws IOException, InjectionException, URISyntaxException {
+    final String sourceSocket = Tang.Factory.getTang().newInjector(configuration).getNamedInstance(SourceAddress.class);
+    final TextSocketSourceConfiguration localTextSocketSourceConf =
+        MISTExampleUtils.getLocalTextSocketSourceConf(sourceSocket);
+    final TextSocketSinkConfiguration localTextSocketSinkConf = MISTExampleUtils.getLocalTextSocketSinkConf();
 
     // Simple reduce function.
     final MISTBiFunction<Integer, Integer, Integer> reduceFunction = (v1, v2) -> { return v1 + v2; };
@@ -115,8 +66,7 @@ public final class WordCount {
         .textSocketOutput(localTextSocketSinkConf);
     final MISTQuery query = queryBuilder.build();
 
-    final MISTExecutionEnvironment executionEnvironment = new MISTTestExecutionEnvironmentImpl(driverHost, driverPort);
-    return executionEnvironment.submit(query);
+    return MISTExampleUtils.submit(query, configuration);
   }
 
   /**
@@ -125,29 +75,20 @@ public final class WordCount {
    * @throws Exception
    */
   public static void main(final String[] args) throws Exception {
-    final Options options = setOptions();
-    final Parser parser = new GnuParser();
-    final CommandLine cl = parser.parse(options, args);
-    if (cl.hasOption("?")) {
-      printHelp(options, null);
+    final JavaConfigurationBuilder jcb = Tang.Factory.getTang().newConfigurationBuilder();
+
+    final CommandLine commandLine = MISTExampleUtils.getDefaultCommandLine(jcb)
+        .registerShortNameOfClass(SourceAddress.class) // Additional parameter
+        .processCommandLine(args);
+
+    if (commandLine == null) {  // Option '?' was entered and processCommandLine printed the help.
+      return;
     }
 
-    if (cl.hasOption("d")) {
-      final String[] driverAddr = cl.getOptionValue("d", "localhost:20332").split(":");
-      driverHost = driverAddr[0];
-      driverPort = Integer.parseInt(driverAddr[1]);
-    }
-
-    if (cl.hasOption("s")) {
-      final String[] sourceAddr = cl.getOptionValue("s", "localhost:20331").split(":");
-      sourceHost = sourceAddr[0];
-      sourcePort = Integer.parseInt(sourceAddr[1]);
-    }
-
-    Thread sinkServer = new Thread(new SinkServer(SINK_PORT));
+    Thread sinkServer = new Thread(MISTExampleUtils.getSinkServer());
     sinkServer.start();
 
-    final APIQuerySubmissionResult result = submitQuery();
+    final APIQuerySubmissionResult result = submitQuery(jcb.build());
     System.out.println("Query submission result: " + result.getQueryId());
   }
 

--- a/src/main/java/edu/snu/mist/examples/parameters/DriverAddress.java
+++ b/src/main/java/edu/snu/mist/examples/parameters/DriverAddress.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.snu.mist.examples.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * Parameter for driver socket configuration.
+ */
+@NamedParameter(doc = "TCP socket of running MIST driver", short_name = "d", default_value = "localhost:20332")
+public final class DriverAddress implements Name<String> {
+}

--- a/src/main/java/edu/snu/mist/examples/parameters/SourceAddress.java
+++ b/src/main/java/edu/snu/mist/examples/parameters/SourceAddress.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.snu.mist.examples.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * Parameter for source socket configuration.
+ */
+@NamedParameter(doc = "TCP socket of source", short_name = "s", default_value = "localhost:20331")
+public final class SourceAddress implements Name<String> {
+}

--- a/src/main/java/edu/snu/mist/examples/parameters/UnionLeftSourceAddress.java
+++ b/src/main/java/edu/snu/mist/examples/parameters/UnionLeftSourceAddress.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.snu.mist.examples.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * Parameter for socket configuration for left source of union.
+ */
+@NamedParameter(doc = "TCP socket of left source of union", short_name = "s1", default_value = "localhost:20328")
+public final class UnionLeftSourceAddress implements Name<String> {
+}

--- a/src/main/java/edu/snu/mist/examples/parameters/UnionRightSourceAddress.java
+++ b/src/main/java/edu/snu/mist/examples/parameters/UnionRightSourceAddress.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.snu.mist.examples.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * Parameter for socket configuration for right source of union.
+ */
+@NamedParameter(doc = "TCP socket of right source of union", short_name = "s2", default_value = "localhost:20329")
+public final class UnionRightSourceAddress implements Name<String> {
+}

--- a/src/main/java/edu/snu/mist/examples/parameters/package-info.java
+++ b/src/main/java/edu/snu/mist/examples/parameters/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Parameter names for MIST examples.
+ */
+package edu.snu.mist.examples.parameters;


### PR DESCRIPTION
### What this PR does
- Introduces `MISTExampleUtils`; it contains common code for MIST examples.
- Revamps existing examples to utilize `MISTExampleUtils` (#247)
- Removes surflous `if (cl.hasOption(...))` to fix bug that examples cannot apply default value when option was not given by user.
### Possible Improvements
- ~~class `MISTExample` consists of lots of `protected static` methods and MIST examples should extend this class to utilize it. Maybe we'd better change methods to `public static` to avoid inheritance.~~ &rarr; adopted. see 5b07303
