### PR TITLE
[MIST-169] API: Define initialize function in ApplyStatefulOperatorStream

### DIFF
--- a/src/main/java/edu/snu/mist/api/ContinuousStream.java
+++ b/src/main/java/edu/snu/mist/api/ContinuousStream.java
@@ -19,6 +19,7 @@ import edu.snu.mist.api.exceptions.StreamTypeMismatchException;
 import edu.snu.mist.api.functions.MISTBiFunction;
 import edu.snu.mist.api.functions.MISTFunction;
 import edu.snu.mist.api.functions.MISTPredicate;
+import edu.snu.mist.api.functions.MISTSupplier;
 import edu.snu.mist.api.operators.*;
 import edu.snu.mist.api.sink.Sink;
 import edu.snu.mist.api.sink.builder.TextSocketSinkConfiguration;
@@ -77,12 +78,14 @@ public interface ContinuousStream<T> extends MISTStream<T> {
    * This stream will produce outputs on every stream input.
    * @param updateStateFunc the function which produces new state with the current state and the input
    * @param produceResultFunc the function which produces result with the updated state and the input
+   * @param initializeStateSup the supplier which generates the initial state
    * @param <S> the type of the operator state
    * @param <OUT> the type of stream output
    * @return new transformed stream after applying the user-defined stateful operation
    */
   <S, OUT> ApplyStatefulOperatorStream<T, OUT, S> applyStateful(MISTBiFunction<T, S, S> updateStateFunc,
-                                                                MISTFunction<S, OUT> produceResultFunc);
+                                                                MISTFunction<S, OUT> produceResultFunc,
+                                                                MISTSupplier<S> initializeStateSup);
 
   /**
    * Applies union operation to the current stream and input continuous stream passed as a parameter.

--- a/src/main/java/edu/snu/mist/api/ContinuousStreamImpl.java
+++ b/src/main/java/edu/snu/mist/api/ContinuousStreamImpl.java
@@ -20,6 +20,7 @@ import edu.snu.mist.api.exceptions.StreamTypeMismatchException;
 import edu.snu.mist.api.functions.MISTBiFunction;
 import edu.snu.mist.api.functions.MISTFunction;
 import edu.snu.mist.api.functions.MISTPredicate;
+import edu.snu.mist.api.functions.MISTSupplier;
 import edu.snu.mist.api.operators.*;
 import edu.snu.mist.api.sink.Sink;
 import edu.snu.mist.api.sink.TextSocketSink;
@@ -90,9 +91,10 @@ public abstract class ContinuousStreamImpl<T> extends MISTStreamImpl<T> implemen
   @Override
   public <S, OUT> ApplyStatefulOperatorStream<T, OUT, S> applyStateful(
       final MISTBiFunction<T, S, S> updateStateFunc,
-      final MISTFunction<S, OUT> produceResultFunc) {
+      final MISTFunction<S, OUT> produceResultFunc,
+      final MISTSupplier<S> initializeState) {
     final ApplyStatefulOperatorStream<T, OUT, S> downStream =
-        new ApplyStatefulOperatorStream<>(updateStateFunc, produceResultFunc, dag);
+        new ApplyStatefulOperatorStream<>(updateStateFunc, produceResultFunc, initializeState, dag);
     dag.addVertex(downStream);
     dag.addEdge(this, downStream, StreamType.Direction.LEFT);
     return downStream;

--- a/src/test/java/edu/snu/mist/api/MISTQueryTest.java
+++ b/src/test/java/edu/snu/mist/api/MISTQueryTest.java
@@ -99,7 +99,7 @@ public final class MISTQueryTest {
     final Map<CharSequence, Object> watermarkConfiguration = sourceInfo.getWatermarkConfiguration();
     final ByteBuffer extractionFunc = (ByteBuffer) sourceConfiguration.get(
         TextSocketSourceParameters.TIMESTAMP_EXTRACTION_FUNCTION);
-    byte[] serializedExtractionFunc = new byte[extractionFunc.remaining()];
+    final byte[] serializedExtractionFunc = new byte[extractionFunc.remaining()];
     extractionFunc.get(serializedExtractionFunc);
     final Function deserializedExtractionFunc =
         (Function) SerializationUtils.deserialize(serializedExtractionFunc);
@@ -114,13 +114,13 @@ public final class MISTQueryTest {
         deserializedExtractionFunc.apply("HelloMIST:1234"));
     final ByteBuffer parsingFunc = (ByteBuffer) watermarkConfiguration.get(
         PunctuatedWatermarkParameters.PARSING_TIMESTAMP_FROM_WATERMARK);
-    byte[] serializedParsingFunc = new byte[parsingFunc.remaining()];
+    final byte[] serializedParsingFunc = new byte[parsingFunc.remaining()];
     parsingFunc.get(serializedParsingFunc);
     final Function deserializedParsingFunc =
         (Function) SerializationUtils.deserialize(serializedParsingFunc);
     final ByteBuffer watermarkPred = (ByteBuffer) watermarkConfiguration.get(
         PunctuatedWatermarkParameters.WATERMARK_PREDICATE);
-    byte[] serializedWatermarkPred = new byte[watermarkPred.remaining()];
+    final byte[] serializedWatermarkPred = new byte[watermarkPred.remaining()];
     watermarkPred.get(serializedWatermarkPred);
     final Predicate deserializedWatermarkPred =
         (Predicate) SerializationUtils.deserialize(serializedWatermarkPred);
@@ -147,15 +147,15 @@ public final class MISTQueryTest {
     final InstantOperatorInfo aggregateWindowInfo = (InstantOperatorInfo) vertex.getAttributes();
     final List<ByteBuffer> aggregateWindowFunctions = aggregateWindowInfo.getFunctions();
 
-    byte[] serializedUpdateStateFunc = new byte[aggregateWindowFunctions.get(0).remaining()];
+    final byte[] serializedUpdateStateFunc = new byte[aggregateWindowFunctions.get(0).remaining()];
     aggregateWindowFunctions.get(0).get(serializedUpdateStateFunc);
     final BiFunction deserializedUpdateStateFunc =
         (BiFunction) SerializationUtils.deserialize(serializedUpdateStateFunc);
-    byte[] serializedProduceResultFunc = new byte[aggregateWindowFunctions.get(1).remaining()];
+    final byte[] serializedProduceResultFunc = new byte[aggregateWindowFunctions.get(1).remaining()];
     aggregateWindowFunctions.get(1).get(serializedProduceResultFunc);
     final Function deserializedProduceResultFunc =
         (Function) SerializationUtils.deserialize(serializedProduceResultFunc);
-    byte[] serializedInitializeStateSup = new byte[aggregateWindowFunctions.get(2).remaining()];
+    final byte[] serializedInitializeStateSup = new byte[aggregateWindowFunctions.get(2).remaining()];
     aggregateWindowFunctions.get(2).get(serializedInitializeStateSup);
     final Supplier deserializedInitializeStateSup =
         (Supplier) SerializationUtils.deserialize(serializedInitializeStateSup);
@@ -170,7 +170,7 @@ public final class MISTQueryTest {
   }
 
   /**
-   * This method tests a serialization of a complex query, containing 7 vertices.
+   * This method tests a serialization of a complex query, containing 9 vertices.
    * @throws InjectionException
    */
   @Test
