### PR TITLE
[MIST-412] Deserialize Configuration in PhysicalPlanGenerator

### DIFF
--- a/src/main/java/edu/snu/mist/core/task/PhysicalObjectGenerator.java
+++ b/src/main/java/edu/snu/mist/core/task/PhysicalObjectGenerator.java
@@ -26,12 +26,8 @@ import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.InjectionException;
-import org.apache.reef.tang.formats.AvroConfigurationSerializer;
-import org.apache.reef.tang.implementation.java.ClassHierarchyImpl;
 
 import javax.inject.Inject;
-import java.io.IOException;
-import java.net.URL;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -40,11 +36,6 @@ import java.util.concurrent.TimeUnit;
  * from serialized configurations.
  */
 final class PhysicalObjectGenerator implements AutoCloseable {
-
-  /**
-   * Avro configuration serializer that serializes/deserializes objects.
-   */
-  private final AvroConfigurationSerializer avroSerializer;
 
   /**
    * Scheduled executor for event generators.
@@ -67,11 +58,9 @@ final class PhysicalObjectGenerator implements AutoCloseable {
   private final NettySharedResource nettySharedResource;
 
   @Inject
-  private PhysicalObjectGenerator(final AvroConfigurationSerializer avroSerializer,
-                                  final ScheduledExecutorServiceWrapper schedulerWrapper,
+  private PhysicalObjectGenerator(final ScheduledExecutorServiceWrapper schedulerWrapper,
                                   final KafkaSharedResource kafkaSharedResource,
                                   final NettySharedResource nettySharedResource) {
-    this.avroSerializer = avroSerializer;
     this.scheduler = schedulerWrapper.getScheduler();
     this.kafkaSharedResource = kafkaSharedResource;
     this.nettySharedResource = nettySharedResource;
@@ -79,16 +68,11 @@ final class PhysicalObjectGenerator implements AutoCloseable {
 
   /**
    * Get an injector from the serialized configuration with the external class loader.
-   * @param confString serialized configuration
    * @param classLoader external class loader
-   * @param urls urls for jar paths
    * @return injector
    */
-  private Injector newDefaultInjector(final String confString,
-                                      final ClassLoader classLoader,
-                                      final URL[] urls) throws IOException {
-    final Configuration conf = avroSerializer.fromString(confString,
-        new ClassHierarchyImpl(urls));
+  private Injector newDefaultInjector(final Configuration conf,
+                                      final ClassLoader classLoader) {
     final Injector injector = Tang.Factory.getTang().newInjector(conf);
     injector.bindVolatileInstance(ClassLoader.class, classLoader);
     return injector;
@@ -96,18 +80,16 @@ final class PhysicalObjectGenerator implements AutoCloseable {
 
   /**
    * Get a new event generator.
-   * @param confString serialized configuration
+   * @param conf configuration
    * @param classLoader external class loader
-   * @param urls urls for jar paths
    * @param <T> event type
    * @return event generator
    */
   @SuppressWarnings("unchecked")
   public <T> EventGenerator<T> newEventGenerator(
-      final String confString,
-      final ClassLoader classLoader,
-      final URL[] urls) throws IOException, InjectionException {
-    final Injector injector = newDefaultInjector(confString, classLoader, urls);
+      final Configuration conf,
+      final ClassLoader classLoader) throws InjectionException {
+    final Injector injector = newDefaultInjector(conf, classLoader);
     injector.bindVolatileInstance(TimeUnit.class, watermarkTimeUnit);
     injector.bindVolatileInstance(ScheduledExecutorService.class, scheduler);
     return injector.getInstance(EventGenerator.class);
@@ -115,18 +97,16 @@ final class PhysicalObjectGenerator implements AutoCloseable {
 
   /**
    * Get a new data generator.
-   * @param confString serialized configuration
+   * @param conf configuration
    * @param classLoader external class loader
-   * @param urls urls for jar paths
    * @param <T> data type
    * @return data generator
    */
   @SuppressWarnings("unchecked")
   public <T> DataGenerator<T> newDataGenerator(
-      final String confString,
-      final ClassLoader classLoader,
-      final URL[] urls) throws IOException, InjectionException {
-    final Injector injector = newDefaultInjector(confString, classLoader, urls);
+      final Configuration conf,
+      final ClassLoader classLoader) throws InjectionException {
+    final Injector injector = newDefaultInjector(conf, classLoader);
     // for netty
     injector.bindVolatileInstance(NettySharedResource.class, nettySharedResource);
     // for kafka
@@ -137,18 +117,16 @@ final class PhysicalObjectGenerator implements AutoCloseable {
   /**
    * Get a new operator.
    * @param operatorId operator id
-   * @param confString serialized configuration
+   * @param conf configuration
    * @param classLoader external class loader
-   * @param urls urls for jar paths
    * @return new operator
    */
   @SuppressWarnings("unchecked")
   public Operator newOperator(
       final String operatorId,
-      final String confString,
-      final ClassLoader classLoader,
-      final URL[] urls) throws IOException, InjectionException {
-    final Injector injector = newDefaultInjector(confString, classLoader, urls);
+      final Configuration conf,
+      final ClassLoader classLoader) throws InjectionException {
+    final Injector injector = newDefaultInjector(conf, classLoader);
     injector.bindVolatileParameter(OperatorId.class, operatorId);
     return injector.getInstance(Operator.class);
   }
@@ -156,18 +134,16 @@ final class PhysicalObjectGenerator implements AutoCloseable {
   /**
    * Get a new sink.
    * @param sinkId sink id
-   * @param confString serialized configuration
+   * @param conf configuration
    * @param classLoader external class loader
-   * @param urls urls for jar paths
    * @return new sink
    */
   @SuppressWarnings("unchecked")
   public <T> Sink<T> newSink(
       final String sinkId,
-      final String confString,
-      final ClassLoader classLoader,
-      final URL[] urls) throws IOException, InjectionException {
-    final Injector injector = newDefaultInjector(confString, classLoader, urls);
+      final Configuration conf,
+      final ClassLoader classLoader) throws InjectionException {
+    final Injector injector = newDefaultInjector(conf, classLoader);
     injector.bindVolatileParameter(OperatorId.class, sinkId);
     // for netty
     injector.bindVolatileInstance(NettySharedResource.class, nettySharedResource);

--- a/src/test/java/edu/snu/mist/core/task/PhysicalObjectGeneratorTest.java
+++ b/src/test/java/edu/snu/mist/core/task/PhysicalObjectGeneratorTest.java
@@ -66,7 +66,7 @@ public final class PhysicalObjectGeneratorTest {
   @Test(expected=InjectionException.class)
   public void testInjectionExceptionOfDataGenerator() throws IOException, InjectionException {
     final Configuration conf = UnionOperatorConfiguration.CONF.build();
-    generator.newDataGenerator(serializer.toString(conf), classLoader, urls);
+    generator.newDataGenerator(conf, classLoader);
   }
 
   @Test
@@ -76,7 +76,7 @@ public final class PhysicalObjectGeneratorTest {
         .setHostPort(13666)
         .build().getConfiguration();
     final DataGenerator<String> dataGenerator =
-        generator.newDataGenerator(serializer.toString(conf), classLoader, urls);
+        generator.newDataGenerator(conf, classLoader);
     Assert.assertTrue(dataGenerator instanceof NettyTextDataGenerator);
   }
 
@@ -89,7 +89,7 @@ public final class PhysicalObjectGeneratorTest {
         .setTimestampExtractionFunction(OperatorTestUtils.TestNettyTimestampExtractFunc.class, funcConf)
         .build().getConfiguration();
     final DataGenerator<String> dataGenerator =
-        generator.newDataGenerator(serializer.toString(conf), classLoader, urls);
+        generator.newDataGenerator(conf, classLoader);
     Assert.assertTrue(dataGenerator instanceof NettyTextDataGenerator);
   }
 
@@ -101,7 +101,7 @@ public final class PhysicalObjectGeneratorTest {
         .setConsumerConfig(kafkaConsumerConf)
         .build().getConfiguration();
     final DataGenerator dataGenerator =
-        generator.newDataGenerator(serializer.toString(conf), classLoader, urls);
+        generator.newDataGenerator(conf, classLoader);
     Assert.assertTrue(dataGenerator instanceof KafkaDataGenerator);
   }
 
@@ -115,14 +115,14 @@ public final class PhysicalObjectGeneratorTest {
         .setTimestampExtractionFunction(OperatorTestUtils.TestKafkaTimestampExtractFunc.class, funcConf)
         .build().getConfiguration();
     final DataGenerator dataGenerator =
-        generator.newDataGenerator(serializer.toString(conf), classLoader, urls);
+        generator.newDataGenerator(conf, classLoader);
     Assert.assertTrue(dataGenerator instanceof KafkaDataGenerator);
   }
 
   @Test(expected=InjectionException.class)
   public void testInjectionExceptionOfEventGenerator() throws IOException, InjectionException {
     final Configuration conf = UnionOperatorConfiguration.CONF.build();
-    generator.newEventGenerator(serializer.toString(conf), classLoader, urls);
+    generator.newEventGenerator(conf, classLoader);
   }
 
   @Test
@@ -131,7 +131,7 @@ public final class PhysicalObjectGeneratorTest {
         .setExpectedDelay(10)
         .setWatermarkPeriod(10)
         .build().getConfiguration();
-    final EventGenerator eg = generator.newEventGenerator(serializer.toString(conf), classLoader, urls);
+    final EventGenerator eg = generator.newEventGenerator(conf, classLoader);
     Assert.assertTrue(eg instanceof PeriodicEventGenerator);
   }
 
@@ -141,7 +141,7 @@ public final class PhysicalObjectGeneratorTest {
         .setParsingWatermarkFunction(input -> 1L)
         .setWatermarkPredicate(input -> true)
         .build().getConfiguration();
-    final EventGenerator eg = generator.newEventGenerator(serializer.toString(conf), classLoader, urls);
+    final EventGenerator eg = generator.newEventGenerator(conf, classLoader);
     Assert.assertTrue(eg instanceof PunctuatedEventGenerator);
   }
 
@@ -158,7 +158,7 @@ public final class PhysicalObjectGeneratorTest {
         .setTimestampExtractionFunction(OperatorTestUtils.TestNettyTimestampExtractFunc.class, funcConf)
         .build().getConfiguration();
     final Configuration conf = Configurations.merge(watermarkConf, srcConf);
-    final EventGenerator eg = generator.newEventGenerator(serializer.toString(conf), classLoader, urls);
+    final EventGenerator eg = generator.newEventGenerator(conf, classLoader);
     Assert.assertTrue(eg instanceof PunctuatedEventGenerator);
   }
 
@@ -172,7 +172,7 @@ public final class PhysicalObjectGeneratorTest {
         .setHostAddress("localhost")
         .setHostPort(13666)
         .build().getConfiguration();
-    generator.newOperator("test", serializer.toString(conf), classLoader, urls);
+    generator.newOperator("test", conf, classLoader);
   }
 
   /**
@@ -181,7 +181,7 @@ public final class PhysicalObjectGeneratorTest {
    * @return operator
    */
   private Operator getOperator(final Configuration conf) throws IOException, InjectionException {
-    return generator.newOperator("test", serializer.toString(conf), classLoader, urls);
+    return generator.newOperator("test", conf, classLoader);
   }
 
   /**
@@ -371,7 +371,7 @@ public final class PhysicalObjectGeneratorTest {
         .setHostAddress("localhost")
         .setHostPort(13666)
         .build().getConfiguration();
-    generator.newSink("test", serializer.toString(conf), classLoader, urls);
+    generator.newSink("test", conf, classLoader);
   }
 
   @Test
@@ -382,7 +382,7 @@ public final class PhysicalObjectGeneratorTest {
         .set(TextSocketSinkConfiguration.SOCKET_HOST_ADDRESS, "localhost")
         .set(TextSocketSinkConfiguration.SOCKET_HOST_PORT, port)
         .build();
-    final Sink sink = generator.newSink("test", serializer.toString(conf), classLoader, urls);
+    final Sink sink = generator.newSink("test", conf, classLoader);
     Assert.assertTrue(sink instanceof NettyTextSink);
     socket.close();
   }


### PR DESCRIPTION
This PR addressed #412 by
* moving deserialization of configuration from `PhysicalObjectGenerator` to `PhysicalPlanGenerator`

Closes #412 