### PR TITLE
[MIST-336] Unify lambda functions for ApplyStatefulOperator into OperatorState

### DIFF
--- a/src/main/java/edu/snu/mist/api/ContinuousStream.java
+++ b/src/main/java/edu/snu/mist/api/ContinuousStream.java
@@ -72,16 +72,11 @@ public interface ContinuousStream<T> extends MISTStream<T> {
   /**
    * Applies user-defined stateful operator to the current stream.
    * This stream will produce outputs on every stream input.
-   * @param updateStateCons the consumer that updates current state S with the data T
-   * @param produceResultFunc the function which produces result with the updated state and the input
-   * @param initializeStateSup the supplier which generates the initial state
-   * @param <S> the type of the operator state
+   * @param applyStatefulFunction the user-defined ApplyStatefulFunction
    * @param <OUT> the type of stream output
    * @return new transformed stream after applying the user-defined stateful operation
    */
-  <S, OUT> ApplyStatefulOperatorStream<T, OUT, S> applyStateful(MISTBiConsumer<T, OperatorState<S>> updateStateCons,
-                                                                MISTFunction<S, OUT> produceResultFunc,
-                                                                MISTSupplier<S> initializeStateSup);
+  <OUT> ApplyStatefulOperatorStream<T, OUT> applyStateful(ApplyStatefulFunction<T, OUT> applyStatefulFunction);
 
   /**
    * Applies union operation to the current stream and input continuous stream passed as a parameter.

--- a/src/main/java/edu/snu/mist/api/ContinuousStreamImpl.java
+++ b/src/main/java/edu/snu/mist/api/ContinuousStreamImpl.java
@@ -87,12 +87,10 @@ public abstract class ContinuousStreamImpl<T> extends MISTStreamImpl<T> implemen
   }
 
   @Override
-  public <S, OUT> ApplyStatefulOperatorStream<T, OUT, S> applyStateful(
-      final MISTBiConsumer<T, OperatorState<S>> updateStateCons,
-      final MISTFunction<S, OUT> produceResultFunc,
-      final MISTSupplier<S> initializeStateSup) {
-    final ApplyStatefulOperatorStream<T, OUT, S> downStream =
-        new ApplyStatefulOperatorStream<>(updateStateCons, produceResultFunc, initializeStateSup, dag);
+  public <OUT> ApplyStatefulOperatorStream<T, OUT> applyStateful(
+      final ApplyStatefulFunction<T, OUT> applyStatefulFunction) {
+    final ApplyStatefulOperatorStream<T, OUT> downStream =
+        new ApplyStatefulOperatorStream<>(applyStatefulFunction, dag);
     dag.addVertex(downStream);
     dag.addEdge(this, downStream, StreamType.Direction.LEFT);
     return downStream;

--- a/src/main/java/edu/snu/mist/api/operators/ApplyStatefulFunction.java
+++ b/src/main/java/edu/snu/mist/api/operators/ApplyStatefulFunction.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.api.operators;
+
+import java.io.Serializable;
+
+/**
+ * This interface defines basic ApplyStatefulFunction used during stateful-operation.
+ * ApplyStatefulFunction initializes an internal state, updates the state with received inputs, and
+ * generates a final result with the current state.
+ * @param <T> the type of the data that ApplyStatefulFunction consumes
+ * @param <R> the type of result
+ */
+public interface ApplyStatefulFunction<T, R> extends Serializable {
+
+  /**
+   * Initializes the internal state.
+   * The initial state should be initialized through this method instead of the constructor.
+   * When MIST submits a query to the server, MIST serializes the object of the ApplyStatefulFunction.
+   * If the internal state is not serializable, MIST cannot serialize the object, throwing an Exception.
+   * Thus, the state should be initialized in this method if it is not serializable.
+   * Also, we need to re-initialize the state for each incoming window
+   * during ApplyStateful operation on windowed stream.
+   */
+  void initialize();
+
+  /**
+   * Updates the internal state with the input.
+   * @param input the input to consume
+   */
+  void update(final T input);
+
+  /**
+   * Produces a final result with the current state.
+   * This method will be called for every input during the stateful operation for continuous stream.
+   * On the other hand, it will be called for each window during the stateful operation for windowed stream.
+   * The produced result should be a different object from the current state,
+   * and not be updated by ApplyStateful operation.
+   * @return the result with current state.
+   */
+  R produceResult();
+}

--- a/src/main/java/edu/snu/mist/api/windows/WindowedStream.java
+++ b/src/main/java/edu/snu/mist/api/windows/WindowedStream.java
@@ -16,11 +16,9 @@
 package edu.snu.mist.api.windows;
 
 import edu.snu.mist.api.MISTStream;
-import edu.snu.mist.api.OperatorState;
-import edu.snu.mist.api.functions.MISTBiConsumer;
+import edu.snu.mist.api.operators.ApplyStatefulFunction;
 import edu.snu.mist.api.functions.MISTBiFunction;
 import edu.snu.mist.api.functions.MISTFunction;
-import edu.snu.mist.api.functions.MISTSupplier;
 import edu.snu.mist.api.operators.AggregateWindowOperatorStream;
 import edu.snu.mist.api.operators.ApplyStatefulWindowOperatorStream;
 import edu.snu.mist.api.operators.ReduceByKeyWindowOperatorStream;
@@ -52,14 +50,9 @@ public interface WindowedStream<T> extends MISTStream<WindowData<T>> {
 
   /**
    * It applies an user-defined stateful operation to the collection of data received from upstream window operator.
-   * @param updateStateCons the consumer that updates temporal state S with the data T
-   * @param produceResultFunc the function that produces result from temporal state
-   * @param initializeStateSup the supplier that generates state of operation
+   * @param applyStatefulFunction the user-defined ApplyStatefulFunction
    * @param <R> the type of result
-   * @param <S> the type of state
-   * @return new aggregated continuous stream after applying the aggregation function
+   * @return new aggregated continuous stream after applying the stateful operation
    */
-  <R, S> ApplyStatefulWindowOperatorStream<T, R, S> applyStatefulWindow(
-      MISTBiConsumer<T, OperatorState<S>> updateStateCons, MISTFunction<S, R> produceResultFunc,
-      MISTSupplier<S> initializeStateSup);
+  <R> ApplyStatefulWindowOperatorStream<T, R> applyStatefulWindow(ApplyStatefulFunction<T, R> applyStatefulFunction);
 }

--- a/src/main/java/edu/snu/mist/api/windows/WindowedStreamImpl.java
+++ b/src/main/java/edu/snu/mist/api/windows/WindowedStreamImpl.java
@@ -17,12 +17,10 @@ package edu.snu.mist.api.windows;
 
 import edu.snu.mist.api.AvroVertexSerializable;
 import edu.snu.mist.api.MISTStreamImpl;
-import edu.snu.mist.api.OperatorState;
+import edu.snu.mist.api.operators.ApplyStatefulFunction;
 import edu.snu.mist.api.StreamType;
-import edu.snu.mist.api.functions.MISTBiConsumer;
 import edu.snu.mist.api.functions.MISTBiFunction;
 import edu.snu.mist.api.functions.MISTFunction;
-import edu.snu.mist.api.functions.MISTSupplier;
 import edu.snu.mist.api.operators.AggregateWindowOperatorStream;
 import edu.snu.mist.api.operators.ApplyStatefulWindowOperatorStream;
 import edu.snu.mist.api.operators.ReduceByKeyWindowOperatorStream;
@@ -69,12 +67,10 @@ public abstract class WindowedStreamImpl<T> extends MISTStreamImpl<WindowData<T>
   }
 
   @Override