@@ -212,7 +212,7 @@ public final class MISTQueryTest {
         final List<ByteBuffer> flatMapInfoFunctions = flatMapInfo.getFunctions();
         final Integer flatMapInfoKeyIndex = flatMapInfo.getKeyIndex();
 
-        byte[] serializedFlatMapFunc = new byte[flatMapInfoFunctions.get(0).remaining()];
+        final byte[] serializedFlatMapFunc = new byte[flatMapInfoFunctions.get(0).remaining()];
         flatMapInfoFunctions.get(0).get(serializedFlatMapFunc);
         final Function flatMapFunc =
             (Function) SerializationUtils.deserialize(serializedFlatMapFunc);
@@ -225,7 +225,7 @@ public final class MISTQueryTest {
         final List<ByteBuffer> filterInfoFunctions = filterInfo.getFunctions();
         final Integer filterKeyIndex = filterInfo.getKeyIndex();
 
-        byte[] serializedFilterPredicate = new byte[filterInfoFunctions.get(0).remaining()];
+        final byte[] serializedFilterPredicate = new byte[filterInfoFunctions.get(0).remaining()];
         filterInfoFunctions.get(0).get(serializedFilterPredicate);
         final Predicate filterPredicate =
             (Predicate) SerializationUtils.deserialize(serializedFilterPredicate);
@@ -239,7 +239,7 @@ public final class MISTQueryTest {
         final List<ByteBuffer> mapInfoFunctions = mapInfo.getFunctions();
         final Integer mapKeyIndex = mapInfo.getKeyIndex();
 
-        byte[] serializedMapFunc = new byte[mapInfoFunctions.get(0).remaining()];
+        final byte[] serializedMapFunc = new byte[mapInfoFunctions.get(0).remaining()];
         mapInfoFunctions.get(0).get(serializedMapFunc);
         final Function mapFunc =
             (Function) SerializationUtils.deserialize(serializedMapFunc);
@@ -260,7 +260,7 @@ public final class MISTQueryTest {
         final List<ByteBuffer> reduceByKeyFunctions = reduceByKeyInfo.getFunctions();
         final Integer reduceByKeyIndex = reduceByKeyInfo.getKeyIndex();
 
-        byte[] serializedReduceFunc = new byte[reduceByKeyFunctions.get(0).remaining()];
+        final byte[] serializedReduceFunc = new byte[reduceByKeyFunctions.get(0).remaining()];
         reduceByKeyFunctions.get(0).get(serializedReduceFunc);
         final BiFunction reduceFunc =
             (BiFunction) SerializationUtils.deserialize(serializedReduceFunc);

--- a/src/test/java/edu/snu/mist/api/operators/InstantOperatorStreamTest.java
+++ b/src/test/java/edu/snu/mist/api/operators/InstantOperatorStreamTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * The test class for operator APIs.
@@ -109,7 +110,7 @@ public final class InstantOperatorStreamTest {
       } else {
         return s;
       }
-    }, s -> s);
+    }, s -> s, () -> 0);
 
     Assert.assertEquals(statefulOperatorStream.getBasicType(), StreamType.BasicType.CONTINUOUS);
     Assert.assertEquals(statefulOperatorStream.getContinuousType(), StreamType.ContinuousType.OPERATOR);
