### PR TITLE
[MIST-328] Use BiConsumer instead of BiFunction in ApplyStatefulOperator

### DIFF
--- a/src/main/java/edu/snu/mist/api/ContinuousStream.java
+++ b/src/main/java/edu/snu/mist/api/ContinuousStream.java
@@ -72,14 +72,14 @@ public interface ContinuousStream<T> extends MISTStream<T> {
   /**
    * Applies user-defined stateful operator to the current stream.
    * This stream will produce outputs on every stream input.
-   * @param updateStateFunc the function which produces new state with the current state and the input
+   * @param updateStateCons the consumer that updates current state S with the data T
    * @param produceResultFunc the function which produces result with the updated state and the input
    * @param initializeStateSup the supplier which generates the initial state
    * @param <S> the type of the operator state
    * @param <OUT> the type of stream output
    * @return new transformed stream after applying the user-defined stateful operation
    */
-  <S, OUT> ApplyStatefulOperatorStream<T, OUT, S> applyStateful(MISTBiFunction<T, S, S> updateStateFunc,
+  <S, OUT> ApplyStatefulOperatorStream<T, OUT, S> applyStateful(MISTBiConsumer<T, OperatorState<S>> updateStateCons,
                                                                 MISTFunction<S, OUT> produceResultFunc,
                                                                 MISTSupplier<S> initializeStateSup);
 

--- a/src/main/java/edu/snu/mist/api/ContinuousStreamImpl.java
+++ b/src/main/java/edu/snu/mist/api/ContinuousStreamImpl.java
@@ -88,11 +88,11 @@ public abstract class ContinuousStreamImpl<T> extends MISTStreamImpl<T> implemen
 
   @Override
   public <S, OUT> ApplyStatefulOperatorStream<T, OUT, S> applyStateful(
-      final MISTBiFunction<T, S, S> updateStateFunc,
+      final MISTBiConsumer<T, OperatorState<S>> updateStateCons,
       final MISTFunction<S, OUT> produceResultFunc,
       final MISTSupplier<S> initializeStateSup) {
     final ApplyStatefulOperatorStream<T, OUT, S> downStream =
-        new ApplyStatefulOperatorStream<>(updateStateFunc, produceResultFunc, initializeStateSup, dag);
+        new ApplyStatefulOperatorStream<>(updateStateCons, produceResultFunc, initializeStateSup, dag);
     dag.addVertex(downStream);
     dag.addEdge(this, downStream, StreamType.Direction.LEFT);
     return downStream;

--- a/src/main/java/edu/snu/mist/api/OperatorState.java
+++ b/src/main/java/edu/snu/mist/api/OperatorState.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.api;
+
+/**
+ * This interface defines basic OperatorState used during stateful-operation.
+ * @param <S> the type of state that OperatorState class contains
+ */
+public interface OperatorState<S> {
+
+  /**
+   * @return the state
+   */
+  S get();
+
+  /**
+   * sets the state.
+   */
+  void set(S newState);
+}

--- a/src/main/java/edu/snu/mist/api/functions/MISTBiConsumer.java
+++ b/src/main/java/edu/snu/mist/api/functions/MISTBiConsumer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.api.functions;
+
+import java.io.Serializable;
+import java.util.function.BiConsumer;
+
+/**
+ * A Java 8 lambda BiConsumer-compatible interface used in MIST API.
+ */
+public interface MISTBiConsumer<T, U> extends BiConsumer<T, U>, Serializable {
+}

--- a/src/main/java/edu/snu/mist/api/operators/ApplyStatefulOperatorStream.java
+++ b/src/main/java/edu/snu/mist/api/operators/ApplyStatefulOperatorStream.java
@@ -16,8 +16,9 @@
 package edu.snu.mist.api.operators;
 
 import edu.snu.mist.api.AvroVertexSerializable;
+import edu.snu.mist.api.OperatorState;
 import edu.snu.mist.api.StreamType;
-import edu.snu.mist.api.functions.MISTBiFunction;
+import edu.snu.mist.api.functions.MISTBiConsumer;
 import edu.snu.mist.api.functions.MISTFunction;
 import edu.snu.mist.api.functions.MISTSupplier;
 import edu.snu.mist.common.DAG;
@@ -36,9 +37,10 @@ import java.util.List;
 public final class ApplyStatefulOperatorStream<IN, OUT, S> extends InstantOperatorStream<IN, OUT> {
 
   /**
-   * BiFunction used for updating the internal state.
+   * BiConsumer used for updating the internal state.
+   * To handle primitive type states, this consumer should consume a OperatorState instance as the state.
    */
-  private final MISTBiFunction<IN, S, S> updateStateFunc;
+  private final MISTBiConsumer<IN, OperatorState<S>> updateStateCons;
   /**
    * Function used for producing the result stream.
    */
@@ -48,21 +50,21 @@ public final class ApplyStatefulOperatorStream<IN, OUT, S> extends InstantOperat
    */
   private final MISTSupplier<S> initializeStateSup;
 
-  public ApplyStatefulOperatorStream(final MISTBiFunction<IN, S, S> updateStateFunc,
+  public ApplyStatefulOperatorStream(final MISTBiConsumer<IN, OperatorState<S>> updateStateCons,
                                      final MISTFunction<S, OUT> produceResultFunc,
                                      final MISTSupplier<S> initializeStateSup,
                                      final DAG<AvroVertexSerializable, StreamType.Direction> dag) {
     super(StreamType.OperatorType.APPLY_STATEFUL, dag);
-    this.updateStateFunc = updateStateFunc;
+    this.updateStateCons = updateStateCons;
     this.produceResultFunc = produceResultFunc;
     this.initializeStateSup = initializeStateSup;
   }
 
   /**
-   * @return the Function with two arguments used for updating its internal state
+   * @return the Consumer that updates the current state with the input data
    */
-  public MISTBiFunction<IN, S, S> getUpdateStateFunc() {
-    return updateStateFunc;
+  public MISTBiConsumer<IN, OperatorState<S>> getUpdateStateCons() {
+    return updateStateCons;
   }
 
   /**
@@ -84,7 +86,7 @@ public final class ApplyStatefulOperatorStream<IN, OUT, S> extends InstantOperat
     final InstantOperatorInfo.Builder iOpInfoBuilder = InstantOperatorInfo.newBuilder();
     iOpInfoBuilder.setInstantOperatorType(InstantOperatorTypeEnum.APPLY_STATEFUL);
     final List<ByteBuffer> serializedFunctionList = new ArrayList<>();
-    serializedFunctionList.add(ByteBuffer.wrap(SerializationUtils.serialize(updateStateFunc)));
+    serializedFunctionList.add(ByteBuffer.wrap(SerializationUtils.serialize(updateStateCons)));
     serializedFunctionList.add(ByteBuffer.wrap(SerializationUtils.serialize(produceResultFunc)));
     serializedFunctionList.add(ByteBuffer.wrap(SerializationUtils.serialize(initializeStateSup)));
     iOpInfoBuilder.setFunctions(serializedFunctionList);

--- a/src/main/java/edu/snu/mist/api/windows/WindowedStream.java
+++ b/src/main/java/edu/snu/mist/api/windows/WindowedStream.java
@@ -16,6 +16,8 @@
 package edu.snu.mist.api.windows;
 
 import edu.snu.mist.api.MISTStream;
+import edu.snu.mist.api.OperatorState;
+import edu.snu.mist.api.functions.MISTBiConsumer;
 import edu.snu.mist.api.functions.MISTBiFunction;
 import edu.snu.mist.api.functions.MISTFunction;
 import edu.snu.mist.api.functions.MISTSupplier;
@@ -50,7 +52,7 @@ public interface WindowedStream<T> extends MISTStream<WindowData<T>> {
 
   /**
    * It applies an user-defined stateful operation to the collection of data received from upstream window operator.
-   * @param updateStateFunc the function that updates temporal state in operator
+   * @param updateStateCons the consumer that updates temporal state S with the data T
    * @param produceResultFunc the function that produces result from temporal state
    * @param initializeStateSup the supplier that generates state of operation
    * @param <R> the type of result
@@ -58,6 +60,6 @@ public interface WindowedStream<T> extends MISTStream<WindowData<T>> {
    * @return new aggregated continuous stream after applying the aggregation function
    */
   <R, S> ApplyStatefulWindowOperatorStream<T, R, S> applyStatefulWindow(
-      MISTBiFunction<T, S, S> updateStateFunc, MISTFunction<S, R> produceResultFunc,
+      MISTBiConsumer<T, OperatorState<S>> updateStateCons, MISTFunction<S, R> produceResultFunc,
       MISTSupplier<S> initializeStateSup);
 }

--- a/src/main/java/edu/snu/mist/api/windows/WindowedStreamImpl.java
+++ b/src/main/java/edu/snu/mist/api/windows/WindowedStreamImpl.java
@@ -17,7 +17,9 @@ package edu.snu.mist.api.windows;
 
 import edu.snu.mist.api.AvroVertexSerializable;
 import edu.snu.mist.api.MISTStreamImpl;
+import edu.snu.mist.api.OperatorState;
 import edu.snu.mist.api.StreamType;
+import edu.snu.mist.api.functions.MISTBiConsumer;
 import edu.snu.mist.api.functions.MISTBiFunction;
 import edu.snu.mist.api.functions.MISTFunction;
 import edu.snu.mist.api.functions.MISTSupplier;
@@ -68,11 +70,11 @@ public abstract class WindowedStreamImpl<T> extends MISTStreamImpl<WindowData<T>
 
   @Override
   public <R, S> ApplyStatefulWindowOperatorStream<T, R, S> applyStatefulWindow(
-      final MISTBiFunction<T, S, S> updateStateFunc,
+      final MISTBiConsumer<T, OperatorState<S>> updateStateCons,
       final MISTFunction<S, R> produceResultFunc,
       final MISTSupplier<S> initializeStateSup) {
     final ApplyStatefulWindowOperatorStream<T, R, S> downStream =
-        new ApplyStatefulWindowOperatorStream<>(updateStateFunc, produceResultFunc, initializeStateSup, dag);
+        new ApplyStatefulWindowOperatorStream<>(updateStateCons, produceResultFunc, initializeStateSup, dag);
     dag.addVertex(downStream);
     dag.addEdge(this, downStream, StreamType.Direction.LEFT);
     return downStream;

--- a/src/main/java/edu/snu/mist/task/DefaultPhysicalPlanGeneratorImpl.java
+++ b/src/main/java/edu/snu/mist/task/DefaultPhysicalPlanGeneratorImpl.java
@@ -189,11 +189,11 @@ final class DefaultPhysicalPlanGeneratorImpl implements PhysicalPlanGenerator {
     final List<ByteBuffer> functionList = iOpInfo.getFunctions();
     switch (iOpInfo.getInstantOperatorType()) {
       case APPLY_STATEFUL: {
-        final BiFunction updateStateFunc = (BiFunction) deserializeLambda(functionList.get(0), classLoader);
+        final BiConsumer updateStateCons = (BiConsumer) deserializeLambda(functionList.get(0), classLoader);
         final Function produceResultFunc = (Function) deserializeLambda(functionList.get(1), classLoader);
         final Supplier initializeStateSup = (Supplier) deserializeLambda(functionList.get(2), classLoader);
         return new ApplyStatefulOperator<>(
-            queryId, operatorId, updateStateFunc, produceResultFunc, initializeStateSup);
+            queryId, operatorId, updateStateCons, produceResultFunc, initializeStateSup);
       }
       case FILTER: {
         final Predicate predicate = (Predicate) deserializeLambda(functionList.get(0), classLoader);
@@ -216,11 +216,11 @@ final class DefaultPhysicalPlanGeneratorImpl implements PhysicalPlanGenerator {
         throw new IllegalArgumentException("MISTTask: ReduceByKeyWindowOperator is currently not supported!");
       }
       case APPLY_STATEFUL_WINDOW: {
-        final BiFunction updateStateFunc = (BiFunction) deserializeLambda(functionList.get(0), classLoader);
+        final BiConsumer updateStateCons = (BiConsumer) deserializeLambda(functionList.get(0), classLoader);
         final Function produceResultFunc = (Function) deserializeLambda(functionList.get(1), classLoader);
         final Supplier initializeStateSup = (Supplier) deserializeLambda(functionList.get(2), classLoader);
         return new ApplyStatefulWindowOperator<>(
-            queryId, operatorId, updateStateFunc, produceResultFunc, initializeStateSup);
+            queryId, operatorId, updateStateCons, produceResultFunc, initializeStateSup);
       }
       case AGGREGATE_WINDOW: {
         final Function aggregateFunc = (Function) deserializeLambda(functionList.get(0), classLoader);

--- a/src/main/java/edu/snu/mist/task/OperatorStateImpl.java
+++ b/src/main/java/edu/snu/mist/task/OperatorStateImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.task;
+
+import edu.snu.mist.api.OperatorState;
+
+/**
+ * This class implements the OperatorState used during stateful-operation.
+ * @param <S> the type of state that OperatorState contains
+ */
+public final class OperatorStateImpl<S> implements OperatorState<S> {
+
+  private S state;
+
+  public OperatorStateImpl(final S state) {
+    this.state = state;
+  }
+
+  @Override
+  public S get() {
+    return state;
+  }
+
+  @Override
+  public void set(final S newState) {
+    this.state = newState;
+  }
+}

--- a/src/test/java/edu/snu/mist/task/operators/ApplyStatefulOperatorTest.java
+++ b/src/test/java/edu/snu/mist/task/operators/ApplyStatefulOperatorTest.java
@@ -15,6 +15,7 @@
  */
 package edu.snu.mist.task.operators;
 
+import edu.snu.mist.api.OperatorState;
 import edu.snu.mist.task.common.MistDataEvent;
 import edu.snu.mist.task.common.MistEvent;
 import edu.snu.mist.task.common.MistWatermarkEvent;
@@ -23,7 +24,7 @@ import org.junit.Test;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.function.BiFunction;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -44,12 +45,10 @@ public final class ApplyStatefulOperatorTest {
     final MistWatermarkEvent watermarkEvent = new MistWatermarkEvent(4L);
 
     // functions that dealing with state
-    final BiFunction<Integer, Integer, Integer> updateStateFunc =
+    final BiConsumer<Integer, OperatorState<Integer>> updateStateCons =
         (input, state) -> {
-          if (input > state) {
-            return input;
-          } else {
-            return state;
+          if (input > state.get()) {
+            state.set(input);
           }
         };
     final Function<Integer, Integer> produceResultFunc = state -> state;
@@ -57,7 +56,7 @@ public final class ApplyStatefulOperatorTest {
 
     final ApplyStatefulOperator<Integer, Integer, Integer> applyStatefulOperator =
         new ApplyStatefulOperator<>(
-            "testQuery", "testAggOp", updateStateFunc, produceResultFunc, initializeStateSup);
+            "testQuery", "testAggOp", updateStateCons, produceResultFunc, initializeStateSup);
 
     final List<MistEvent> result = new LinkedList<>();
     applyStatefulOperator.setOutputEmitter(new SimpleOutputEmitter(result));

--- a/src/test/java/edu/snu/mist/task/operators/ApplyStatefulWindowOperatorTest.java
+++ b/src/test/java/edu/snu/mist/task/operators/ApplyStatefulWindowOperatorTest.java
@@ -15,6 +15,7 @@
  */
 package edu.snu.mist.task.operators;
 
+import edu.snu.mist.api.OperatorState;
 import edu.snu.mist.task.common.MistDataEvent;
 import edu.snu.mist.task.common.MistEvent;
 import edu.snu.mist.task.common.MistWatermarkEvent;
@@ -24,7 +25,7 @@ import org.junit.Test;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.function.BiFunction;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -46,12 +47,10 @@ public final class ApplyStatefulWindowOperatorTest {
     final MistWatermarkEvent watermarkEvent = new MistWatermarkEvent(101L);
 
     // functions that dealing with state
-    final BiFunction<Integer, Integer, Integer> updateStateFunc =
+    final BiConsumer<Integer, OperatorState<Integer>> updateStateCons =
         (input, state) -> {
-          if (input > state) {
-            return input;
-          } else {
-            return state;
+          if (input > state.get()) {
+            state.set(input);
           }
         };
     final Function<Integer, String> produceResultFunc = state -> state.toString();
@@ -59,7 +58,7 @@ public final class ApplyStatefulWindowOperatorTest {
 
     final ApplyStatefulWindowOperator<Integer, String, Integer> applyStatefulWindowOperator =
         new ApplyStatefulWindowOperator<>(
-            "testQuery", "testAggOp", updateStateFunc, produceResultFunc, initializeStateSup);
+            "testQuery", "testAggOp", updateStateCons, produceResultFunc, initializeStateSup);
 
     final List<MistEvent> result = new LinkedList<>();
     applyStatefulWindowOperator.setOutputEmitter(new SimpleOutputEmitter(result));


### PR DESCRIPTION
This PR addressed the issue #328  by
- modifying `ApplyStatefulOperator` & `ApplyStatefulWindowOperator` to use `BiConsumer` instead of `BiFunction`
- adding `State` class that contains state instance to handle with primitive type states consuming

Closes #328
