### PR TITLE
[MIST-391] Change the use of Functional Interfaces to MIST interfaces

### DIFF
--- a/src/main/java/edu/snu/mist/common/operators/AggregateWindowOperator.java
+++ b/src/main/java/edu/snu/mist/common/operators/AggregateWindowOperator.java
@@ -15,17 +15,17 @@
  */
 package edu.snu.mist.common.operators;
 
+import edu.snu.mist.common.MistDataEvent;
+import edu.snu.mist.common.MistWatermarkEvent;
 import edu.snu.mist.common.SerializeUtils;
+import edu.snu.mist.common.functions.MISTFunction;
 import edu.snu.mist.common.parameters.OperatorId;
 import edu.snu.mist.common.parameters.SerializedUdf;
 import edu.snu.mist.common.windows.WindowData;
-import edu.snu.mist.common.MistDataEvent;
-import edu.snu.mist.common.MistWatermarkEvent;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
 import java.io.IOException;
-import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -42,7 +42,7 @@ public final class AggregateWindowOperator<IN, OUT>
   /**
    * The function that processes the input WindowData.
    */
-  private final Function<WindowData<IN>, OUT> aggregateFunc;
+  private final MISTFunction<WindowData<IN>, OUT> aggregateFunc;
 
   @Inject
   private AggregateWindowOperator(
@@ -58,7 +58,7 @@ public final class AggregateWindowOperator<IN, OUT>
    */
   @Inject
   public AggregateWindowOperator(@Parameter(OperatorId.class) final String operatorId,
-                                 final Function<WindowData<IN>, OUT> aggregateFunc) {
+                                 final MISTFunction<WindowData<IN>, OUT> aggregateFunc) {
     super(operatorId);
     this.aggregateFunc = aggregateFunc;
   }

--- a/src/main/java/edu/snu/mist/common/operators/FilterOperator.java
+++ b/src/main/java/edu/snu/mist/common/operators/FilterOperator.java
@@ -18,13 +18,13 @@ package edu.snu.mist.common.operators;
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.MistWatermarkEvent;
 import edu.snu.mist.common.SerializeUtils;
+import edu.snu.mist.common.functions.MISTPredicate;
 import edu.snu.mist.common.parameters.OperatorId;
 import edu.snu.mist.common.parameters.SerializedUdf;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
 import java.io.IOException;
-import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -38,7 +38,7 @@ public final class FilterOperator<I> extends OneStreamOperator {
   /**
    * Filter function.
    */
-  private final Predicate<I> filterFunc;
+  private final MISTPredicate<I> filterFunc;
 
   @Inject
   private FilterOperator(
@@ -50,7 +50,7 @@ public final class FilterOperator<I> extends OneStreamOperator {
 
   @Inject
   public FilterOperator(@Parameter(OperatorId.class) final String operatorId,
-                        final Predicate<I> filterFunc) {
+                        final MISTPredicate<I> filterFunc) {
     super(operatorId);
     this.filterFunc = filterFunc;
   }

--- a/src/main/java/edu/snu/mist/common/operators/FlatMapOperator.java
+++ b/src/main/java/edu/snu/mist/common/operators/FlatMapOperator.java
@@ -18,6 +18,7 @@ package edu.snu.mist.common.operators;
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.MistWatermarkEvent;
 import edu.snu.mist.common.SerializeUtils;
+import edu.snu.mist.common.functions.MISTFunction;
 import edu.snu.mist.common.parameters.OperatorId;
 import edu.snu.mist.common.parameters.SerializedUdf;
 import org.apache.reef.tang.annotations.Parameter;
@@ -25,7 +26,6 @@ import org.apache.reef.tang.annotations.Parameter;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.util.List;
-import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -38,7 +38,7 @@ public final class FlatMapOperator<I, O> extends OneStreamOperator {
   /**
    * FlatMap function.
    */
-  private final Function<I, List<O>> flatMapFunc;
+  private final MISTFunction<I, List<O>> flatMapFunc;
 
   @Inject
   private FlatMapOperator(
@@ -50,7 +50,7 @@ public final class FlatMapOperator<I, O> extends OneStreamOperator {
 
   @Inject
   public FlatMapOperator(@Parameter(OperatorId.class) final String operatorId,
-                         final Function<I, List<O>> flatMapFunc) {
+                         final MISTFunction<I, List<O>> flatMapFunc) {
     super(operatorId);
     this.flatMapFunc = flatMapFunc;
   }

--- a/src/main/java/edu/snu/mist/common/operators/JoinOperator.java
+++ b/src/main/java/edu/snu/mist/common/operators/JoinOperator.java
@@ -15,13 +15,14 @@
  */
 package edu.snu.mist.common.operators;
 
+import edu.snu.mist.common.MistDataEvent;
+import edu.snu.mist.common.MistWatermarkEvent;
 import edu.snu.mist.common.SerializeUtils;
+import edu.snu.mist.common.functions.MISTBiPredicate;
 import edu.snu.mist.common.parameters.OperatorId;
 import edu.snu.mist.common.parameters.SerializedUdf;
 import edu.snu.mist.common.types.Tuple2;
 import edu.snu.mist.common.windows.WindowData;
-import edu.snu.mist.common.MistDataEvent;
-import edu.snu.mist.common.MistWatermarkEvent;
 import edu.snu.mist.common.windows.WindowImpl;
 import org.apache.reef.tang.annotations.Parameter;
 
@@ -30,7 +31,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
-import java.util.function.BiPredicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -46,7 +46,7 @@ public final class JoinOperator<T, U> extends OneStreamOperator {
   /**
    * The user-defined predicate which checks whether two inputs from both stream are matched or not.
    */
-  private final BiPredicate<T, U> joinBiPredicate;
+  private final MISTBiPredicate<T, U> joinBiPredicate;
 
   @Inject
   private JoinOperator(
@@ -58,7 +58,7 @@ public final class JoinOperator<T, U> extends OneStreamOperator {
 
   @Inject
   public JoinOperator(@Parameter(OperatorId.class) final String operatorId,
-                      final BiPredicate<T, U> joinBiPredicate) {
+                      final MISTBiPredicate<T, U> joinBiPredicate) {
     super(operatorId);
     this.joinBiPredicate = joinBiPredicate;
   }

--- a/src/main/java/edu/snu/mist/common/operators/MapOperator.java
+++ b/src/main/java/edu/snu/mist/common/operators/MapOperator.java
@@ -18,13 +18,13 @@ package edu.snu.mist.common.operators;
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.MistWatermarkEvent;
 import edu.snu.mist.common.SerializeUtils;
+import edu.snu.mist.common.functions.MISTFunction;
 import edu.snu.mist.common.parameters.OperatorId;
 import edu.snu.mist.common.parameters.SerializedUdf;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
 import java.io.IOException;
-import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -39,7 +39,7 @@ public final class MapOperator<I, O> extends OneStreamOperator {
   /**
    * Map function.
    */
-  private final Function<I, O> mapFunc;
+  private final MISTFunction<I, O> mapFunc;
 
   @Inject
   private MapOperator(
@@ -51,7 +51,7 @@ public final class MapOperator<I, O> extends OneStreamOperator {
 
   @Inject
   public MapOperator(@Parameter(OperatorId.class) final String operatorId,
-                     final Function<I, O> mapFunc) {
+                     final MISTFunction<I, O> mapFunc) {
     super(operatorId);
     this.mapFunc = mapFunc;
   }

--- a/src/main/java/edu/snu/mist/common/operators/ReduceByKeyOperator.java
+++ b/src/main/java/edu/snu/mist/common/operators/ReduceByKeyOperator.java
@@ -15,20 +15,20 @@
  */
 package edu.snu.mist.common.operators;
 
+import edu.snu.mist.common.MistDataEvent;
+import edu.snu.mist.common.MistWatermarkEvent;
 import edu.snu.mist.common.SerializeUtils;
+import edu.snu.mist.common.functions.MISTBiFunction;
 import edu.snu.mist.common.parameters.KeyIndex;
 import edu.snu.mist.common.parameters.OperatorId;
 import edu.snu.mist.common.parameters.SerializedUdf;
 import edu.snu.mist.common.types.Tuple2;
-import edu.snu.mist.common.MistDataEvent;
-import edu.snu.mist.common.MistWatermarkEvent;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
-import java.util.function.BiFunction;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -47,7 +47,7 @@ public final class ReduceByKeyOperator<K extends Serializable, V extends Seriali
   /**
    * A reduce function.
    */
-  private final BiFunction<V, V, V> reduceFunc;
+  private final MISTBiFunction<V, V, V> reduceFunc;
 
   /**
    * An index of key.
@@ -76,7 +76,7 @@ public final class ReduceByKeyOperator<K extends Serializable, V extends Seriali
   @Inject
   public ReduceByKeyOperator(@Parameter(OperatorId.class) final String operatorId,
                              @Parameter(KeyIndex.class) final int keyIndex,
-                             final BiFunction<V, V, V> reduceFunc) {
+                             final MISTBiFunction<V, V, V> reduceFunc) {
     super(operatorId);
     this.reduceFunc = reduceFunc;
     this.keyIndex = keyIndex;

--- a/src/main/java/edu/snu/mist/common/sources/EventGeneratorImpl.java
+++ b/src/main/java/edu/snu/mist/common/sources/EventGeneratorImpl.java
@@ -17,10 +17,10 @@ package edu.snu.mist.common.sources;
 
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.OutputEmitter;
+import edu.snu.mist.common.functions.MISTFunction;
 import org.apache.reef.io.Tuple;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 
 /**
  * This abstract class represents the basic event generator.
@@ -38,14 +38,14 @@ public abstract class EventGeneratorImpl<I, V> implements EventGenerator<I> {
   /**
    * The function that extract timestamp from input object.
    */
-  private final Function<I, Tuple<V, Long>> extractTimestampFunc;
+  private final MISTFunction<I, Tuple<V, Long>> extractTimestampFunc;
 
   /**
    * The emitter that is the destination of watermark.
    */
   protected OutputEmitter outputEmitter;
 
-  public EventGeneratorImpl(final Function<I, Tuple<V, Long>> extractTimestampFunc) {
+  public EventGeneratorImpl(final MISTFunction<I, Tuple<V, Long>> extractTimestampFunc) {
     this.extractTimestampFunc = extractTimestampFunc;
     this.started = new AtomicBoolean(false);
   }

--- a/src/main/java/edu/snu/mist/common/sources/PeriodicEventGenerator.java
+++ b/src/main/java/edu/snu/mist/common/sources/PeriodicEventGenerator.java
@@ -17,6 +17,7 @@ package edu.snu.mist.common.sources;
 
 import edu.snu.mist.common.MistWatermarkEvent;
 import edu.snu.mist.common.SerializeUtils;
+import edu.snu.mist.common.functions.MISTFunction;
 import edu.snu.mist.common.parameters.PeriodicWatermarkDelay;
 import edu.snu.mist.common.parameters.PeriodicWatermarkPeriod;
 import edu.snu.mist.common.parameters.SerializedTimestampExtractUdf;
@@ -28,7 +29,6 @@ import java.io.IOException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 /**
  * This class represents the watermark source that emits watermark periodically.
@@ -81,7 +81,7 @@ public final class PeriodicEventGenerator<I, V> extends EventGeneratorImpl<I, V>
   }
 
   @Inject
-  public PeriodicEventGenerator(final Function<I, Tuple<V, Long>> extractTimestampFunc,
+  public PeriodicEventGenerator(final MISTFunction<I, Tuple<V, Long>> extractTimestampFunc,
                                 @Parameter(PeriodicWatermarkPeriod.class) final long period,
                                 @Parameter(PeriodicWatermarkDelay.class) final long expectedDelay,
                                 final TimeUnit timeUnit,

--- a/src/main/java/edu/snu/mist/common/sources/PunctuatedEventGenerator.java
+++ b/src/main/java/edu/snu/mist/common/sources/PunctuatedEventGenerator.java
@@ -17,6 +17,8 @@ package edu.snu.mist.common.sources;
 
 import edu.snu.mist.common.MistWatermarkEvent;
 import edu.snu.mist.common.SerializeUtils;
+import edu.snu.mist.common.functions.MISTFunction;
+import edu.snu.mist.common.functions.MISTPredicate;
 import edu.snu.mist.common.functions.WatermarkTimestampFunction;
 import edu.snu.mist.common.parameters.SerializedTimestampExtractUdf;
 import edu.snu.mist.common.parameters.SerializedTimestampParseUdf;
@@ -26,8 +28,6 @@ import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
 import java.io.IOException;
-import java.util.function.Function;
-import java.util.function.Predicate;
 
 /**
  * This class represents the watermark source that parse the input and emits punctuated watermark.
@@ -39,12 +39,12 @@ public final class PunctuatedEventGenerator<I, V> extends EventGeneratorImpl<I, 
   /**
    * The function check whether the input is watermark or not.
    */
-  private final Predicate<I> isWatermark;
+  private final MISTPredicate<I> isWatermark;
 
   /**
    * The function get input which is watermark and parse the timestamp.
    */
-  private final Function<I, Long> parseTimestamp;
+  private final WatermarkTimestampFunction<I> parseTimestamp;
 
   @Inject
   private PunctuatedEventGenerator(
@@ -61,22 +61,22 @@ public final class PunctuatedEventGenerator<I, V> extends EventGeneratorImpl<I, 
       @Parameter(SerializedTimestampParseUdf.class) final String timestampParseObj,
       @Parameter(SerializedWatermarkPredicateUdf.class) final String isWatermarkObj,
       final ClassLoader classLoader) throws IOException, ClassNotFoundException {
-    this((Function)SerializeUtils.deserializeFromString(timestampExtractObj, classLoader),
-        (Predicate)SerializeUtils.deserializeFromString(timestampParseObj, classLoader),
+    this((MISTFunction)SerializeUtils.deserializeFromString(timestampExtractObj, classLoader),
+        (MISTPredicate)SerializeUtils.deserializeFromString(timestampParseObj, classLoader),
         (WatermarkTimestampFunction)SerializeUtils.deserializeFromString(isWatermarkObj, classLoader));
   }
 
   @Inject
   public PunctuatedEventGenerator(
-      final Predicate<I> isWatermark,
+      final MISTPredicate<I> isWatermark,
       final WatermarkTimestampFunction<I> parseTimestamp) {
     this(null, isWatermark, parseTimestamp);
   }
 
   @Inject
   public PunctuatedEventGenerator(
-      final Function<I, Tuple<V, Long>> extractTimestampFunc,
-      final Predicate<I> isWatermark,
+      final MISTFunction<I, Tuple<V, Long>> extractTimestampFunc,
+      final MISTPredicate<I> isWatermark,
       final WatermarkTimestampFunction<I> parseTimestamp) {
     super(extractTimestampFunc);
     this.isWatermark = isWatermark;

--- a/src/test/java/edu/snu/mist/common/operators/AggregateWindowOperatorTest.java
+++ b/src/test/java/edu/snu/mist/common/operators/AggregateWindowOperatorTest.java
@@ -18,6 +18,7 @@ package edu.snu.mist.common.operators;
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.MistEvent;
 import edu.snu.mist.common.MistWatermarkEvent;
+import edu.snu.mist.common.functions.MISTFunction;
 import edu.snu.mist.common.windows.WindowData;
 import edu.snu.mist.common.windows.WindowImpl;
 import org.junit.Assert;
@@ -25,7 +26,6 @@ import org.junit.Test;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.function.Function;
 
 public final class AggregateWindowOperatorTest {
 
@@ -45,7 +45,7 @@ public final class AggregateWindowOperatorTest {
     final MistWatermarkEvent watermarkEvent = new MistWatermarkEvent(101L);
 
     // functions that dealing with input WindowData
-    final Function<WindowData<Integer>, String> aggregateFunc =
+    final MISTFunction<WindowData<Integer>, String> aggregateFunc =
         (windowData) -> {
           return windowData.getDataCollection().toString() + ", " + windowData.getStart() + ", " + windowData.getEnd();
         };

--- a/src/test/java/edu/snu/mist/common/operators/JoinOperatorTest.java
+++ b/src/test/java/edu/snu/mist/common/operators/JoinOperatorTest.java
@@ -18,6 +18,7 @@ package edu.snu.mist.common.operators;
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.MistEvent;
 import edu.snu.mist.common.MistWatermarkEvent;
+import edu.snu.mist.common.functions.MISTBiPredicate;
 import edu.snu.mist.common.types.Tuple2;
 import edu.snu.mist.common.windows.WindowData;
 import edu.snu.mist.common.windows.WindowImpl;
@@ -28,7 +29,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.function.BiPredicate;
 
 public final class JoinOperatorTest {
 
@@ -50,7 +50,7 @@ public final class JoinOperatorTest {
     final MistWatermarkEvent watermarkEvent = new MistWatermarkEvent(101L);
 
     // predicate that tests whether two input data have same key or not
-    final BiPredicate<Tuple2<String, Integer>, Tuple2<Integer, Long>> joinPredicate =
+    final MISTBiPredicate<Tuple2<String, Integer>, Tuple2<Integer, Long>> joinPredicate =
         (tuple1, tuple2) -> tuple1.get(1).equals(tuple2.get(0));
 
     final JoinOperator<Tuple2<String, Integer>, Tuple2<Integer, Long>> joinOperator =

--- a/src/test/java/edu/snu/mist/common/operators/StatefulOperatorTest.java
+++ b/src/test/java/edu/snu/mist/common/operators/StatefulOperatorTest.java
@@ -17,6 +17,7 @@ package edu.snu.mist.common.operators;
 
 import com.google.common.collect.ImmutableList;
 import edu.snu.mist.common.MistDataEvent;
+import edu.snu.mist.common.functions.MISTBiFunction;
 import edu.snu.mist.common.types.Tuple2;
 import edu.snu.mist.utils.TestOutputEmitter;
 import org.apache.reef.tang.exceptions.InjectionException;
@@ -27,7 +28,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiFunction;
 import java.util.logging.Logger;
 
 public final class StatefulOperatorTest {
@@ -90,7 +90,7 @@ public final class StatefulOperatorTest {
     // Set the key index of tuple
     final int keyIndex = 0;
     // Reduce function for word count
-    final BiFunction<Integer, Integer, Integer> wordCountFunc = (oldVal, val) -> oldVal + val;
+    final MISTBiFunction<Integer, Integer, Integer> wordCountFunc = (oldVal, val) -> oldVal + val;
     final ReduceByKeyOperator<String, Integer> wcOperator =
         new ReduceByKeyOperator<>(operatorId, keyIndex, wordCountFunc);
 

--- a/src/test/java/edu/snu/mist/common/operators/StatelessOperatorTest.java
+++ b/src/test/java/edu/snu/mist/common/operators/StatelessOperatorTest.java
@@ -17,6 +17,8 @@ package edu.snu.mist.common.operators;
 
 import com.google.common.collect.ImmutableList;
 import edu.snu.mist.common.MistDataEvent;
+import edu.snu.mist.common.functions.MISTFunction;
+import edu.snu.mist.common.functions.MISTPredicate;
 import edu.snu.mist.utils.TestOutputEmitter;
 import org.apache.reef.io.Tuple;
 import org.apache.reef.tang.exceptions.InjectionException;
@@ -26,8 +28,6 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.function.Function;
-import java.util.function.Predicate;
 
 public final class StatelessOperatorTest {
 
@@ -61,7 +61,7 @@ public final class StatelessOperatorTest {
     final List<Tuple> expected = Arrays.asList(outputs);
 
     // map function: convert string to tuple
-    final Function<String, Tuple> mapFunc = (mapInput) -> new Tuple<>(mapInput, 1);
+    final MISTFunction<String, Tuple> mapFunc = (mapInput) -> new Tuple<>(mapInput, 1);
     final MapOperator<String, Tuple> mapOperator = new MapOperator<>("testMapOp", mapFunc);
     testStatelessOperator(inputStream, expected, mapOperator);
   }
@@ -82,7 +82,7 @@ public final class StatelessOperatorTest {
     final List<String> expected = Arrays.asList("alpha", "area", "application", "ally");
 
     // create a filter function
-    final Predicate<String> filterFunc = (input) -> input.startsWith("a");
+    final MISTPredicate<String> filterFunc = (input) -> input.startsWith("a");
     final FilterOperator<String> filterOperator = new FilterOperator<>("testOp", filterFunc);
     testStatelessOperator(inputStream, expected, filterOperator);
   }
@@ -101,7 +101,7 @@ public final class StatelessOperatorTest {
     final List<String> expected = Arrays.asList(outputs);
 
     // map function: splits the string by space.
-    final Function<String, List<String>> flatMapFunc = (mapInput) -> Arrays.asList(mapInput.split(" "));
+    final MISTFunction<String, List<String>> flatMapFunc = (mapInput) -> Arrays.asList(mapInput.split(" "));
     final FlatMapOperator<String, String> flatMapOperator = new FlatMapOperator<>("testOp", flatMapFunc);
     testStatelessOperator(inputStream, expected, flatMapOperator);
   }

--- a/src/test/java/edu/snu/mist/common/sources/NettySourceTest.java
+++ b/src/test/java/edu/snu/mist/common/sources/NettySourceTest.java
@@ -18,6 +18,8 @@ package edu.snu.mist.common.sources;
 import edu.snu.mist.common.MistDataEvent;
 import edu.snu.mist.common.MistWatermarkEvent;
 import edu.snu.mist.common.OutputEmitter;
+import edu.snu.mist.common.functions.MISTFunction;
+import edu.snu.mist.common.functions.MISTPredicate;
 import edu.snu.mist.common.functions.WatermarkTimestampFunction;
 import edu.snu.mist.common.shared.NettySharedResource;
 import edu.snu.mist.common.stream.NettyChannelHandler;
@@ -40,8 +42,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -113,9 +113,9 @@ public final class NettySourceTest {
         final DataGenerator<String> dataGenerator =
             new NettyTextDataGenerator(SERVER_ADDR, SERVER_PORT, nettySharedResource);
 
-        final Function<String, Tuple<String, Long>> extractFunc = (input) ->
+        final MISTFunction<String, Tuple<String, Long>> extractFunc = (input) ->
             new Tuple<>(input.toString().split(":")[0], Long.parseLong(input.toString().split(":")[1]));
-        final Predicate<String> isWatermark = (input) -> input.toString().split(":")[0].equals("Watermark");
+        final MISTPredicate<String> isWatermark = (input) -> input.toString().split(":")[0].equals("Watermark");
         final WatermarkTimestampFunction<String> parseTsFunc =
             (input) -> Long.parseLong(input.toString().split(":")[1]);
         final EventGenerator<String> eventGenerator =

--- a/src/test/java/edu/snu/mist/core/task/QueryManagerTest.java
+++ b/src/test/java/edu/snu/mist/core/task/QueryManagerTest.java
@@ -18,6 +18,9 @@ package edu.snu.mist.core.task;
 import edu.snu.mist.common.AdjacentListDAG;
 import edu.snu.mist.common.DAG;
 import edu.snu.mist.common.PhysicalVertex;
+import edu.snu.mist.common.functions.MISTBiFunction;
+import edu.snu.mist.common.functions.MISTFunction;
+import edu.snu.mist.common.functions.MISTPredicate;
 import edu.snu.mist.common.operators.*;
 import edu.snu.mist.common.sinks.Sink;
 import edu.snu.mist.common.sources.*;
@@ -43,9 +46,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -73,15 +73,15 @@ public final class QueryManagerTest {
    * and the operators are executed correctly.
    */
   // UDF functions for operators
-  private final Function<String, List<String>> flatMapFunc = (input) -> Arrays.asList(input.split(" "));
-  private final Predicate<String> filterFunc =
+  private final MISTFunction<String, List<String>> flatMapFunc = (input) -> Arrays.asList(input.split(" "));
+  private final MISTPredicate<String> filterFunc =
       (input) -> !(input.equals("a") || input.equals("or") || input.equals("the") || input.equals("of")
           || input.equals("in") || input.equals("at") || input.equals("that")
           || input.equals("out") || input.equals("were"));
-  private final Function<String, Tuple2<String, Integer>> toTupleMapFunc = (input) -> new Tuple2<>(input, 1);
-  private final BiFunction<Integer, Integer, Integer> reduceByKeyFunc = (oldVal, newVal) -> oldVal + newVal;
-  private final Function<Map<String, Integer>, String> toStringMapFunc = (input) -> input.toString();
-  private final Function<Map<String, Integer>, Integer> totalCountMapFunc =
+  private final MISTFunction<String, Tuple2<String, Integer>> toTupleMapFunc = (input) -> new Tuple2<>(input, 1);
+  private final MISTBiFunction<Integer, Integer, Integer> reduceByKeyFunc = (oldVal, newVal) -> oldVal + newVal;
+  private final MISTFunction<Map<String, Integer>, String> toStringMapFunc = (input) -> input.toString();
+  private final MISTFunction<Map<String, Integer>, Integer> totalCountMapFunc =
       (input) -> input.values().stream().reduce(0, (x, y) -> x + y);
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
This PR addressed #391 by
* changing `Predicate` to `MISTPredicate`
* changing `Function` to `MISTFunction`
* changing `BiFunction` to `MISTBiFunction`
* changing `BiPredicate` to `MISTBiPredicate`

Closes #391 