@@ -119,9 +120,11 @@ public final class InstantOperatorStreamTest {
         statefulOperatorStream.getUpdateStateFunc();
     final Function<Integer, Integer> produceResultFunc =
         statefulOperatorStream.getProduceResultFunc();
+    final Supplier<Integer> initializeStateSup =
+        statefulOperatorStream.getInitializeStateSup();
 
     /* Simulate two data inputs on UDF stream */
-    final int initialState = 0;
+    final int initialState = initializeStateSup.get();
     final Tuple2 firstInput = new Tuple2<>("ABC", 1);
     final Tuple2 secondInput = new Tuple2<>("BAC", 1);
     final int firstState = stateUpdateFunc.apply(firstInput, initialState);
@@ -129,6 +132,7 @@ public final class InstantOperatorStreamTest {
     final int secondState = stateUpdateFunc.apply(secondInput, firstState);
     final int secondResult = produceResultFunc.apply(secondState);
 
+    Assert.assertEquals(0, initialState);
     Assert.assertEquals(1, firstState);
     Assert.assertEquals(1, firstResult);
     Assert.assertEquals(1, secondState);

--- a/src/test/java/edu/snu/mist/api/serialize/OperatorSerializeTest.java
+++ b/src/test/java/edu/snu/mist/api/serialize/OperatorSerializeTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.api.serialize;
+
+import edu.snu.mist.api.AvroVertexSerializable;
+import edu.snu.mist.api.StreamType;
+import edu.snu.mist.api.functions.MISTBiFunction;
+import edu.snu.mist.api.functions.MISTFunction;
+import edu.snu.mist.api.functions.MISTSupplier;
+import edu.snu.mist.api.operators.ApplyStatefulOperatorStream;
+import edu.snu.mist.common.DAG;
+import edu.snu.mist.formats.avro.InstantOperatorInfo;
+import edu.snu.mist.formats.avro.Vertex;
+import edu.snu.mist.formats.avro.VertexTypeEnum;
+import org.apache.commons.lang.SerializationUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * This is the test class for serializing operators into avro vertex.
+ */
+public class OperatorSerializeTest {
+  private final MISTBiFunction<String, Integer, Integer> expectedUpdateStateFunc =
+      (input, state) -> {
+        if (Integer.parseInt(input) > state) {
+          return Integer.parseInt(input);
+        } else {
+          return state;
+        }
+      };
+  private final MISTFunction<Integer, String> expectedProduceResultFunc = state -> state.toString();
+  private final MISTSupplier<Integer> expectedInitializeStateSup = () -> Integer.MIN_VALUE;
+
+  /**
+   * This method tests a serialization of ApplyStatefulOperator.
+   */
+  @Test
+  public void applyStatefulSerializationTest() {
+    final DAG<AvroVertexSerializable, StreamType.Direction> mockDag = mock(DAG.class);
+    final ApplyStatefulOperatorStream statefulOpStream = new ApplyStatefulOperatorStream<>(
+        expectedUpdateStateFunc, expectedProduceResultFunc, expectedInitializeStateSup, mockDag);
+    final Vertex serializedVertex = statefulOpStream.getSerializedVertex();
+
+    // Test whether the vertex is created properly or not.
+    Assert.assertEquals(serializedVertex.getVertexType(), VertexTypeEnum.INSTANT_OPERATOR);
+    final InstantOperatorInfo statefulOpInfo = (InstantOperatorInfo) serializedVertex.getAttributes();
+    final List<ByteBuffer> statefulOpFunctions = statefulOpInfo.getFunctions();
+
+    final byte[] serializedUpdateStateFunc = new byte[statefulOpFunctions.get(0).remaining()];
+    statefulOpFunctions.get(0).get(serializedUpdateStateFunc);
+    final BiFunction deserializedUpdateStateFunc =
+        (BiFunction) SerializationUtils.deserialize(serializedUpdateStateFunc);
+    final byte[] serializedProduceResultFunc = new byte[statefulOpFunctions.get(1).remaining()];
+    statefulOpFunctions.get(1).get(serializedProduceResultFunc);
+    final Function deserializedProduceResultFunc =
+        (Function) SerializationUtils.deserialize(serializedProduceResultFunc);
+    final byte[] serializedInitializeStateSup = new byte[statefulOpFunctions.get(2).remaining()];
+    statefulOpFunctions.get(2).get(serializedInitializeStateSup);
+    final Supplier deserializedInitializeStateSup =
+        (Supplier) SerializationUtils.deserialize(serializedInitializeStateSup);
+
+    Assert.assertEquals(expectedInitializeStateSup.get(), deserializedInitializeStateSup.get());
+    Assert.assertEquals(expectedUpdateStateFunc.apply("10", 5), deserializedUpdateStateFunc.apply("10", 5));
+    Assert.assertEquals(expectedUpdateStateFunc.apply("10", 15), deserializedUpdateStateFunc.apply("10", 15));
+    Assert.assertEquals(expectedProduceResultFunc.apply(15), deserializedProduceResultFunc.apply(15));
+    Assert.assertNotEquals(expectedProduceResultFunc.apply(15), deserializedProduceResultFunc.apply(10));
+  }
+}


### PR DESCRIPTION
This PR addressed the issue #169 by
- adding `Supplier` called `initializeStateSup` into `ApplyStatefulOperatorStream` api
- adding serialization test for it

Closes #169
