### PR TITLE
[MIST-442] Renaming `SingleInputOperatorUDFConfiguration`

### DIFF
--- a/src/main/java/edu/snu/mist/api/datastreams/ContinuousStreamImpl.java
+++ b/src/main/java/edu/snu/mist/api/datastreams/ContinuousStreamImpl.java
@@ -97,9 +97,9 @@ public final class ContinuousStreamImpl<T> extends MISTStreamImpl<T> implements 
       final Serializable udf,
       final Class<? extends Operator> clazz) {
     try {
-      final Configuration opConf = SingleInputOperatorUDFConfiguration.CONF
-          .set(SingleInputOperatorUDFConfiguration.UDF_STRING, SerializeUtils.serializeToString(udf))
-          .set(SingleInputOperatorUDFConfiguration.OPERATOR, clazz)
+      final Configuration opConf = OperatorUDFConfiguration.CONF
+          .set(OperatorUDFConfiguration.UDF_STRING, SerializeUtils.serializeToString(udf))
+          .set(OperatorUDFConfiguration.OPERATOR, clazz)
           .build();
       return transformToSingleInputContinuousStream(opConf, this);
     } catch (final IOException e) {
@@ -259,9 +259,9 @@ public final class ContinuousStreamImpl<T> extends MISTStreamImpl<T> implements 
         .union(inputStream.map(secondMapFunc))
         .window(windowInfo);
     try {
-      final Configuration opConf = SingleInputOperatorUDFConfiguration.CONF
-          .set(SingleInputOperatorUDFConfiguration.UDF_STRING, SerializeUtils.serializeToString(joinBiPredicate))
-          .set(SingleInputOperatorUDFConfiguration.OPERATOR, JoinOperator.class)
+      final Configuration opConf = OperatorUDFConfiguration.CONF
+          .set(OperatorUDFConfiguration.UDF_STRING, SerializeUtils.serializeToString(joinBiPredicate))
+          .set(OperatorUDFConfiguration.OPERATOR, JoinOperator.class)
           .build();
       return transformToWindowedStream(opConf, windowedStream);
     } catch (final IOException e) {

--- a/src/main/java/edu/snu/mist/api/datastreams/WindowedStreamImpl.java
+++ b/src/main/java/edu/snu/mist/api/datastreams/WindowedStreamImpl.java
@@ -74,9 +74,9 @@ final class WindowedStreamImpl<T> extends MISTStreamImpl<WindowData<T>> implemen
   @Override
   public <R> ContinuousStream<R> aggregateWindow(final MISTFunction<WindowData<T>, R> aggregateFunc) {
     try {
-      final Configuration conf = SingleInputOperatorUDFConfiguration.CONF
-          .set(SingleInputOperatorUDFConfiguration.UDF_STRING, SerializeUtils.serializeToString(aggregateFunc))
-          .set(SingleInputOperatorUDFConfiguration.OPERATOR, AggregateWindowOperator.class)
+      final Configuration conf = OperatorUDFConfiguration.CONF
+          .set(OperatorUDFConfiguration.UDF_STRING, SerializeUtils.serializeToString(aggregateFunc))
+          .set(OperatorUDFConfiguration.OPERATOR, AggregateWindowOperator.class)
           .build();
       return transformToSingleInputContinuousStream(conf, this);
     } catch (final IOException e) {
@@ -99,10 +99,10 @@ final class WindowedStreamImpl<T> extends MISTStreamImpl<WindowData<T>> implemen
   public <R> ContinuousStream<R> applyStatefulWindow(
       final ApplyStatefulFunction<T, R> applyStatefulFunction) {
     try {
-      final Configuration conf = SingleInputOperatorUDFConfiguration.CONF
-          .set(SingleInputOperatorUDFConfiguration.UDF_STRING,
+      final Configuration conf = OperatorUDFConfiguration.CONF
+          .set(OperatorUDFConfiguration.UDF_STRING,
               SerializeUtils.serializeToString(applyStatefulFunction))
-          .set(SingleInputOperatorUDFConfiguration.OPERATOR, ApplyStatefulWindowOperator.class)
+          .set(OperatorUDFConfiguration.OPERATOR, ApplyStatefulWindowOperator.class)
           .build();
       return transformToSingleInputContinuousStream(conf, this);
     } catch (final IOException e) {

--- a/src/main/java/edu/snu/mist/api/datastreams/configurations/OperatorUDFConfiguration.java
+++ b/src/main/java/edu/snu/mist/api/datastreams/configurations/OperatorUDFConfiguration.java
@@ -26,7 +26,7 @@ import org.apache.reef.tang.formats.RequiredParameter;
  * A configuration for operators that use a single user-defined function.
  * Ex) map, flatMap, filter, applyStateful.
  */
-public final class SingleInputOperatorUDFConfiguration extends ConfigurationModuleBuilder {
+public final class OperatorUDFConfiguration extends ConfigurationModuleBuilder {
 
   /**
    * Required Parameter for binding the serialized objects of the user-defined function.
@@ -41,7 +41,7 @@ public final class SingleInputOperatorUDFConfiguration extends ConfigurationModu
   /**
    * A configuration for binding the serialized objects of the user-defined function.
    */
-  public static final ConfigurationModule CONF = new SingleInputOperatorUDFConfiguration()
+  public static final ConfigurationModule CONF = new OperatorUDFConfiguration()
       .bindNamedParameter(SerializedUdf.class, UDF_STRING)
       .bindImplementation(Operator.class, OPERATOR)
       .build();

--- a/src/test/java/edu/snu/mist/core/task/PhysicalObjectGeneratorTest.java
+++ b/src/test/java/edu/snu/mist/core/task/PhysicalObjectGeneratorTest.java
@@ -192,9 +192,9 @@ public final class PhysicalObjectGeneratorTest {
    */
   private Operator getSingleUdfOperator(final Class<? extends Operator> operatorClass,
                                         final Serializable obj) throws IOException, InjectionException {
-    final Configuration conf = SingleInputOperatorUDFConfiguration.CONF
-        .set(SingleInputOperatorUDFConfiguration.OPERATOR, operatorClass)
-        .set(SingleInputOperatorUDFConfiguration.UDF_STRING, SerializeUtils.serializeToString(obj))
+    final Configuration conf = OperatorUDFConfiguration.CONF
+        .set(OperatorUDFConfiguration.OPERATOR, operatorClass)
+        .set(OperatorUDFConfiguration.UDF_STRING, SerializeUtils.serializeToString(obj))
         .build();
     return getOperator(conf);
   }


### PR DESCRIPTION
This PR addressed #442 by 

- renaming `SingleInputOperatorUDFConfiguration` to `OperatorUDFConfiguration` because it is irrelevant with single input

Closes #442 