-  public <R, S> ApplyStatefulWindowOperatorStream<T, R, S> applyStatefulWindow(
-      final MISTBiConsumer<T, OperatorState<S>> updateStateCons,
-      final MISTFunction<S, R> produceResultFunc,
-      final MISTSupplier<S> initializeStateSup) {
-    final ApplyStatefulWindowOperatorStream<T, R, S> downStream =
-        new ApplyStatefulWindowOperatorStream<>(updateStateCons, produceResultFunc, initializeStateSup, dag);
+  public <R> ApplyStatefulWindowOperatorStream<T, R> applyStatefulWindow(
+      final ApplyStatefulFunction<T, R> applyStatefulFunction) {
+    final ApplyStatefulWindowOperatorStream<T, R> downStream =
+        new ApplyStatefulWindowOperatorStream<>(applyStatefulFunction, dag);
     dag.addVertex(downStream);
     dag.addEdge(this, downStream, StreamType.Direction.LEFT);
     return downStream;

--- a/src/test/java/edu/snu/mist/api/operators/utils/CountStringFunction.java
+++ b/src/test/java/edu/snu/mist/api/operators/utils/CountStringFunction.java
@@ -13,29 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.mist.task;
+package edu.snu.mist.api.operators.utils;
 
-import edu.snu.mist.api.OperatorState;
+import edu.snu.mist.api.operators.ApplyStatefulFunction;
+import edu.snu.mist.api.types.Tuple2;
 
 /**
- * This class implements the OperatorState used during stateful-operation.
- * @param <S> the type of state that OperatorState contains
+ * A simple ApplyStatefulFunction that counts String which starts with capital A.
  */
-public final class OperatorStateImpl<S> implements OperatorState<S> {
+public final class CountStringFunction implements ApplyStatefulFunction<Tuple2<String, Integer>, Integer> {
+  // the internal state
+  private int state;
 
-  private S state;
-
-  public OperatorStateImpl(final S state) {
-    this.state = state;
+  public CountStringFunction() {
   }
 
   @Override
-  public S get() {
+  public void initialize() {
+    this.state = 0;
+  }
+
+  @Override
+  public void update(final Tuple2<String, Integer> input) {
+    if (((String)input.get(0)).startsWith("A")) {
+      state++;
+    }
+  }
+
+  @Override
+  public Integer produceResult() {
     return state;
-  }
-
-  @Override
-  public void set(final S newState) {
-    this.state = newState;
   }
 }

--- a/src/test/java/edu/snu/mist/api/operators/utils/package-info.java
+++ b/src/test/java/edu/snu/mist/api/operators/utils/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Utility classes for test.
+ */
+package edu.snu.mist.api.operators.utils;

--- a/src/test/java/edu/snu/mist/task/operators/ApplyStatefulOperatorTest.java
+++ b/src/test/java/edu/snu/mist/task/operators/ApplyStatefulOperatorTest.java
@@ -15,18 +15,16 @@
  */
 package edu.snu.mist.task.operators;
 
-import edu.snu.mist.api.OperatorState;
+import edu.snu.mist.api.operators.ApplyStatefulFunction;
 import edu.snu.mist.task.common.MistDataEvent;
 import edu.snu.mist.task.common.MistEvent;
 import edu.snu.mist.task.common.MistWatermarkEvent;
+import edu.snu.mist.task.utils.FindMaxIntFunction;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.function.BiConsumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 public final class ApplyStatefulOperatorTest {
 
@@ -44,20 +42,11 @@ public final class ApplyStatefulOperatorTest {
     final MistDataEvent data30 = new MistDataEvent(30, 3L);
     final MistWatermarkEvent watermarkEvent = new MistWatermarkEvent(4L);
 
-    // functions that dealing with state
-    final BiConsumer<Integer, OperatorState<Integer>> updateStateCons =
-        (input, state) -> {
-          if (input > state.get()) {
-            state.set(input);
-          }
-        };
-    final Function<Integer, Integer> produceResultFunc = state -> state;
-    final Supplier<Integer> initializeStateSup = () -> Integer.MIN_VALUE;
+    // the state managing function finding maximum integer value among received inputs
+    final ApplyStatefulFunction applyStatefulFunction = new FindMaxIntFunction();
 
-    final ApplyStatefulOperator<Integer, Integer, Integer> applyStatefulOperator =
-        new ApplyStatefulOperator<>(
-            "testQuery", "testAggOp", updateStateCons, produceResultFunc, initializeStateSup);
-
+    final ApplyStatefulOperator<Integer, Integer> applyStatefulOperator =
+        new ApplyStatefulOperator<>("testQuery", "testAggOp", applyStatefulFunction);
     final List<MistEvent> result = new LinkedList<>();
     applyStatefulOperator.setOutputEmitter(new SimpleOutputEmitter(result));
 

--- a/src/test/java/edu/snu/mist/task/utils/FindMaxIntFunction.java
+++ b/src/test/java/edu/snu/mist/task/utils/FindMaxIntFunction.java
@@ -13,21 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.mist.api;
+package edu.snu.mist.task.utils;
+
+import edu.snu.mist.api.operators.ApplyStatefulFunction;
 
 /**
- * This interface defines basic OperatorState used during stateful-operation.
- * @param <S> the type of state that OperatorState class contains
+ * A simple ApplyStatefulFunction that finds maximum integer among the received inputs.
  */
-public interface OperatorState<S> {
+public final class FindMaxIntFunction implements ApplyStatefulFunction<Integer, Integer> {
+  // the internal state
+  private int state;
 
-  /**
-   * @return the state
-   */
-  S get();
+  public FindMaxIntFunction() {
+  }
 
-  /**
-   * sets the state.
-   */
-  void set(S newState);
+  @Override
+  public void initialize() {
+    this.state = Integer.MIN_VALUE;
+  }
+
+  @Override
+  public void update(final Integer input) {
+    if (input > state) {
+      state = input;
+    }
+  }
+
+  @Override
+  public Integer produceResult() {
+    return state;
+  }
 }


### PR DESCRIPTION
This PR addressed the issue #336  by
- renaming `OperatorState` to `ApplyStatefulFunction`
- modifying `ApplyStatefulFunction` to update an internal state and produce a result with the current state
- making `ApplyStateful` operators to use `ApplyStatefulFunction` as a parameter instead of  `updateStateCons`, `produceResultFunc`, and `initialStateSup`

Closes #336
