### PR TITLE
[MIST-379] Make sources, operators, and sinks injectable

### DIFF
--- a/src/main/java/edu/snu/mist/common/functions/WatermarkTimestampFunction.java
+++ b/src/main/java/edu/snu/mist/common/functions/WatermarkTimestampFunction.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.common.functions;
+
+import java.io.Serializable;
+import java.util.function.Function;
+
+/**
+ * A function for extracting timestamps from watermarks in sources.
+ */
+public interface WatermarkTimestampFunction<T> extends Function<T, Long>, Serializable {
+}

--- a/src/main/java/edu/snu/mist/common/operators/AggregateWindowOperator.java
+++ b/src/main/java/edu/snu/mist/common/operators/AggregateWindowOperator.java
@@ -15,10 +15,13 @@
  */
 package edu.snu.mist.common.operators;
 
+import edu.snu.mist.common.parameters.OperatorId;
 import edu.snu.mist.common.windows.WindowData;
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.MistWatermarkEvent;
+import org.apache.reef.tang.annotations.Parameter;
 
+import javax.inject.Inject;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -42,7 +45,8 @@ public final class AggregateWindowOperator<IN, OUT>
    * @param operatorId identifier of operator
    * @param aggregateFunc the function that processes the input WindowData
    */
-  public AggregateWindowOperator(final String operatorId,
+  @Inject
+  public AggregateWindowOperator(@Parameter(OperatorId.class) final String operatorId,
                                  final Function<WindowData<IN>, OUT> aggregateFunc) {
     super(operatorId);
     this.aggregateFunc = aggregateFunc;

--- a/src/main/java/edu/snu/mist/common/operators/ApplyStatefulOperator.java
+++ b/src/main/java/edu/snu/mist/common/operators/ApplyStatefulOperator.java
@@ -18,7 +18,10 @@ package edu.snu.mist.common.operators;
 import edu.snu.mist.common.functions.ApplyStatefulFunction;
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.MistWatermarkEvent;
+import edu.snu.mist.common.parameters.OperatorId;
+import org.apache.reef.tang.annotations.Parameter;
 
+import javax.inject.Inject;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -40,7 +43,8 @@ public final class ApplyStatefulOperator<IN, OUT> extends OneStreamOperator {
    * @param operatorId identifier of operator
    * @param applyStatefulFunction the user-defined ApplyStatefulFunction.
    */
-  public ApplyStatefulOperator(final String operatorId,
+  @Inject
+  public ApplyStatefulOperator(@Parameter(OperatorId.class) final String operatorId,
                                final ApplyStatefulFunction<IN, OUT> applyStatefulFunction) {
     super(operatorId);
     this.applyStatefulFunction = applyStatefulFunction;

--- a/src/main/java/edu/snu/mist/common/operators/ApplyStatefulWindowOperator.java
+++ b/src/main/java/edu/snu/mist/common/operators/ApplyStatefulWindowOperator.java
@@ -16,10 +16,13 @@
 package edu.snu.mist.common.operators;
 
 import edu.snu.mist.common.functions.ApplyStatefulFunction;
+import edu.snu.mist.common.parameters.OperatorId;
 import edu.snu.mist.common.windows.WindowData;
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.MistWatermarkEvent;
+import org.apache.reef.tang.annotations.Parameter;
 
+import javax.inject.Inject;
 import java.util.Collection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -42,7 +45,8 @@ public final class ApplyStatefulWindowOperator<IN, OUT>
    * @param operatorId identifier of operator
    * @param applyStatefulFunction the user-defined ApplyStatefulFunction
    */
-  public ApplyStatefulWindowOperator(final String operatorId,
+  @Inject
+  public ApplyStatefulWindowOperator(@Parameter(OperatorId.class) final String operatorId,
                                      final ApplyStatefulFunction<IN, OUT> applyStatefulFunction) {
     super(operatorId);
     this.applyStatefulFunction = applyStatefulFunction;

--- a/src/main/java/edu/snu/mist/common/operators/CountWindowOperator.java
+++ b/src/main/java/edu/snu/mist/common/operators/CountWindowOperator.java
@@ -17,7 +17,12 @@ package edu.snu.mist.common.operators;
 
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.MistWatermarkEvent;
+import edu.snu.mist.common.parameters.OperatorId;
+import edu.snu.mist.common.parameters.WindowInterval;
+import edu.snu.mist.common.parameters.WindowSize;
+import org.apache.reef.tang.annotations.Parameter;
 
+import javax.inject.Inject;
 import java.util.logging.Logger;
 
 /**
@@ -32,9 +37,10 @@ public final class CountWindowOperator<T> extends FixedSizeWindowOperator<T> {
    */
   private long count;
 
-  public CountWindowOperator(final String operatorId,
-                             final int windowSize,
-                             final int windowEmissionInterval) {
+  @Inject
+  public CountWindowOperator(@Parameter(OperatorId.class) final String operatorId,
+                             @Parameter(WindowSize.class) final int windowSize,
+                             @Parameter(WindowInterval.class) final int windowEmissionInterval) {
     super(operatorId, windowSize, windowEmissionInterval);
     this.count = 1L;
   }

--- a/src/main/java/edu/snu/mist/common/operators/FilterOperator.java
+++ b/src/main/java/edu/snu/mist/common/operators/FilterOperator.java
@@ -17,7 +17,10 @@ package edu.snu.mist.common.operators;
 
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.MistWatermarkEvent;
+import edu.snu.mist.common.parameters.OperatorId;
+import org.apache.reef.tang.annotations.Parameter;
 
+import javax.inject.Inject;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -34,7 +37,8 @@ public final class FilterOperator<I> extends OneStreamOperator {
    */
   private final Predicate<I> filterFunc;
 
-  public FilterOperator(final String operatorId,
+  @Inject
+  public FilterOperator(@Parameter(OperatorId.class) final String operatorId,
                         final Predicate<I> filterFunc) {
     super(operatorId);
     this.filterFunc = filterFunc;

--- a/src/main/java/edu/snu/mist/common/operators/FlatMapOperator.java
+++ b/src/main/java/edu/snu/mist/common/operators/FlatMapOperator.java
@@ -17,7 +17,10 @@ package edu.snu.mist.common.operators;
 
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.MistWatermarkEvent;
+import edu.snu.mist.common.parameters.OperatorId;
+import org.apache.reef.tang.annotations.Parameter;
 
+import javax.inject.Inject;
 import java.util.List;
 import java.util.function.Function;
 import java.util.logging.Level;
@@ -34,11 +37,13 @@ public final class FlatMapOperator<I, O> extends OneStreamOperator {
    */
   private final Function<I, List<O>> flatMapFunc;
 
-  public FlatMapOperator(final String operatorId,
+  @Inject
+  public FlatMapOperator(@Parameter(OperatorId.class) final String operatorId,
                          final Function<I, List<O>> flatMapFunc) {
     super(operatorId);
     this.flatMapFunc = flatMapFunc;
   }
+
 
   /**
    * FlatMaps the list of outputs.

--- a/src/main/java/edu/snu/mist/common/operators/JoinOperator.java
+++ b/src/main/java/edu/snu/mist/common/operators/JoinOperator.java
@@ -15,12 +15,15 @@
  */
 package edu.snu.mist.common.operators;
 
+import edu.snu.mist.common.parameters.OperatorId;
 import edu.snu.mist.common.types.Tuple2;
 import edu.snu.mist.common.windows.WindowData;
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.MistWatermarkEvent;
 import edu.snu.mist.common.windows.WindowImpl;
+import org.apache.reef.tang.annotations.Parameter;
 
+import javax.inject.Inject;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -42,7 +45,8 @@ public final class JoinOperator<T, U> extends OneStreamOperator {
    */
   private final BiPredicate<T, U> joinBiPredicate;
 
-  public JoinOperator(final String operatorId,
+  @Inject
+  public JoinOperator(@Parameter(OperatorId.class) final String operatorId,
                       final BiPredicate<T, U> joinBiPredicate) {
     super(operatorId);
     this.joinBiPredicate = joinBiPredicate;

--- a/src/main/java/edu/snu/mist/common/operators/MapOperator.java
+++ b/src/main/java/edu/snu/mist/common/operators/MapOperator.java
@@ -17,7 +17,10 @@ package edu.snu.mist.common.operators;
 
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.MistWatermarkEvent;
+import edu.snu.mist.common.parameters.OperatorId;
+import org.apache.reef.tang.annotations.Parameter;
 
+import javax.inject.Inject;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -35,7 +38,8 @@ public final class MapOperator<I, O> extends OneStreamOperator {
    */
   private final Function<I, O> mapFunc;
 
-  public MapOperator(final String operatorId,
+  @Inject
+  public MapOperator(@Parameter(OperatorId.class) final String operatorId,
                      final Function<I, O> mapFunc) {
     super(operatorId);
     this.mapFunc = mapFunc;

--- a/src/main/java/edu/snu/mist/common/operators/ReduceByKeyOperator.java
+++ b/src/main/java/edu/snu/mist/common/operators/ReduceByKeyOperator.java
@@ -15,10 +15,14 @@
  */
 package edu.snu.mist.common.operators;
 
+import edu.snu.mist.common.parameters.KeyIndex;
+import edu.snu.mist.common.parameters.OperatorId;
 import edu.snu.mist.common.types.Tuple2;
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.MistWatermarkEvent;
+import org.apache.reef.tang.annotations.Parameter;
 
+import javax.inject.Inject;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.function.BiFunction;
@@ -57,8 +61,9 @@ public final class ReduceByKeyOperator<K extends Serializable, V extends Seriali
    * @param operatorId identifier of operator
    * @param keyIndex index of key
    */
-  public ReduceByKeyOperator(final String operatorId,
-                             final int keyIndex,
+  @Inject
+  public ReduceByKeyOperator(@Parameter(OperatorId.class) final String operatorId,
+                             @Parameter(KeyIndex.class) final int keyIndex,
                              final BiFunction<V, V, V> reduceFunc) {
     super(operatorId);
     this.reduceFunc = reduceFunc;

--- a/src/main/java/edu/snu/mist/common/operators/SessionWindowOperator.java
+++ b/src/main/java/edu/snu/mist/common/operators/SessionWindowOperator.java
@@ -17,9 +17,13 @@ package edu.snu.mist.common.operators;
 
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.MistWatermarkEvent;
+import edu.snu.mist.common.parameters.OperatorId;
+import edu.snu.mist.common.parameters.WindowInterval;
 import edu.snu.mist.common.windows.Window;
 import edu.snu.mist.common.windows.WindowImpl;
+import org.apache.reef.tang.annotations.Parameter;
 
+import javax.inject.Inject;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -43,8 +47,9 @@ public final class SessionWindowOperator<T> extends OneStreamOperator {
    */
   private Window<T> currentWindow;
 
-  public SessionWindowOperator(final String operatorId,
-                               final int sessionInterval) {
+  @Inject
+  public SessionWindowOperator(@Parameter(OperatorId.class) final String operatorId,
+                               @Parameter(WindowInterval.class) final int sessionInterval) {
     super(operatorId);
     this.sessionInterval = sessionInterval;
     currentWindow = null;

--- a/src/main/java/edu/snu/mist/common/operators/TimeWindowOperator.java
+++ b/src/main/java/edu/snu/mist/common/operators/TimeWindowOperator.java
@@ -17,7 +17,12 @@ package edu.snu.mist.common.operators;
 
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.MistWatermarkEvent;
+import edu.snu.mist.common.parameters.OperatorId;
+import edu.snu.mist.common.parameters.WindowInterval;
+import edu.snu.mist.common.parameters.WindowSize;
+import org.apache.reef.tang.annotations.Parameter;
 
+import javax.inject.Inject;
 import java.util.logging.Logger;
 
 /**
@@ -27,9 +32,10 @@ import java.util.logging.Logger;
 public final class TimeWindowOperator<T> extends FixedSizeWindowOperator<T> {
   private static final Logger LOG = Logger.getLogger(TimeWindowOperator.class.getName());
 
-  public TimeWindowOperator(final String operatorId,
-                            final int windowSize,
-                            final int windowEmissionInterval) {
+  @Inject
+  public TimeWindowOperator(@Parameter(OperatorId.class) final String operatorId,
+                            @Parameter(WindowSize.class) final int windowSize,
+                            @Parameter(WindowInterval.class) final int windowEmissionInterval) {
     super(operatorId, windowSize, windowEmissionInterval);
   }
 

--- a/src/main/java/edu/snu/mist/common/operators/UnionOperator.java
+++ b/src/main/java/edu/snu/mist/common/operators/UnionOperator.java
@@ -17,7 +17,10 @@ package edu.snu.mist.common.operators;
 
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.MistWatermarkEvent;
+import edu.snu.mist.common.parameters.OperatorId;
+import org.apache.reef.tang.annotations.Parameter;
 
+import javax.inject.Inject;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.logging.Level;
@@ -42,7 +45,8 @@ public final class UnionOperator extends TwoStreamOperator {
   private long recentLeftTimestamp;
   private long recentRightTimestamp;
 
-  public UnionOperator(final String operatorId) {
+  @Inject
+  public UnionOperator(@Parameter(OperatorId.class) final String operatorId) {
     super(operatorId);
     this.leftUpstreamQueue = new LinkedBlockingQueue<>();
     this.rightUpstreamQueue = new LinkedBlockingQueue<>();

--- a/src/main/java/edu/snu/mist/common/parameters/JarFilePaths.java
+++ b/src/main/java/edu/snu/mist/common/parameters/JarFilePaths.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.common.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+import java.util.List;
+
+@NamedParameter(doc = "Jar file paths that will be used for loading class loaders")
+public final class JarFilePaths implements Name<List<String>> {
+  // empty
+}

--- a/src/main/java/edu/snu/mist/common/parameters/KafkaTopic.java
+++ b/src/main/java/edu/snu/mist/common/parameters/KafkaTopic.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.common.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Kafka topic")
+public final class KafkaTopic implements Name<String> {
+  // empty
+}

--- a/src/main/java/edu/snu/mist/common/parameters/PeriodicWatermarkDelay.java
+++ b/src/main/java/edu/snu/mist/common/parameters/PeriodicWatermarkDelay.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.common.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Periodic watermark's delay that delays the watermark's timestamps")
+public final class PeriodicWatermarkDelay implements Name<Long> {
+  // empty
+}

--- a/src/main/java/edu/snu/mist/common/parameters/PeriodicWatermarkPeriod.java
+++ b/src/main/java/edu/snu/mist/common/parameters/PeriodicWatermarkPeriod.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.common.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Periodic watermarks are generated every this period")
+public final class PeriodicWatermarkPeriod implements Name<Long> {
+  // empty
+}

--- a/src/main/java/edu/snu/mist/common/parameters/WindowInterval.java
+++ b/src/main/java/edu/snu/mist/common/parameters/WindowInterval.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.common.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Window interval (time or number)")
+public final class WindowInterval implements Name<Integer> {
+}

--- a/src/main/java/edu/snu/mist/common/parameters/WindowSize.java
+++ b/src/main/java/edu/snu/mist/common/parameters/WindowSize.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.common.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Window size (sec or number)")
+public final class WindowSize implements Name<Integer> {
+}

--- a/src/main/java/edu/snu/mist/common/sinks/NettyTextSink.java
+++ b/src/main/java/edu/snu/mist/common/sinks/NettyTextSink.java
@@ -16,13 +16,18 @@
 package edu.snu.mist.common.sinks;
 
 import edu.snu.mist.common.OutputEmitter;
+import edu.snu.mist.common.parameters.OperatorId;
+import edu.snu.mist.common.parameters.SocketServerIp;
+import edu.snu.mist.common.parameters.SocketServerPort;
 import edu.snu.mist.common.shared.NettySharedResource;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import org.apache.reef.io.network.util.StringIdentifierFactory;
+import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.wake.Identifier;
 
+import javax.inject.Inject;
 import java.io.IOException;
 
 /**
@@ -50,10 +55,11 @@ public final class NettyTextSink implements Sink<String> {
    */
   private final String newline = System.getProperty("line.separator");
 
+  @Inject
   public NettyTextSink(
-      final String sinkId,
-      final String serverAddress,
-      final int port,
+      @Parameter(OperatorId.class) final String sinkId,
+      @Parameter(SocketServerIp.class) final String serverAddress,
+      @Parameter(SocketServerPort.class) final int port,
       final NettySharedResource sharedResource,
       final StringIdentifierFactory identifierFactory) throws IOException {
     this.sinkId = identifierFactory.getNewInstance(sinkId);

--- a/src/main/java/edu/snu/mist/common/sources/KafkaDataGenerator.java
+++ b/src/main/java/edu/snu/mist/common/sources/KafkaDataGenerator.java
@@ -15,11 +15,14 @@
  */
 package edu.snu.mist.common.sources;
 
+import edu.snu.mist.common.parameters.KafkaTopic;
 import edu.snu.mist.common.shared.KafkaSharedResource;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.reef.tang.annotations.Parameter;
 
+import javax.inject.Inject;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Map;
@@ -73,8 +76,9 @@ public final class KafkaDataGenerator<K, V> implements DataGenerator<ConsumerRec
    */
   private EventGenerator<ConsumerRecord<K, V>> eventGenerator;
 
+  @Inject
   public KafkaDataGenerator(
-      final String topic,
+      @Parameter(KafkaTopic.class) final String topic,
       final Map<String, Object> kafkaConsumerConf,
       final KafkaSharedResource kafkaSharedResource) {
     this.started = new AtomicBoolean(false);

--- a/src/main/java/edu/snu/mist/common/sources/NettyTextDataGenerator.java
+++ b/src/main/java/edu/snu/mist/common/sources/NettyTextDataGenerator.java
@@ -15,12 +15,16 @@
  */
 package edu.snu.mist.common.sources;
 
+import edu.snu.mist.common.parameters.SocketServerIp;
+import edu.snu.mist.common.parameters.SocketServerPort;
 import edu.snu.mist.common.shared.NettySharedResource;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.wake.EventHandler;
 
+import javax.inject.Inject;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -62,9 +66,10 @@ public final class NettyTextDataGenerator implements DataGenerator<String> {
    */
   private EventGenerator eventGenerator;
 
+  @Inject
   public NettyTextDataGenerator(
-      final String serverAddr,
-      final int port,
+      @Parameter(SocketServerIp.class) final String serverAddr,
+      @Parameter(SocketServerPort.class) final int port,
       final NettySharedResource resource) throws IOException {
     this.clientBootstrap = resource.getClientBootstrap();
     this.channelMap = resource.getChannelMap();

--- a/src/main/java/edu/snu/mist/common/sources/PeriodicEventGenerator.java
+++ b/src/main/java/edu/snu/mist/common/sources/PeriodicEventGenerator.java
@@ -16,8 +16,12 @@
 package edu.snu.mist.common.sources;
 
 import edu.snu.mist.common.MistWatermarkEvent;
+import edu.snu.mist.common.parameters.PeriodicWatermarkDelay;
+import edu.snu.mist.common.parameters.PeriodicWatermarkPeriod;
 import org.apache.reef.io.Tuple;
+import org.apache.reef.tang.annotations.Parameter;
 
+import javax.inject.Inject;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -53,8 +57,19 @@ public final class PeriodicEventGenerator<I, V> extends EventGeneratorImpl<I, V>
    */
   private ScheduledFuture result;
 
+  @Inject
+  public PeriodicEventGenerator(@Parameter(PeriodicWatermarkPeriod.class) final long period,
+                                @Parameter(PeriodicWatermarkDelay.class) final long expectedDelay,
+                                final TimeUnit timeUnit,
+                                final ScheduledExecutorService scheduler) {
+    this(null, period, expectedDelay, timeUnit, scheduler);
+  }
+
+  @Inject
   public PeriodicEventGenerator(final Function<I, Tuple<V, Long>> extractTimestampFunc,
-                                final long period, final long expectedDelay, final TimeUnit timeUnit,
+                                @Parameter(PeriodicWatermarkPeriod.class) final long period,
+                                @Parameter(PeriodicWatermarkDelay.class) final long expectedDelay,
+                                final TimeUnit timeUnit,
                                 final ScheduledExecutorService scheduler) {
     super(extractTimestampFunc);
     if (period <= 0L || expectedDelay < 0L) {

--- a/src/main/java/edu/snu/mist/common/sources/PunctuatedEventGenerator.java
+++ b/src/main/java/edu/snu/mist/common/sources/PunctuatedEventGenerator.java
@@ -16,8 +16,10 @@
 package edu.snu.mist.common.sources;
 
 import edu.snu.mist.common.MistWatermarkEvent;
+import edu.snu.mist.common.functions.WatermarkTimestampFunction;
 import org.apache.reef.io.Tuple;
 
+import javax.inject.Inject;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -38,8 +40,18 @@ public final class PunctuatedEventGenerator<I, V> extends EventGeneratorImpl<I, 
    */
   private final Function<I, Long> parseTimestamp;
 
-  public PunctuatedEventGenerator(final Function<I, Tuple<V, Long>> extractTimestampFunc,
-                                  final Predicate<I> isWatermark, final Function<I, Long> parseTimestamp) {
+  @Inject
+  public PunctuatedEventGenerator(
+      final Predicate<I> isWatermark,
+      final WatermarkTimestampFunction<I> parseTimestamp) {
+    this(null, isWatermark, parseTimestamp);
+  }
+
+  @Inject
+  public PunctuatedEventGenerator(
+      final Function<I, Tuple<V, Long>> extractTimestampFunc,
+      final Predicate<I> isWatermark,
+      final WatermarkTimestampFunction<I> parseTimestamp) {
     super(extractTimestampFunc);
     this.isWatermark = isWatermark;
     this.parseTimestamp = parseTimestamp;

--- a/src/main/java/edu/snu/mist/core/task/DefaultPhysicalPlanGeneratorImpl.java
+++ b/src/main/java/edu/snu/mist/core/task/DefaultPhysicalPlanGeneratorImpl.java
@@ -20,6 +20,7 @@ import edu.snu.mist.common.DAG;
 import edu.snu.mist.common.ExternalJarObjectInputStream;
 import edu.snu.mist.common.PhysicalVertex;
 import edu.snu.mist.common.functions.ApplyStatefulFunction;
+import edu.snu.mist.common.functions.WatermarkTimestampFunction;
 import edu.snu.mist.common.operators.*;
 import edu.snu.mist.common.parameters.*;
 import edu.snu.mist.common.shared.KafkaSharedResource;
@@ -141,7 +142,7 @@ final class DefaultPhysicalPlanGeneratorImpl implements PhysicalPlanGenerator {
           final Predicate<I> isWatermark =
               deserializeLambda((ByteBuffer) watermarkConfString.get(
                   PunctuatedWatermarkParameters.WATERMARK_PREDICATE), classLoader);
-          final Function<I, Long> parseTimestamp =
+          final WatermarkTimestampFunction<I> parseTimestamp =
               deserializeLambda((ByteBuffer) watermarkConfString.get(
                   PunctuatedWatermarkParameters.PARSING_TIMESTAMP_FROM_WATERMARK), classLoader);
           return new PunctuatedEventGenerator<>(timestampExtractionFunc, isWatermark, parseTimestamp);

--- a/src/test/java/edu/snu/mist/common/sources/NettySourceTest.java
+++ b/src/test/java/edu/snu/mist/common/sources/NettySourceTest.java
@@ -18,6 +18,7 @@ package edu.snu.mist.common.sources;
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.MistWatermarkEvent;
 import edu.snu.mist.common.OutputEmitter;
+import edu.snu.mist.common.functions.WatermarkTimestampFunction;
 import edu.snu.mist.common.shared.NettySharedResource;
 import edu.snu.mist.common.stream.NettyChannelHandler;
 import edu.snu.mist.common.stream.textmessage.NettyTextMessageStreamGenerator;
@@ -115,7 +116,7 @@ public final class NettySourceTest {
         final Function<String, Tuple<String, Long>> extractFunc = (input) ->
             new Tuple<>(input.toString().split(":")[0], Long.parseLong(input.toString().split(":")[1]));
         final Predicate<String> isWatermark = (input) -> input.toString().split(":")[0].equals("Watermark");
-        final Function<String, Long> parseTsFunc =
+        final WatermarkTimestampFunction<String> parseTsFunc =
             (input) -> Long.parseLong(input.toString().split(":")[1]);
         final EventGenerator<String> eventGenerator =
             new PunctuatedEventGenerator<>(extractFunc, isWatermark, parseTsFunc);


### PR DESCRIPTION
**This PR should be merged after #380 **

This PR addressed #379 by
* making sources, operators, and sinks `injectable` 

Closes #379 