### PR TITLE
[MIST-370] Remove queryId from operators

### DIFF
--- a/src/main/java/edu/snu/mist/core/task/TextSinkFactory.java
+++ b/src/main/java/edu/snu/mist/core/task/TextSinkFactory.java
@@ -24,14 +24,12 @@ public interface TextSinkFactory extends AutoCloseable {
 
   /**
    * Create new instance of sink.
-   * @param queryId query id
    * @param sinkId sink id
    * @param serverAddress server address
    * @param port server port
    * @return a new sink
    */
-  Sink<String> newSink(String queryId,
-                       String sinkId,
+  Sink<String> newSink(String sinkId,
                        String serverAddress,
                        int port) throws Exception;
 }

--- a/src/main/java/edu/snu/mist/core/task/operators/AggregateWindowOperator.java
+++ b/src/main/java/edu/snu/mist/core/task/operators/AggregateWindowOperator.java
@@ -39,14 +39,12 @@ public final class AggregateWindowOperator<IN, OUT>
   private final Function<WindowData<IN>, OUT> aggregateFunc;
 
   /**
-   * @param queryId identifier of the query which contains this operator
    * @param operatorId identifier of operator
    * @param aggregateFunc the function that processes the input WindowData
    */
-  public AggregateWindowOperator(final String queryId,
-                                 final String operatorId,
+  public AggregateWindowOperator(final String operatorId,
                                  final Function<WindowData<IN>, OUT> aggregateFunc) {
-    super(queryId, operatorId);
+    super(operatorId);
     this.aggregateFunc = aggregateFunc;
   }
 

--- a/src/main/java/edu/snu/mist/core/task/operators/ApplyStatefulOperator.java
+++ b/src/main/java/edu/snu/mist/core/task/operators/ApplyStatefulOperator.java
@@ -37,14 +37,12 @@ public final class ApplyStatefulOperator<IN, OUT> extends OneStreamOperator {
   private final ApplyStatefulFunction<IN, OUT> applyStatefulFunction;
 
   /**
-   * @param queryId identifier of the query which contains this operator
    * @param operatorId identifier of operator
    * @param applyStatefulFunction the user-defined ApplyStatefulFunction.
    */
-  public ApplyStatefulOperator(final String queryId,
-                               final String operatorId,
+  public ApplyStatefulOperator(final String operatorId,
                                final ApplyStatefulFunction<IN, OUT> applyStatefulFunction) {
-    super(queryId, operatorId);
+    super(operatorId);
     this.applyStatefulFunction = applyStatefulFunction;
     this.applyStatefulFunction.initialize();
   }

--- a/src/main/java/edu/snu/mist/core/task/operators/ApplyStatefulWindowOperator.java
+++ b/src/main/java/edu/snu/mist/core/task/operators/ApplyStatefulWindowOperator.java
@@ -39,14 +39,12 @@ public final class ApplyStatefulWindowOperator<IN, OUT>
   private final ApplyStatefulFunction<IN, OUT> applyStatefulFunction;
 
   /**
-   * @param queryId identifier of the query which contains this operator
    * @param operatorId identifier of operator
    * @param applyStatefulFunction the user-defined ApplyStatefulFunction
    */
-  public ApplyStatefulWindowOperator(final String queryId,
-                                     final String operatorId,
+  public ApplyStatefulWindowOperator(final String operatorId,
                                      final ApplyStatefulFunction<IN, OUT> applyStatefulFunction) {
-    super(queryId, operatorId);
+    super(operatorId);
     this.applyStatefulFunction = applyStatefulFunction;
   }
 

--- a/src/main/java/edu/snu/mist/core/task/operators/BaseOperator.java
+++ b/src/main/java/edu/snu/mist/core/task/operators/BaseOperator.java
@@ -26,11 +26,6 @@ public abstract class BaseOperator implements Operator {
   private static final Logger LOG = Logger.getLogger(BaseOperator.class.getName());
 
   /**
-   * An identifier of queryId.
-   */
-  protected final String queryId;
-
-  /**
    * An identifier of operatorId.
    */
   protected final String operatorId;
@@ -40,20 +35,13 @@ public abstract class BaseOperator implements Operator {
    */
   protected OutputEmitter outputEmitter;
 
-  public BaseOperator(final String queryId,
-                      final String operatorId) {
-    this.queryId = queryId;
+  public BaseOperator(final String operatorId) {
     this.operatorId = operatorId;
   }
 
   @Override
   public void setOutputEmitter(final OutputEmitter emitter) {
     this.outputEmitter = emitter;
-  }
-
-  @Override
-  public String getQueryIdentifier() {
-    return queryId;
   }
 
   @Override

--- a/src/main/java/edu/snu/mist/core/task/operators/CountWindowOperator.java
+++ b/src/main/java/edu/snu/mist/core/task/operators/CountWindowOperator.java
@@ -32,11 +32,10 @@ public final class CountWindowOperator<T> extends FixedSizeWindowOperator<T> {
    */
   private long count;
 
-  public CountWindowOperator(final String queryId,
-                             final String operatorId,
+  public CountWindowOperator(final String operatorId,
                              final int windowSize,
                              final int windowEmissionInterval) {
-    super(queryId, operatorId, windowSize, windowEmissionInterval);
+    super(operatorId, windowSize, windowEmissionInterval);
     this.count = 1L;
   }
 

--- a/src/main/java/edu/snu/mist/core/task/operators/FilterOperator.java
+++ b/src/main/java/edu/snu/mist/core/task/operators/FilterOperator.java
@@ -34,10 +34,9 @@ public final class FilterOperator<I> extends OneStreamOperator {
    */
   private final Predicate<I> filterFunc;
 
-  public FilterOperator(final String queryId,
-                        final String operatorId,
+  public FilterOperator(final String operatorId,
                         final Predicate<I> filterFunc) {
-    super(queryId, operatorId);
+    super(operatorId);
     this.filterFunc = filterFunc;
   }
 

--- a/src/main/java/edu/snu/mist/core/task/operators/FixedSizeWindowOperator.java
+++ b/src/main/java/edu/snu/mist/core/task/operators/FixedSizeWindowOperator.java
@@ -56,11 +56,10 @@ abstract class FixedSizeWindowOperator<T> extends OneStreamOperator {
    */
   private final Queue<Window<T>> windowQueue;
 
-  protected FixedSizeWindowOperator(final String queryId,
-                                    final String operatorId,
+  protected FixedSizeWindowOperator(final String operatorId,
                                     final int windowSize,
                                     final int windowEmissionInterval) {
-    super(queryId, operatorId);
+    super(operatorId);
     this.windowSize = windowSize;
     this.windowEmissionInterval = windowEmissionInterval;
     this.windowQueue = new LinkedList<>();

--- a/src/main/java/edu/snu/mist/core/task/operators/FlatMapOperator.java
+++ b/src/main/java/edu/snu/mist/core/task/operators/FlatMapOperator.java
@@ -34,10 +34,9 @@ public final class FlatMapOperator<I, O> extends OneStreamOperator {
    */
   private final Function<I, List<O>> flatMapFunc;
 
-  public FlatMapOperator(final String queryId,
-                         final String operatorId,
+  public FlatMapOperator(final String operatorId,
                          final Function<I, List<O>> flatMapFunc) {
-    super(queryId, operatorId);
+    super(operatorId);
     this.flatMapFunc = flatMapFunc;
   }
 

--- a/src/main/java/edu/snu/mist/core/task/operators/JoinOperator.java
+++ b/src/main/java/edu/snu/mist/core/task/operators/JoinOperator.java
@@ -42,10 +42,9 @@ public final class JoinOperator<T, U> extends OneStreamOperator {
    */
   private final BiPredicate<T, U> joinBiPredicate;
 
-  public JoinOperator(final String queryId,
-                      final String operatorId,
+  public JoinOperator(final String operatorId,
                       final BiPredicate<T, U> joinBiPredicate) {
-    super(queryId, operatorId);
+    super(operatorId);
     this.joinBiPredicate = joinBiPredicate;
   }
 

--- a/src/main/java/edu/snu/mist/core/task/operators/MapOperator.java
+++ b/src/main/java/edu/snu/mist/core/task/operators/MapOperator.java
@@ -35,10 +35,9 @@ public final class MapOperator<I, O> extends OneStreamOperator {
    */
   private final Function<I, O> mapFunc;
 
-  public MapOperator(final String queryId,
-                     final String operatorId,
+  public MapOperator(final String operatorId,
                      final Function<I, O> mapFunc) {
-    super(queryId, operatorId);
+    super(operatorId);
     this.mapFunc = mapFunc;
   }
 

--- a/src/main/java/edu/snu/mist/core/task/operators/OneStreamOperator.java
+++ b/src/main/java/edu/snu/mist/core/task/operators/OneStreamOperator.java
@@ -27,9 +27,8 @@ import java.util.logging.Logger;
 public abstract class OneStreamOperator extends BaseOperator {
   private static final Logger LOG = Logger.getLogger(OneStreamOperator.class.getName());
 
-  public OneStreamOperator(final String queryId,
-                           final String operatorId) {
-    super(queryId, operatorId);
+  public OneStreamOperator(final String operatorId) {
+    super(operatorId);
   }
 
   @Override

--- a/src/main/java/edu/snu/mist/core/task/operators/Operator.java
+++ b/src/main/java/edu/snu/mist/core/task/operators/Operator.java
@@ -32,12 +32,6 @@ public interface Operator extends OutputEmittable {
   String getOperatorIdentifier();
 
   /**
-   * Gets the query identifier containing this operator.
-   * @return an identifier
-   */
-  String getQueryIdentifier();
-
-  /**
    * Process data of left upstream.
    * @param data data
    */

--- a/src/main/java/edu/snu/mist/core/task/operators/ReduceByKeyOperator.java
+++ b/src/main/java/edu/snu/mist/core/task/operators/ReduceByKeyOperator.java
@@ -54,15 +54,13 @@ public final class ReduceByKeyOperator<K extends Serializable, V extends Seriali
 
   /**
    * @param reduceFunc reduce function
-   * @param queryId identifier of the query which contains this operator
    * @param operatorId identifier of operator
    * @param keyIndex index of key
    */
-  public ReduceByKeyOperator(final String queryId,
-                             final String operatorId,
+  public ReduceByKeyOperator(final String operatorId,
                              final int keyIndex,
                              final BiFunction<V, V, V> reduceFunc) {
-    super(queryId, operatorId);
+    super(operatorId);
     this.reduceFunc = reduceFunc;
     this.keyIndex = keyIndex;
     this.state = createInitialState();

--- a/src/main/java/edu/snu/mist/core/task/operators/SessionWindowOperator.java
+++ b/src/main/java/edu/snu/mist/core/task/operators/SessionWindowOperator.java
@@ -43,10 +43,9 @@ public final class SessionWindowOperator<T> extends OneStreamOperator {
    */
   private Window<T> currentWindow;
 
-  public SessionWindowOperator(final String queryId,
-                               final String operatorId,
+  public SessionWindowOperator(final String operatorId,
                                final int sessionInterval) {
-    super(queryId, operatorId);
+    super(operatorId);
     this.sessionInterval = sessionInterval;
     currentWindow = null;
   }

--- a/src/main/java/edu/snu/mist/core/task/operators/TimeWindowOperator.java
+++ b/src/main/java/edu/snu/mist/core/task/operators/TimeWindowOperator.java
@@ -27,11 +27,10 @@ import java.util.logging.Logger;
 public final class TimeWindowOperator<T> extends FixedSizeWindowOperator<T> {
   private static final Logger LOG = Logger.getLogger(TimeWindowOperator.class.getName());
 
-  public TimeWindowOperator(final String queryId,
-                            final String operatorId,
+  public TimeWindowOperator(final String operatorId,
                             final int windowSize,
                             final int windowEmissionInterval) {
-    super(queryId, operatorId, windowSize, windowEmissionInterval);
+    super(operatorId, windowSize, windowEmissionInterval);
   }
 
   @Override

--- a/src/main/java/edu/snu/mist/core/task/operators/TwoStreamOperator.java
+++ b/src/main/java/edu/snu/mist/core/task/operators/TwoStreamOperator.java
@@ -23,8 +23,7 @@ import java.util.logging.Logger;
 public abstract class TwoStreamOperator extends BaseOperator {
   private static final Logger LOG = Logger.getLogger(TwoStreamOperator.class.getName());
 
-  public TwoStreamOperator(final String queryId,
-                           final String operatorId) {
-    super(queryId, operatorId);
+  public TwoStreamOperator(final String operatorId) {
+    super(operatorId);
   }
 }

--- a/src/main/java/edu/snu/mist/core/task/operators/UnionOperator.java
+++ b/src/main/java/edu/snu/mist/core/task/operators/UnionOperator.java
@@ -42,9 +42,8 @@ public final class UnionOperator extends TwoStreamOperator {
   private long recentLeftTimestamp;
   private long recentRightTimestamp;
 
-  public UnionOperator(final String queryId,
-                       final String operatorId) {
-    super(queryId, operatorId);
+  public UnionOperator(final String operatorId) {
+    super(operatorId);
     this.leftUpstreamQueue = new LinkedBlockingQueue<>();
     this.rightUpstreamQueue = new LinkedBlockingQueue<>();
     defaultWatermark = new MistWatermarkEvent(0L);

--- a/src/main/java/edu/snu/mist/core/task/sinks/NettyTextSink.java
+++ b/src/main/java/edu/snu/mist/core/task/sinks/NettyTextSink.java
@@ -28,11 +28,6 @@ import java.io.IOException;
 public final class NettyTextSink implements Sink<String> {
 
   /**
-   * Query id.
-   */
-  private final Identifier queryId;
-
-  /**
    * Sink id.
    */
   private final Identifier sinkId;
@@ -52,11 +47,9 @@ public final class NettyTextSink implements Sink<String> {
    */
   private final String newline = System.getProperty("line.separator");
 
-  public NettyTextSink(final String queryId,
-                       final String sinkId,
+  public NettyTextSink(final String sinkId,
                        final Channel channel,
                        final StringIdentifierFactory identifierFactory) throws IOException {
-    this.queryId = identifierFactory.getNewInstance(queryId);
     this.sinkId = identifierFactory.getNewInstance(sinkId);
     this.channel = channel;
   }
@@ -64,11 +57,6 @@ public final class NettyTextSink implements Sink<String> {
   @Override
   public Identifier getIdentifier() {
     return sinkId;
-  }
-
-  @Override
-  public Identifier getQueryIdentifier() {
-    return queryId;
   }
 
   @Override

--- a/src/main/java/edu/snu/mist/core/task/sinks/NettyTextSinkFactory.java
+++ b/src/main/java/edu/snu/mist/core/task/sinks/NettyTextSinkFactory.java
@@ -89,8 +89,7 @@ public final class NettyTextSinkFactory implements TextSinkFactory {
 
 
   @Override
-  public Sink<String> newSink(final String queryId,
-                              final String sinkId,
+  public Sink<String> newSink(final String sinkId,
                               final String serverAddress,
                               final int port) throws Exception {
     final ChannelFuture channelFuture = clientBootstrap.connect(serverAddress, port);
@@ -102,7 +101,7 @@ public final class NettyTextSinkFactory implements TextSinkFactory {
       throw new RuntimeException(sb.toString());
     }
     final Channel channel = channelFuture.channel();
-    return new NettyTextSink(queryId, sinkId, channel, identifierFactory);
+    return new NettyTextSink(sinkId, channel, identifierFactory);
   }
 
   @Override

--- a/src/main/java/edu/snu/mist/core/task/sinks/Sink.java
+++ b/src/main/java/edu/snu/mist/core/task/sinks/Sink.java
@@ -28,10 +28,4 @@ public interface Sink<I> extends InputHandler<I>, AutoCloseable, PhysicalVertex 
    * Identifier of sink.
    */
   Identifier getIdentifier();
-
-  /**
-   * Gets the query identifier containing this sink.
-   * @return an identifier
-   */
-  Identifier getQueryIdentifier();
 }

--- a/src/main/java/edu/snu/mist/core/task/sources/Source.java
+++ b/src/main/java/edu/snu/mist/core/task/sources/Source.java
@@ -41,12 +41,6 @@ public interface Source<T> extends AutoCloseable, PhysicalVertex {
   Identifier getIdentifier();
 
   /**
-   * Gets the query identifier containing this source.
-   * @return identifier of query
-   */
-  Identifier getQueryIdentifier();
-
-  /**
    * Gets the data generator.
    * @return the data generator
    */

--- a/src/main/java/edu/snu/mist/core/task/sources/SourceImpl.java
+++ b/src/main/java/edu/snu/mist/core/task/sources/SourceImpl.java
@@ -24,11 +24,6 @@ import org.apache.reef.wake.Identifier;
 public final class SourceImpl<T> implements Source<T>{
 
   /**
-   * Query id.
-   */
-  private final Identifier queryId;
-
-  /**
    * Source id.
    */
   private final Identifier sourceId;
@@ -43,9 +38,8 @@ public final class SourceImpl<T> implements Source<T>{
    */
   private final EventGenerator<T> eventGenerator;
 
-  public SourceImpl(final Identifier queryId, final Identifier sourceId,
+  public SourceImpl(final Identifier sourceId,
                     final DataGenerator<T> dataGenerator, final EventGenerator<T> eventGenerator) {
-    this.queryId = queryId;
     this.sourceId = sourceId;
     this.dataGenerator = dataGenerator;
     this.eventGenerator = eventGenerator;
@@ -72,11 +66,6 @@ public final class SourceImpl<T> implements Source<T>{
   @Override
   public Identifier getIdentifier() {
     return sourceId;
-  }
-
-  @Override
-  public Identifier getQueryIdentifier() {
-    return queryId;
   }
 
   @Override

--- a/src/test/java/edu/snu/mist/core/task/EventProcessorTest.java
+++ b/src/test/java/edu/snu/mist/core/task/EventProcessorTest.java
@@ -55,10 +55,10 @@ public final class EventProcessorTest {
     final List<Integer> result = new LinkedList<>();
 
     final PartitionedQuery query1 = new DefaultPartitionedQuery();
-    query1.insertToHead(new TestOperator("o1", "q1"));
+    query1.insertToHead(new TestOperator("o1"));
     query1.setOutputEmitter(new TestOutputEmitter<>(list1));
     final PartitionedQuery query2 = new DefaultPartitionedQuery();
-    query2.insertToHead(new TestOperator("o2", "q2"));
+    query2.insertToHead(new TestOperator("o2"));
     query2.setOutputEmitter(new TestOutputEmitter<>(list2));
 
     for (int i = 0; i < numTasks; i++) {
@@ -104,7 +104,7 @@ public final class EventProcessorTest {
     final List<Integer> result = new LinkedList<>();
 
     final PartitionedQuery query = new DefaultPartitionedQuery();
-    query.insertToHead(new TestOperator("o1", "q1"));
+    query.insertToHead(new TestOperator("o1"));
     query.setOutputEmitter(new TestOutputEmitter<>(list1));
 
     for (int i = 0; i < numTasks; i++) {
@@ -141,9 +141,8 @@ public final class EventProcessorTest {
    * It just forwards inputs to outputEmitter.
    */
   class TestOperator extends OneStreamOperator {
-    public TestOperator(final String opId,
-                        final String queryId) {
-      super(opId, queryId);
+    public TestOperator(final String opId) {
+      super(opId);
     }
 
     @Override

--- a/src/test/java/edu/snu/mist/core/task/PartitionedQueryTest.java
+++ b/src/test/java/edu/snu/mist/core/task/PartitionedQueryTest.java
@@ -54,14 +54,13 @@ public final class PartitionedQueryTest {
 
     final Injector injector = Tang.Factory.getTang().newInjector();
     final StringIdentifierFactory idFactory = injector.getInstance(StringIdentifierFactory.class);
-    final String queryId = "testQuery";
     final String squareOpId = "squareOp";
     final String incOpId = "incOp";
     final String doubleOpId = "doubleOp";
 
-    final Operator squareOp = new SquareOperator(queryId, squareOpId);
-    final Operator incOp = new IncrementOperator(queryId, incOpId);
-    final Operator doubleOp = new DoubleOperator(queryId, doubleOpId);
+    final Operator squareOp = new SquareOperator(squareOpId);
+    final Operator incOp = new IncrementOperator(incOpId);
+    final Operator doubleOp = new DoubleOperator(doubleOpId);
 
     // 2 * (input * input + 1)
     final Integer expected1 = 2 * (input * input + 1);
@@ -105,9 +104,8 @@ public final class PartitionedQueryTest {
    * This emits squared inputs.
    */
   class SquareOperator extends OneStreamOperator {
-    SquareOperator(final String queryId,
-                   final String operatorId) {
-      super(queryId, operatorId);
+    SquareOperator(final String operatorId) {
+      super(operatorId);
     }
 
     @Override
@@ -128,9 +126,8 @@ public final class PartitionedQueryTest {
    * This increments the input.
    */
   class IncrementOperator extends OneStreamOperator {
-    IncrementOperator(final String queryId,
-                      final String operatorId) {
-      super(queryId, operatorId);
+    IncrementOperator(final String operatorId) {
+      super(operatorId);
     }
 
     @Override
@@ -150,9 +147,8 @@ public final class PartitionedQueryTest {
    * This doubles the input.
    */
   class DoubleOperator extends OneStreamOperator {
-    DoubleOperator(final String queryId,
-                   final String operatorId) {
-      super(queryId, operatorId);
+    DoubleOperator(final String operatorId) {
+      super(operatorId);
     }
 
     @Override

--- a/src/test/java/edu/snu/mist/core/task/QueryManagerTest.java
+++ b/src/test/java/edu/snu/mist/core/task/QueryManagerTest.java
@@ -114,8 +114,8 @@ public final class QueryManagerTest {
     final TestDataGenerator dataGenerator = new TestDataGenerator(inputs);
     final EventGenerator eventGenerator =
         new PunctuatedEventGenerator(null, input -> false, null);
-    final Source src = new SourceImpl(identifierFactory.getNewInstance(queryId),
-        identifierFactory.getNewInstance("testSource"), dataGenerator, eventGenerator);
+    final Source src = new SourceImpl(identifierFactory.getNewInstance("testSource"),
+        dataGenerator, eventGenerator);
 
     final JavaConfigurationBuilder jcb = Tang.Factory.getTang().newConfigurationBuilder();
     jcb.bindNamedParameter(NumThreads.class, Integer.toString(4));
@@ -206,11 +206,11 @@ public final class QueryManagerTest {
     final TestDataGenerator beforeStopDataGenerator = new TestDataGenerator(beforeStopInputs);
     final EventGenerator eventGenerator =
         new PunctuatedEventGenerator(null, input -> false, null);
-    final Source beforeStopSrc = new SourceImpl(identifierFactory.getNewInstance(queryId),
+    final Source beforeStopSrc = new SourceImpl(
         identifierFactory.getNewInstance("testSource"), beforeStopDataGenerator, eventGenerator);
 
     final TestDataGenerator afterResumeDataGenerator = new TestDataGenerator(afterResumeInputs);
-    final Source afterResumeSrc = new SourceImpl(identifierFactory.getNewInstance(queryId),
+    final Source afterResumeSrc = new SourceImpl(
         identifierFactory.getNewInstance("testSource2"), afterResumeDataGenerator, eventGenerator);
 
     final JavaConfigurationBuilder jcb = Tang.Factory.getTang().newConfigurationBuilder();
@@ -298,19 +298,18 @@ public final class QueryManagerTest {
                                     final Source src,
                                     final Sink sink1,
                                     final Sink sink2) {
-    final String queryId = tuple.getKey();
 
     // Create operators and partitioned queries
     //                     (pq1)                                     (pq2)
     // src -> [flatMap -> filter -> toTupleMap -> reduceByKey] -> [toStringMap]   -> sink1
     //                                                         -> [totalCountMap] -> sink2
     //                                                               (pq3)
-    final Operator flatMap = new FlatMapOperator<>(queryId, "flatMap", flatMapFunc);
-    final Operator filter = new FilterOperator<>(queryId, "filter", filterFunc);
-    final Operator toTupleMap = new MapOperator<>(queryId, "toTupleMap", toTupleMapFunc);
-    final Operator reduceByKey = new ReduceByKeyOperator<>(queryId, "reduceByKey", 0, reduceByKeyFunc);
-    final Operator toStringMap = new MapOperator<>(queryId, "toStringMap", toStringMapFunc);
-    final Operator totalCountMap = new MapOperator<>(queryId, "totalCountMap", totalCountMapFunc);
+    final Operator flatMap = new FlatMapOperator<>("flatMap", flatMapFunc);
+    final Operator filter = new FilterOperator<>("filter", filterFunc);
+    final Operator toTupleMap = new MapOperator<>("toTupleMap", toTupleMapFunc);
+    final Operator reduceByKey = new ReduceByKeyOperator<>("reduceByKey", 0, reduceByKeyFunc);
+    final Operator toStringMap = new MapOperator<>("toStringMap", toStringMapFunc);
+    final Operator totalCountMap = new MapOperator<>("totalCountMap", totalCountMapFunc);
 
     final PartitionedQuery pq1 = new DefaultPartitionedQuery();
     pq1.insertToTail(flatMap);
@@ -515,11 +514,6 @@ public final class QueryManagerTest {
 
     @Override
     public Identifier getIdentifier() {
-      return null;
-    }
-
-    @Override
-    public Identifier getQueryIdentifier() {
       return null;
     }
 

--- a/src/test/java/edu/snu/mist/core/task/operators/AggregateWindowOperatorTest.java
+++ b/src/test/java/edu/snu/mist/core/task/operators/AggregateWindowOperatorTest.java
@@ -51,7 +51,7 @@ public final class AggregateWindowOperatorTest {
         };
 
     final AggregateWindowOperator<Integer, String> aggregateWindowOperator =
-        new AggregateWindowOperator<>("testQuery", "testAggOp", aggregateFunc);
+        new AggregateWindowOperator<>("testAggOp", aggregateFunc);
 
     final List<MistEvent> result = new LinkedList<>();
     aggregateWindowOperator.setOutputEmitter(new SimpleOutputEmitter(result));

--- a/src/test/java/edu/snu/mist/core/task/operators/ApplyStatefulOperatorTest.java
+++ b/src/test/java/edu/snu/mist/core/task/operators/ApplyStatefulOperatorTest.java
@@ -46,7 +46,7 @@ public final class ApplyStatefulOperatorTest {
     final ApplyStatefulFunction applyStatefulFunction = new FindMaxIntFunction();
 
     final ApplyStatefulOperator<Integer, Integer> applyStatefulOperator =
-        new ApplyStatefulOperator<>("testQuery", "testAggOp", applyStatefulFunction);
+        new ApplyStatefulOperator<>("testAggOp", applyStatefulFunction);
     final List<MistEvent> result = new LinkedList<>();
     applyStatefulOperator.setOutputEmitter(new SimpleOutputEmitter(result));
 

--- a/src/test/java/edu/snu/mist/core/task/operators/ApplyStatefulWindowOperatorTest.java
+++ b/src/test/java/edu/snu/mist/core/task/operators/ApplyStatefulWindowOperatorTest.java
@@ -47,8 +47,7 @@ public final class ApplyStatefulWindowOperatorTest {
     final ApplyStatefulFunction<Integer, Integer> applyStatefulFunction = new FindMaxIntFunction();
 
     final ApplyStatefulWindowOperator<Integer, Integer> applyStatefulWindowOperator =
-        new ApplyStatefulWindowOperator<>(
-            "testQuery", "testAggOp", applyStatefulFunction);
+        new ApplyStatefulWindowOperator<>("testAggOp", applyStatefulFunction);
 
     final List<MistEvent> result = new LinkedList<>();
     applyStatefulWindowOperator.setOutputEmitter(new SimpleOutputEmitter(result));

--- a/src/test/java/edu/snu/mist/core/task/operators/FixedSizeWindowOperatorTest.java
+++ b/src/test/java/edu/snu/mist/core/task/operators/FixedSizeWindowOperatorTest.java
@@ -56,7 +56,7 @@ public final class FixedSizeWindowOperatorTest {
     final int emissionInterval = 250;
 
     final TimeWindowOperator<Integer> timeWindowOperator =
-        new TimeWindowOperator<>("testQuery", "testAggOp", windowSize, emissionInterval);
+        new TimeWindowOperator<>("testAggOp", windowSize, emissionInterval);
 
     final List<MistEvent> result = new LinkedList<>();
     timeWindowOperator.setOutputEmitter(new SimpleOutputEmitter(result));
@@ -117,7 +117,7 @@ public final class FixedSizeWindowOperatorTest {
     final int emissionInterval = 750;
 
     final TimeWindowOperator<Integer> timeWindowOperator =
-            new TimeWindowOperator<>("testQuery", "testAggOp", windowSize, emissionInterval);
+            new TimeWindowOperator<>("testAggOp", windowSize, emissionInterval);
 
     final List<MistEvent> result = new LinkedList<>();
     timeWindowOperator.setOutputEmitter(new SimpleOutputEmitter(result));
@@ -164,7 +164,7 @@ public final class FixedSizeWindowOperatorTest {
     final int emissionInterval = 3;
 
     final CountWindowOperator<Integer> countWindowOperator =
-            new CountWindowOperator<>("testQuery", "testAggOp", windowSize, emissionInterval);
+            new CountWindowOperator<>("testAggOp", windowSize, emissionInterval);
 
     final List<MistEvent> result = new LinkedList<>();
     countWindowOperator.setOutputEmitter(new SimpleOutputEmitter(result));
@@ -233,7 +233,7 @@ public final class FixedSizeWindowOperatorTest {
     final int emissionInterval = 5;
 
     final CountWindowOperator<Integer> countWindowOperator =
-        new CountWindowOperator<>("testQuery", "testAggOp", windowSize, emissionInterval);
+        new CountWindowOperator<>("testAggOp", windowSize, emissionInterval);
 
     final List<MistEvent> result = new LinkedList<>();
     countWindowOperator.setOutputEmitter(new SimpleOutputEmitter(result));

--- a/src/test/java/edu/snu/mist/core/task/operators/JoinOperatorTest.java
+++ b/src/test/java/edu/snu/mist/core/task/operators/JoinOperatorTest.java
@@ -54,7 +54,7 @@ public final class JoinOperatorTest {
         (tuple1, tuple2) -> tuple1.get(1).equals(tuple2.get(0));
 
     final JoinOperator<Tuple2<String, Integer>, Tuple2<Integer, Long>> joinOperator =
-        new JoinOperator<>("testQuery", "testJoinOp", joinPredicate);
+        new JoinOperator<>("testJoinOp", joinPredicate);
 
     // expected pairs
     // {Hello, 1} and {1, 3000L}

--- a/src/test/java/edu/snu/mist/core/task/operators/SessionWindowOperatorTest.java
+++ b/src/test/java/edu/snu/mist/core/task/operators/SessionWindowOperatorTest.java
@@ -51,7 +51,7 @@ public final class SessionWindowOperatorTest {
   public void testSessionWindowOperator() throws InterruptedException {
     final int sessionInterval = 500;
     final SessionWindowOperator<Integer> sessionWindowOperator =
-        new SessionWindowOperator<>("testQuery", "testAggOp", sessionInterval);
+        new SessionWindowOperator<>("testAggOp", sessionInterval);
     final List<MistEvent> result = new LinkedList<>();
     sessionWindowOperator.setOutputEmitter(new SimpleOutputEmitter(result));
 

--- a/src/test/java/edu/snu/mist/core/task/operators/StatefulOperatorTest.java
+++ b/src/test/java/edu/snu/mist/core/task/operators/StatefulOperatorTest.java
@@ -86,14 +86,13 @@ public final class StatefulOperatorTest {
     expected.add(o5);
     expected.add(o6);
 
-    final String queryId = "testQuery";
     final String operatorId = "testReduceByKeyOperator";
     // Set the key index of tuple
     final int keyIndex = 0;
     // Reduce function for word count
     final BiFunction<Integer, Integer, Integer> wordCountFunc = (oldVal, val) -> oldVal + val;
     final ReduceByKeyOperator<String, Integer> wcOperator =
-        new ReduceByKeyOperator<>(queryId, operatorId, keyIndex, wordCountFunc);
+        new ReduceByKeyOperator<>(operatorId, keyIndex, wordCountFunc);
 
     // output test
     final List<Map<String, Integer>> result = new LinkedList<>();

--- a/src/test/java/edu/snu/mist/core/task/operators/StatelessOperatorTest.java
+++ b/src/test/java/edu/snu/mist/core/task/operators/StatelessOperatorTest.java
@@ -62,7 +62,7 @@ public final class StatelessOperatorTest {
 
     // map function: convert string to tuple
     final Function<String, Tuple> mapFunc = (mapInput) -> new Tuple<>(mapInput, 1);
-    final MapOperator<String, Tuple> mapOperator = new MapOperator<>("testQuery", "testMapOp", mapFunc);
+    final MapOperator<String, Tuple> mapOperator = new MapOperator<>("testMapOp", mapFunc);
     testStatelessOperator(inputStream, expected, mapOperator);
   }
 
@@ -83,7 +83,7 @@ public final class StatelessOperatorTest {
 
     // create a filter function
     final Predicate<String> filterFunc = (input) -> input.startsWith("a");
-    final FilterOperator<String> filterOperator = new FilterOperator<>("testQuery", "testOp", filterFunc);
+    final FilterOperator<String> filterOperator = new FilterOperator<>("testOp", filterFunc);
     testStatelessOperator(inputStream, expected, filterOperator);
   }
 
@@ -102,7 +102,7 @@ public final class StatelessOperatorTest {
 
     // map function: splits the string by space.
     final Function<String, List<String>> flatMapFunc = (mapInput) -> Arrays.asList(mapInput.split(" "));
-    final FlatMapOperator<String, String> flatMapOperator = new FlatMapOperator<>("testQuery", "testOp", flatMapFunc);
+    final FlatMapOperator<String, String> flatMapOperator = new FlatMapOperator<>("testOp", flatMapFunc);
     testStatelessOperator(inputStream, expected, flatMapOperator);
   }
 }

--- a/src/test/java/edu/snu/mist/core/task/operators/UnionOperatorTest.java
+++ b/src/test/java/edu/snu/mist/core/task/operators/UnionOperatorTest.java
@@ -46,7 +46,7 @@ public final class UnionOperatorTest {
     final MistDataEvent g = new MistDataEvent("g", 6L);
     final MistWatermarkEvent rw2 = new MistWatermarkEvent(11L);
 
-    final UnionOperator unionOperator = new UnionOperator("testQuery", "testUnionOp");
+    final UnionOperator unionOperator = new UnionOperator("testUnionOp");
 
     final List<MistEvent> result = new LinkedList<>();
     unionOperator.setOutputEmitter(new SimpleOutputEmitter(result));

--- a/src/test/java/edu/snu/mist/core/task/sinks/TextSinkFactoryTest.java
+++ b/src/test/java/edu/snu/mist/core/task/sinks/TextSinkFactoryTest.java
@@ -68,7 +68,7 @@ public final class TextSinkFactoryTest {
         // result list
         // Create sinks
         for (int i = 0; i < numSinks; i++) {
-          final Sink<String> sink = textSinkFactory.newSink(QUERY_ID, Integer.toString(i), SERVER_ADDR, SERVER_PORT);
+          final Sink<String> sink = textSinkFactory.newSink(Integer.toString(i), SERVER_ADDR, SERVER_PORT);
           sinks.add(sink);
         }
 

--- a/src/test/java/edu/snu/mist/core/task/sources/NettySourceTest.java
+++ b/src/test/java/edu/snu/mist/core/task/sources/NettySourceTest.java
@@ -42,7 +42,6 @@ import java.util.logging.Logger;
 public final class NettySourceTest {
 
   private static final Logger LOG = Logger.getLogger(NettyTextDataGeneratorFactory.class.getName());
-  private static final String QUERY_ID = "testQuery";
   private static final String SERVER_ADDR = "localhost";
   private static final int SERVER_PORT = 12112;
 
@@ -98,7 +97,7 @@ public final class NettySourceTest {
                   new Tuple<>(input.toString().split(":")[0], Long.parseLong(input.toString().split(":")[1])),
                   (input) -> input.toString().split(":")[0].equals("Watermark"),
                   (input) -> Long.parseLong(input.toString().split(":")[1]));
-          final Source<String> source = new SourceImpl<>(identifierFactory.getNewInstance(QUERY_ID),
+          final Source<String> source = new SourceImpl<>(
               identifierFactory.getNewInstance(Integer.toString(i)), dataGenerator, eventGenerator);
 
           sources.add(source);
@@ -174,7 +173,7 @@ public final class NettySourceTest {
         final DataGenerator<String> dataGenerator = textDataGeneratorFactory.newDataGenerator(SERVER_ADDR, SERVER_PORT);
         final EventGenerator<String> eventGenerator =
             new PeriodicEventGenerator<>(null, period, period, TimeUnit.MILLISECONDS, scheduler);
-        final Source<String> periodicSource = new SourceImpl<>(identifierFactory.getNewInstance(QUERY_ID),
+        final Source<String> periodicSource = new SourceImpl<>(
             identifierFactory.getNewInstance(Integer.toString(1)), dataGenerator, eventGenerator);
 
         final List<String> periodicReceivedData = new LinkedList<>();


### PR DESCRIPTION
This PR addressed #370 by
* removing `queryId` from sources, operators, and sinks.

Closes #370 