### PR TITLE
[MIST-323] Implement api for join operators

### DIFF
--- a/src/main/avro/client_to_task_msg.avpr
+++ b/src/main/avro/client_to_task_msg.avpr
@@ -178,8 +178,16 @@
                                     "type": "enum",
                                       "symbols":
                                       [
-                                        "TIME", "COUNT", "SESSION"
+                                        "TIME", "COUNT", "SESSION", "JOIN"
                                       ]
+                                  }
+                                },
+                                {
+                                  "name": "Functions",
+                                  "type":
+                                  {
+                                    "type": "array",
+                                    "items": "bytes"
                                   }
                                 },
                                 {

--- a/src/main/avro/physical_plan.avsc
+++ b/src/main/avro/physical_plan.avsc
@@ -173,8 +173,16 @@
                               "type": "enum",
                                 "symbols":
                                 [
-                                  "TIME", "COUNT", "SESSION"
+                                  "TIME", "COUNT", "SESSION", "JOIN"
                                 ]
+                            }
+                          },
+                          {
+                            "name": "Functions",
+                            "type":
+                            {
+                              "type": "array",
+                              "items": "bytes"
                             }
                           },
                           {

--- a/src/main/java/edu/snu/mist/api/ContinuousStream.java
+++ b/src/main/java/edu/snu/mist/api/ContinuousStream.java
@@ -16,13 +16,11 @@
 package edu.snu.mist.api;
 
 import edu.snu.mist.api.exceptions.StreamTypeMismatchException;
-import edu.snu.mist.api.functions.MISTBiFunction;
-import edu.snu.mist.api.functions.MISTFunction;
-import edu.snu.mist.api.functions.MISTPredicate;
-import edu.snu.mist.api.functions.MISTSupplier;
+import edu.snu.mist.api.functions.*;
 import edu.snu.mist.api.operators.*;
 import edu.snu.mist.api.sink.Sink;
 import edu.snu.mist.api.sink.builder.TextSocketSinkConfiguration;
+import edu.snu.mist.api.windows.WindowInformation;
 
 import java.util.List;
 
@@ -91,23 +89,27 @@ public interface ContinuousStream<T> extends MISTStream<T> {
    * @param inputStream the stream to be unified with this stream
    * @return new unified stream after applying type-checking
    */
-  UnionOperatorStream<T> union(final ContinuousStream<T> inputStream) throws StreamTypeMismatchException;
+  UnionOperatorStream<T> union(ContinuousStream<T> inputStream) throws StreamTypeMismatchException;
 
   /**
-   * Creates a new time-based WindowsStream according to the size and emission interval of window.
-   * @param windowSize The option decides the size of the window expressed in milliseconds
-   * @param windowEmissionInterval The option decides when to emit windowed stream expressed in milliseconds
-   * @return new windowed stream after applying the time-based windowing operation
+   * Creates a new WindowsStream according to the WindowInformation.
+   * @param windowInfo the WindowInformation contains some information used during windowing operation
+   * @return new windowed stream after applying the windowing operation
    */
-  TimeWindowOperatorStream<T> timeWindow(int windowSize, int windowEmissionInterval);
+  WindowOperatorStream<T> window(WindowInformation windowInfo);
 
   /**
-   * Creates a new count-based WindowsStream according to the size and emission interval of window.
-   * @param windowSize The option decides the size of the window expressed in the number of inputs
-   * @param windowEmissionInterval The option decides when to emit windowed stream expressed in the number of inputs
-   * @return new windowed stream after applying the count-based windowing operation
+   * Joins current stream with the input stream.
+   * Two streams are windowed according to the WindowInfo and joined within the window.
+   * @param inputStream the stream to be joined with this stream
+   * @param joinBiPredicate the function that decides to join a pair of inputs in two streams
+   * @param windowInfo the windowing information for joining two streams
+   * @param <U> the data type of the input stream to be joined with this stream
+   * @return new windowed and joined stream
    */
-  CountWindowOperatorStream<T> countWindow(int windowSize, int windowEmissionInterval);
+  <U> JoinOperatorStream<T, U> join(ContinuousStream<U> inputStream,
+                                    MISTBiPredicate<T, U> joinBiPredicate,
+                                    WindowInformation windowInfo);
 
   /**
    * Defines a text socket output Sink for the current stream according to the TextSocketSinkConfiguration.

--- a/src/main/java/edu/snu/mist/api/StreamType.java
+++ b/src/main/java/edu/snu/mist/api/StreamType.java
@@ -53,7 +53,7 @@ public final class StreamType {
    * The type of operator stream.
    */
   public static enum OperatorType {FILTER, FLAT_MAP, MAP, REDUCE_BY_KEY, REDUCE_BY_KEY_WINDOW,
-    APPLY_STATEFUL, APPLY_STATEFUL_WINDOW, UNION, AGGREGATE_WINDOW, TIME_WINDOW, COUNT_WINDOW}
+    APPLY_STATEFUL, APPLY_STATEFUL_WINDOW, UNION, AGGREGATE_WINDOW, TIME_WINDOW, COUNT_WINDOW, JOIN}
 
   /**
    * The type of stream direction. Union operator should get two streams: LEFT/RIGHT.

--- a/src/main/java/edu/snu/mist/api/functions/MISTBiPredicate.java
+++ b/src/main/java/edu/snu/mist/api/functions/MISTBiPredicate.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.api.functions;
+
+import java.io.Serializable;
+import java.util.function.BiPredicate;
+
+/**
+ * A Java 8 lambda BiPredicate-compatible interface used in MIST API.
+ */
+public interface MISTBiPredicate<T, U> extends BiPredicate<T, U>, Serializable {
+}

--- a/src/main/java/edu/snu/mist/api/operators/AggregateWindowOperatorStream.java
+++ b/src/main/java/edu/snu/mist/api/operators/AggregateWindowOperatorStream.java
@@ -18,7 +18,7 @@ package edu.snu.mist.api.operators;
 import edu.snu.mist.api.AvroVertexSerializable;
 import edu.snu.mist.api.StreamType;
 import edu.snu.mist.api.functions.MISTFunction;
-import edu.snu.mist.api.WindowData;
+import edu.snu.mist.api.windows.WindowData;
 import edu.snu.mist.common.DAG;
 import edu.snu.mist.formats.avro.InstantOperatorInfo;
 import edu.snu.mist.formats.avro.InstantOperatorTypeEnum;

--- a/src/main/java/edu/snu/mist/api/operators/ApplyStatefulWindowOperatorStream.java
+++ b/src/main/java/edu/snu/mist/api/operators/ApplyStatefulWindowOperatorStream.java
@@ -20,7 +20,7 @@ import edu.snu.mist.api.StreamType;
 import edu.snu.mist.api.functions.MISTBiFunction;
 import edu.snu.mist.api.functions.MISTFunction;
 import edu.snu.mist.api.functions.MISTSupplier;
-import edu.snu.mist.api.WindowData;
+import edu.snu.mist.api.windows.WindowData;
 import edu.snu.mist.common.DAG;
 import edu.snu.mist.formats.avro.InstantOperatorInfo;
 import edu.snu.mist.formats.avro.InstantOperatorTypeEnum;

--- a/src/main/java/edu/snu/mist/api/operators/JoinOperatorStream.java
+++ b/src/main/java/edu/snu/mist/api/operators/JoinOperatorStream.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.api.operators;
+
+import edu.snu.mist.api.AvroVertexSerializable;
+import edu.snu.mist.api.StreamType;
+import edu.snu.mist.api.windows.WindowedStreamImpl;
+import edu.snu.mist.api.functions.MISTBiPredicate;
+import edu.snu.mist.api.types.Tuple2;
+import edu.snu.mist.common.DAG;
+import edu.snu.mist.formats.avro.WindowOperatorInfo;
+import edu.snu.mist.formats.avro.WindowOperatorTypeEnum;
+import org.apache.commons.lang.SerializationUtils;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class describes a join operator stream which gets windowed and unified stream, and
+ * joins a pair of inputs in two streams that satisfies the user-defined predicate maintaining the window.
+ * @param <T> the type of first input DataStream
+ * @param <U> the type of second input DataStream
+ */
+public final class JoinOperatorStream<T, U> extends WindowedStreamImpl<Tuple2<T, U>> {
+
+  /**
+   * The user-defined predicate which checks whether two inputs from both stream are matched or not.
+   */
+  private final MISTBiPredicate<T, U> joinBiPredicate;
+
+  public JoinOperatorStream(final MISTBiPredicate<T, U> joinBiPredicate,
+                            final DAG<AvroVertexSerializable, StreamType.Direction> dag) {
+    super(StreamType.OperatorType.JOIN, dag);
+    this.joinBiPredicate = joinBiPredicate;
+  }
+
+  /**
+   * @return The user-defined predicate to check whether two inputs from both stream are matched or not.
+   */
+  public MISTBiPredicate<T, U> getJoinBiPredicate() {
+    return joinBiPredicate;
+  }
+
+  @Override
+  protected WindowOperatorInfo getWindowOpInfo() {
+    final WindowOperatorInfo.Builder wOpInfoBuilder = WindowOperatorInfo.newBuilder();
+    wOpInfoBuilder.setWindowOperatorType(WindowOperatorTypeEnum.JOIN);
+    final List<ByteBuffer> serializedFunctionList = new ArrayList<>();
+    serializedFunctionList.add(ByteBuffer.wrap(SerializationUtils.serialize(joinBiPredicate)));
+    wOpInfoBuilder.setFunctions(serializedFunctionList);
+    wOpInfoBuilder.setWindowSize(0);
+    wOpInfoBuilder.setWindowEmissionInterval(0);
+    return wOpInfoBuilder.build();
+  }
+}

--- a/src/main/java/edu/snu/mist/api/operators/ReduceByKeyWindowOperatorStream.java
+++ b/src/main/java/edu/snu/mist/api/operators/ReduceByKeyWindowOperatorStream.java
@@ -18,7 +18,7 @@ package edu.snu.mist.api.operators;
 import edu.snu.mist.api.AvroVertexSerializable;
 import edu.snu.mist.api.StreamType;
 import edu.snu.mist.api.functions.MISTBiFunction;
-import edu.snu.mist.api.WindowData;
+import edu.snu.mist.api.windows.WindowData;
 import edu.snu.mist.common.DAG;
 import edu.snu.mist.formats.avro.InstantOperatorTypeEnum;
 

--- a/src/main/java/edu/snu/mist/api/operators/WindowOperatorStream.java
+++ b/src/main/java/edu/snu/mist/api/operators/WindowOperatorStream.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.api.operators;
+
+import edu.snu.mist.api.AvroVertexSerializable;
+import edu.snu.mist.api.StreamType;
+import edu.snu.mist.api.windows.WindowInformation;
+import edu.snu.mist.api.windows.WindowedStreamImpl;
+import edu.snu.mist.common.DAG;
+import edu.snu.mist.formats.avro.WindowOperatorInfo;
+
+/**
+ * This class describes WindowedStream that conducts windowing operation according to WindowInformation.
+ */
+public final class WindowOperatorStream<T> extends WindowedStreamImpl<T> {
+
+  /**
+   * The window information for this window operator stream.
+   */
+  private WindowInformation windowInfo;
+
+  public WindowOperatorStream(final WindowInformation windowInfo,
+                              final DAG<AvroVertexSerializable, StreamType.Direction> dag) {
+    super(windowInfo.getWindowOpType(), dag);
+    this.windowInfo = windowInfo;
+  }
+
+  /**
+   * @return the window information
+   */
+  public WindowInformation getWindowInfo() {
+    return windowInfo;
+  }
+
+  @Override
+  protected WindowOperatorInfo getWindowOpInfo() {
+    return windowInfo.getSerializedWindowOpInfo();
+  }
+}

--- a/src/main/java/edu/snu/mist/api/windows/CountWindowInformation.java
+++ b/src/main/java/edu/snu/mist/api/windows/CountWindowInformation.java
@@ -13,26 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.mist.api.operators;
+package edu.snu.mist.api.windows;
 
-import edu.snu.mist.api.AvroVertexSerializable;
 import edu.snu.mist.api.StreamType;
-import edu.snu.mist.common.DAG;
 import edu.snu.mist.formats.avro.WindowOperatorTypeEnum;
 
 /**
- * This class describes the count-based part of FixedSizeWindowOperatorStream.
+ * This class represents count-based FixedSizeWindowInformation.
  */
-public final class CountWindowOperatorStream<T> extends FixedSizeWindowOperatorStream<T> {
+public final class CountWindowInformation extends FixedSizeWindowInformation {
 
-  public CountWindowOperatorStream(final int windowSize,
-                                   final int windowEmissionInterval,
-                                   final DAG<AvroVertexSerializable, StreamType.Direction> dag) {
-    super(windowSize, windowEmissionInterval, StreamType.OperatorType.COUNT_WINDOW, dag);
+  public CountWindowInformation(final int windowSize,
+                                final int windowEmissionInterval) {
+    super(windowSize, windowEmissionInterval);
   }
 
   @Override
   protected WindowOperatorTypeEnum getWindowOpTypeEnum() {
     return WindowOperatorTypeEnum.COUNT;
+  }
+
+  @Override
+  public StreamType.OperatorType getWindowOpType() {
+    return StreamType.OperatorType.COUNT_WINDOW;
   }
 }

--- a/src/main/java/edu/snu/mist/api/windows/TimeWindowInformation.java
+++ b/src/main/java/edu/snu/mist/api/windows/TimeWindowInformation.java
@@ -13,26 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.mist.api.operators;
+package edu.snu.mist.api.windows;
 
-import edu.snu.mist.api.AvroVertexSerializable;
 import edu.snu.mist.api.StreamType;
-import edu.snu.mist.common.DAG;
 import edu.snu.mist.formats.avro.WindowOperatorTypeEnum;
 
 /**
- * This class describes the time-based part of FixedSizeWindowOperatorStream.
+ * This class represents time-based FixedSizeWindowInformation.
  */
-public final class TimeWindowOperatorStream<T> extends FixedSizeWindowOperatorStream<T> {
+public final class TimeWindowInformation extends FixedSizeWindowInformation {
 
-  public TimeWindowOperatorStream(final int windowSize,
-                                  final int windowEmissionInterval,
-                                  final DAG<AvroVertexSerializable, StreamType.Direction> dag) {
-    super(windowSize, windowEmissionInterval, StreamType.OperatorType.TIME_WINDOW, dag);
+  public TimeWindowInformation(final int windowSize,
+                               final int windowEmissionInterval) {
+    super(windowSize, windowEmissionInterval);
   }
 
   @Override
   protected WindowOperatorTypeEnum getWindowOpTypeEnum() {
     return WindowOperatorTypeEnum.TIME;
+  }
+
+  @Override
+  public StreamType.OperatorType getWindowOpType() {
+    return StreamType.OperatorType.TIME_WINDOW;
   }
 }

--- a/src/main/java/edu/snu/mist/api/windows/WindowData.java
+++ b/src/main/java/edu/snu/mist/api/windows/WindowData.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.api.windows;
+
+import java.util.Collection;
+
+/**
+ * This interface represents the result data of windowing operation.
+ * It contains the result data collection, start and end information.
+ * The start and end may represent time or count.
+ * @param <T> the type of data in this window
+ */
+public interface WindowData<T> {
+
+  /**
+   * @return the result data collection of window
+   */
+  Collection<T> getDataCollection();
+
+  /**
+   * @return the start time or count
+   */
+  long getStart();
+
+  /**
+   * @return the end time or count
+   */
+  long getEnd();
+}

--- a/src/main/java/edu/snu/mist/api/windows/WindowInformation.java
+++ b/src/main/java/edu/snu/mist/api/windows/WindowInformation.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.api.windows;
+
+import edu.snu.mist.api.StreamType;
+import edu.snu.mist.formats.avro.WindowOperatorInfo;
+
+/**
+ * This interface represents an information container that has some information used during windowing operation.
+ * During windowed stream creation, this information class will be passed as a parameter.
+ */
+public interface WindowInformation {
+
+  /**
+   * @return the type of windowing operation in a form of StreamType.OperatorType.
+   */
+  StreamType.OperatorType getWindowOpType();
+
+  /**
+   * @return the serialized window operator information.
+   */
+  WindowOperatorInfo getSerializedWindowOpInfo();
+}

--- a/src/main/java/edu/snu/mist/api/windows/WindowedStream.java
+++ b/src/main/java/edu/snu/mist/api/windows/WindowedStream.java
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.mist.api;
+package edu.snu.mist.api.windows;
 
+import edu.snu.mist.api.MISTStream;
 import edu.snu.mist.api.functions.MISTBiFunction;
 import edu.snu.mist.api.functions.MISTFunction;
 import edu.snu.mist.api.functions.MISTSupplier;

--- a/src/main/java/edu/snu/mist/api/windows/WindowedStreamImpl.java
+++ b/src/main/java/edu/snu/mist/api/windows/WindowedStreamImpl.java
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.mist.api;
+package edu.snu.mist.api.windows;
 
+import edu.snu.mist.api.AvroVertexSerializable;
+import edu.snu.mist.api.MISTStreamImpl;
+import edu.snu.mist.api.StreamType;
 import edu.snu.mist.api.functions.MISTBiFunction;
 import edu.snu.mist.api.functions.MISTFunction;
 import edu.snu.mist.api.functions.MISTSupplier;
@@ -83,7 +86,7 @@ public abstract class WindowedStreamImpl<T> extends MISTStreamImpl<WindowData<T>
   }
 
   /**
-   * Get an instant operator info.
+   * @return the window operator info.
    */
   protected abstract WindowOperatorInfo getWindowOpInfo();
 

--- a/src/main/java/edu/snu/mist/api/windows/package-info.java
+++ b/src/main/java/edu/snu/mist/api/windows/package-info.java
@@ -13,30 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.mist.api;
-
-import java.util.Collection;
 
 /**
- * This interface represents the result data of windowing operation.
- * It contains the result data collection, start and end information.
- * The start and end may represent time or count.
- * @param <T> the type of data in this window
+ * A package for MIST API associated with windowing operation.
  */
-public interface WindowData<T> {
-
-  /**
-   * @return the result data collection of window
-   */
-  Collection<T> getDataCollection();
-
-  /**
-   * @return the start time or count
-   */
-  long getStart();
-
-  /**
-   * @return the end time or count
-   */
-  long getEnd();
-}
+package edu.snu.mist.api.windows;

--- a/src/main/java/edu/snu/mist/examples/WindowAndAggregate.java
+++ b/src/main/java/edu/snu/mist/examples/WindowAndAggregate.java
@@ -19,7 +19,8 @@ package edu.snu.mist.examples;
 import edu.snu.mist.api.APIQueryControlResult;
 import edu.snu.mist.api.MISTQuery;
 import edu.snu.mist.api.MISTQueryBuilder;
-import edu.snu.mist.api.WindowData;
+import edu.snu.mist.api.windows.TimeWindowInformation;
+import edu.snu.mist.api.windows.WindowData;
 import edu.snu.mist.api.functions.MISTFunction;
 import edu.snu.mist.api.sink.builder.TextSocketSinkConfiguration;
 import edu.snu.mist.api.sources.builder.TextSocketSourceConfiguration;
@@ -64,7 +65,7 @@ public final class WindowAndAggregate {
 
     final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
     queryBuilder.socketTextStream(localTextSocketSourceConf)
-        .timeWindow(windowSize, windowEmissionInterval)
+        .window(new TimeWindowInformation(windowSize, windowEmissionInterval))
         .aggregateWindow(aggregateFunc)
         .textSocketOutput(localTextSocketSinkConf);
     final MISTQuery query = queryBuilder.build();

--- a/src/main/java/edu/snu/mist/task/operators/AggregateWindowOperator.java
+++ b/src/main/java/edu/snu/mist/task/operators/AggregateWindowOperator.java
@@ -17,7 +17,7 @@ package edu.snu.mist.task.operators;
 
 import com.sun.corba.se.impl.io.TypeMismatchException;
 import edu.snu.mist.api.StreamType;
-import edu.snu.mist.api.WindowData;
+import edu.snu.mist.api.windows.WindowData;
 import edu.snu.mist.task.common.MistDataEvent;
 import edu.snu.mist.task.common.MistWatermarkEvent;
 

--- a/src/main/java/edu/snu/mist/task/operators/ApplyStatefulWindowOperator.java
+++ b/src/main/java/edu/snu/mist/task/operators/ApplyStatefulWindowOperator.java
@@ -17,7 +17,7 @@ package edu.snu.mist.task.operators;
 
 import com.sun.corba.se.impl.io.TypeMismatchException;
 import edu.snu.mist.api.StreamType;
-import edu.snu.mist.api.WindowData;
+import edu.snu.mist.api.windows.WindowData;
 import edu.snu.mist.task.common.MistDataEvent;
 import edu.snu.mist.task.common.MistWatermarkEvent;
 

--- a/src/main/java/edu/snu/mist/task/operators/FixedSizeWindowOperator.java
+++ b/src/main/java/edu/snu/mist/task/operators/FixedSizeWindowOperator.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.mist.task.operators;
 
-import edu.snu.mist.api.WindowData;
+import edu.snu.mist.api.windows.WindowData;
 import edu.snu.mist.task.common.MistDataEvent;
 import edu.snu.mist.task.common.MistWatermarkEvent;
 import edu.snu.mist.task.windows.Window;

--- a/src/main/java/edu/snu/mist/task/windows/Window.java
+++ b/src/main/java/edu/snu/mist/task/windows/Window.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.mist.task.windows;
 
-import edu.snu.mist.api.WindowData;
+import edu.snu.mist.api.windows.WindowData;
 import edu.snu.mist.task.common.MistDataEvent;
 import edu.snu.mist.task.common.MistWatermarkEvent;
 

--- a/src/test/java/edu/snu/mist/api/MISTQueryTest.java
+++ b/src/test/java/edu/snu/mist/api/MISTQueryTest.java
@@ -26,6 +26,7 @@ import edu.snu.mist.api.sources.builder.TextSocketSourceConfiguration;
 import edu.snu.mist.api.sources.parameters.PunctuatedWatermarkParameters;
 import edu.snu.mist.api.sources.parameters.TextSocketSourceParameters;
 import edu.snu.mist.api.types.Tuple2;
+import edu.snu.mist.api.windows.TimeWindowInformation;
 import edu.snu.mist.formats.avro.*;
 import org.apache.commons.lang.SerializationUtils;
 import org.apache.reef.io.Tuple;
@@ -174,9 +175,9 @@ public final class MISTQueryTest {
         .flatMap(expectedFlatMapFunc)
         .filter(expectedFilterPredicate)
         .map(expectedMapFunc)
-        .timeWindow(expectedWindowSize, expectedWindowEmissionInterval)
+        .window(new TimeWindowInformation(expectedWindowSize, expectedWindowEmissionInterval))
         .reduceByKeyWindow(0, String.class, expectedReduceFunc)
-        .timeWindow(expectedWindowSize, expectedWindowEmissionInterval)
+        .window(new TimeWindowInformation(expectedWindowSize, expectedWindowEmissionInterval))
         .applyStatefulWindow(expectedUpdateStateFunc, expectedProduceResultFunc, expectedInitializeStateSup)
         .textSocketOutput(textSocketSinkConf);
     final MISTQuery complexQuery = queryBuilder.build();

--- a/src/test/java/edu/snu/mist/task/operators/AggregateWindowOperatorTest.java
+++ b/src/test/java/edu/snu/mist/task/operators/AggregateWindowOperatorTest.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.mist.task.operators;
 
-import edu.snu.mist.api.WindowData;
+import edu.snu.mist.api.windows.WindowData;
 import edu.snu.mist.task.common.MistDataEvent;
 import edu.snu.mist.task.common.MistEvent;
 import edu.snu.mist.task.common.MistWatermarkEvent;

--- a/src/test/java/edu/snu/mist/task/operators/FixedSizeWindowOperatorTest.java
+++ b/src/test/java/edu/snu/mist/task/operators/FixedSizeWindowOperatorTest.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.mist.task.operators;
 
-import edu.snu.mist.api.WindowData;
+import edu.snu.mist.api.windows.WindowData;
 import edu.snu.mist.task.common.MistDataEvent;
 import edu.snu.mist.task.common.MistEvent;
 import edu.snu.mist.task.common.MistWatermarkEvent;


### PR DESCRIPTION
This PR addressed the issue #323  by
- implementing  `JoinStreamContainer` which contains the two input streams of join operation
- making user to apply window operation into the `JoinStreamContainer`, which would unify the two input streams as a `Tuple2` form, apply the window operation, and filter the unified streams with user-defined `MISTBiPredicate`
- implementing `join` function in `ContinuousStream` that generates `JoinStreamContainer`

Closes #323
