### PR TITLE
[MIST-469] Rename ChainedDAG to OperatorChainDAG

### DIFF
--- a/src/main/avro/client_to_task_msg.avpr
+++ b/src/main/avro/client_to_task_msg.avpr
@@ -23,7 +23,7 @@
   [
     {
       "type": "record",
-      "name": "AvroChainedDag",
+      "name": "AvroOperatorChainDag",
       "fields":
       [
         {
@@ -178,8 +178,8 @@
       "request":
       [
         {
-          "name": "chainedDag",
-          "type": "AvroChainedDag"
+          "name": "operatorChainDag",
+          "type": "AvroOperatorChainDag"
         }
       ],
       "response": "QueryControlResult"

--- a/src/main/java/edu/snu/mist/api/LogicalDagOptimizer.java
+++ b/src/main/java/edu/snu/mist/api/LogicalDagOptimizer.java
@@ -31,7 +31,7 @@ import java.util.*;
 /**
  * This class implements a logical DAG optimizer.
  * Through this optimizer, a few DAG optimization techniques will be applied to the logical DAG in client-side.
- * The optimized DAG will be chained through ChainedDagGenerator.
+ * The optimized DAG will be chained through OperatorChainDagGenerator.
  * TODO: [MIST-452] (Minor) handle corner case in conditional branch API
  */
 public final class LogicalDagOptimizer {

--- a/src/main/java/edu/snu/mist/api/MISTDefaultExecutionEnvironmentImpl.java
+++ b/src/main/java/edu/snu/mist/api/MISTDefaultExecutionEnvironmentImpl.java
@@ -106,14 +106,14 @@ public final class MISTDefaultExecutionEnvironmentImpl implements MISTExecutionE
     }
 
     // Build logical plan using serialized vertices and edges.
-    final Tuple<List<AvroVertexChain>, List<Edge>> serializedDag = queryToSubmit.getAvroChainedDAG();
-    final AvroChainedDag.Builder chainedDagBuilder = AvroChainedDag.newBuilder();
-    final AvroChainedDag chainedDag = chainedDagBuilder
+    final Tuple<List<AvroVertexChain>, List<Edge>> serializedDag = queryToSubmit.getAvroOperatorChainDag();
+    final AvroOperatorChainDag.Builder operatorChainDagBuilder = AvroOperatorChainDag.newBuilder();
+    final AvroOperatorChainDag operatorChainDag = operatorChainDagBuilder
         .setJarFilePaths(jarUploadResult.getPaths())
         .setAvroVertices(serializedDag.getKey())
         .setEdges(serializedDag.getValue())
         .build();
-    final QueryControlResult queryControlResult = proxyToTask.sendQueries(chainedDag);
+    final QueryControlResult queryControlResult = proxyToTask.sendQueries(operatorChainDag);
 
     // Transform QueryControlResult to APIQueryControlResult
     final APIQueryControlResult apiQueryControlResult =

--- a/src/main/java/edu/snu/mist/api/MISTQuery.java
+++ b/src/main/java/edu/snu/mist/api/MISTQuery.java
@@ -30,9 +30,9 @@ import java.util.List;
 public interface MISTQuery {
 
   /**
-   * Get the serialized vertices and edges of the chained DAG.
+   * Get the serialized vertices and edges of the DAG with operator chains.
    */
-  Tuple<List<AvroVertexChain>, List<Edge>> getAvroChainedDAG();
+  Tuple<List<AvroVertexChain>, List<Edge>> getAvroOperatorChainDag();
 
   /**
    * Get the DAG of the query.

--- a/src/main/java/edu/snu/mist/api/OperatorChainDagGenerator.java
+++ b/src/main/java/edu/snu/mist/api/OperatorChainDagGenerator.java
@@ -55,29 +55,29 @@ import java.util.*;
  *         [... op2] ->
  *
  */
-public final class ChainedDagGenerator {
+public final class OperatorChainDagGenerator {
 
   /**
-   * The optimized DAG of a query to convert into chained DAG.
+   * The optimized DAG of a query to convert into OperatorChain DAG.
    */
   private DAG<MISTStream, MISTEdge> optimizedDag;
 
-  public ChainedDagGenerator() {
+  public OperatorChainDagGenerator() {
   }
 
   /**
-   * Set the optimized DAG to convert into chained DAG.
+   * Set the optimized DAG to convert into OperatorChainDAG.
    */
   public void setOptimizedDag(final DAG<MISTStream, MISTEdge> optimizedDag) {
     this.optimizedDag = optimizedDag;
   }
 
   /**
-   * Generate chained DAG according to the logic described above.
-   * @return the chained DAG
+   * Generate OperatorChain DAG according to the logic described above.
+   * @return the OperatorChain DAG
    * The chain is represented as a list and AvroVertexSerializable can be serialized by avro
    */
-  public DAG<List<MISTStream>, MISTEdge> generateChainedDAG() {
+  public DAG<List<MISTStream>, MISTEdge> generateOperatorChainDAG() {
     final DAG<OperatorChain, MISTEdge> partitionedQueryDAG =
         new AdjacentListDAG<>();
     final Map<MISTStream, OperatorChain> vertexChainMap = new HashMap<>();

--- a/src/main/java/edu/snu/mist/core/task/DagGenerator.java
+++ b/src/main/java/edu/snu/mist/core/task/DagGenerator.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.mist.core.task;
 
-import edu.snu.mist.formats.avro.AvroChainedDag;
+import edu.snu.mist.formats.avro.AvroOperatorChainDag;
 import org.apache.reef.io.Tuple;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.tang.exceptions.InjectionException;
@@ -23,7 +23,7 @@ import org.apache.reef.tang.exceptions.InjectionException;
 import java.io.IOException;
 
 /**
- * This interface is for generating a pair of the logical and execution dag from avro chained dag.
+ * This interface is for generating a pair of the logical and execution dag from avro operator chain dag.
  */
 @DefaultImplementation(DefaultDagGeneratorImpl.class)
 public interface DagGenerator {
@@ -32,6 +32,6 @@ public interface DagGenerator {
    * @param queryIdAndAvroLogicalDag the tuple of queryId and avro logical dag
    * @return a pair of the logical and execution dag
    */
-  LogicalAndExecutionDag generate(Tuple<String, AvroChainedDag> queryIdAndAvroLogicalDag)
+  LogicalAndExecutionDag generate(Tuple<String, AvroOperatorChainDag> queryIdAndAvroLogicalDag)
       throws IOException, ClassNotFoundException, InjectionException;
 }

--- a/src/main/java/edu/snu/mist/core/task/DefaultClientToTaskMessageImpl.java
+++ b/src/main/java/edu/snu/mist/core/task/DefaultClientToTaskMessageImpl.java
@@ -16,7 +16,7 @@
 package edu.snu.mist.core.task;
 
 import edu.snu.mist.core.task.stores.QueryInfoStore;
-import edu.snu.mist.formats.avro.AvroChainedDag;
+import edu.snu.mist.formats.avro.AvroOperatorChainDag;
 import edu.snu.mist.formats.avro.ClientToTaskMessage;
 import edu.snu.mist.formats.avro.JarUploadResult;
 import edu.snu.mist.formats.avro.QueryControlResult;
@@ -84,9 +84,9 @@ public final class DefaultClientToTaskMessageImpl implements ClientToTaskMessage
   }
 
   @Override
-  public QueryControlResult sendQueries(final AvroChainedDag avroChainedDag) throws AvroRemoteException {
-    final String queryId = queryIdGenerator.generate(avroChainedDag);
-    return queryManager.create(new Tuple<>(queryId, avroChainedDag));
+  public QueryControlResult sendQueries(final AvroOperatorChainDag chainDag) throws AvroRemoteException {
+    final String queryId = queryIdGenerator.generate(chainDag);
+    return queryManager.create(new Tuple<>(queryId, chainDag));
   }
 
   @Override

--- a/src/main/java/edu/snu/mist/core/task/DefaultDagGeneratorImpl.java
+++ b/src/main/java/edu/snu/mist/core/task/DefaultDagGeneratorImpl.java
@@ -73,31 +73,31 @@ final class DefaultDagGeneratorImpl implements DagGenerator {
   }
 
   /**
-   * This generates the logical and physical plan from the avro chained dag.
-   * Note that the avro chained dag is already partitioned,
+   * This generates the logical and physical plan from the avro operator chain dag.
+   * Note that the avro operator chain dag is already partitioned,
    * so we need to rewind the partition to generate the logical dag.
-   * @param queryIdAndAvroChainedDag the tuple of queryId and avro chained dag
+   * @param queryIdAndAvroOperatorChainDag the tuple of queryId and avro operator chain dag
    * @return the logical and execution dag
    */
   @SuppressWarnings("unchecked")
   @Override
   public LogicalAndExecutionDag generate(
-      final Tuple<String, AvroChainedDag> queryIdAndAvroChainedDag)
+      final Tuple<String, AvroOperatorChainDag> queryIdAndAvroOperatorChainDag)
       throws IllegalArgumentException, IOException, ClassNotFoundException, InjectionException {
-    final AvroChainedDag avroChainedDag = queryIdAndAvroChainedDag.getValue();
+    final AvroOperatorChainDag avroOpChainDag = queryIdAndAvroOperatorChainDag.getValue();
     // For execution dag
-    final List<ExecutionVertex> deserializedVertices = new ArrayList<>(avroChainedDag.getAvroVertices().size());
+    final List<ExecutionVertex> deserializedVertices = new ArrayList<>(avroOpChainDag.getAvroVertices().size());
     final DAG<ExecutionVertex, MISTEdge> executionDAG = new AdjacentListDAG<>();
     // This is for logical dag
-    final List<List<LogicalVertex>> logicalVertices = new ArrayList<>(avroChainedDag.getAvroVertices().size());
+    final List<List<LogicalVertex>> logicalVertices = new ArrayList<>(avroOpChainDag.getAvroVertices().size());
     final DAG<LogicalVertex, MISTEdge> logicalDAG = new AdjacentListDAG<>();
 
     // Get a class loader
-    final URL[] urls = SerializeUtils.getURLs(avroChainedDag.getJarFilePaths());
+    final URL[] urls = SerializeUtils.getURLs(avroOpChainDag.getJarFilePaths());
     final ClassLoader classLoader = classLoaderProvider.newInstance(urls);
 
     // Deserialize vertices
-    for (final AvroVertexChain avroVertexChain : avroChainedDag.getAvroVertices()) {
+    for (final AvroVertexChain avroVertexChain : avroOpChainDag.getAvroVertices()) {
       switch (avroVertexChain.getAvroVertexChainType()) {
         case SOURCE: {
           final Vertex vertex = avroVertexChain.getVertexChain().get(0);
@@ -189,7 +189,7 @@ final class DefaultDagGeneratorImpl implements DagGenerator {
     }
 
     // Add edge info to the execution dag and logical dag
-    for (final Edge edge : avroChainedDag.getEdges()) {
+    for (final Edge edge : avroOpChainDag.getEdges()) {
       final int srcIndex = edge.getFrom();
       final int dstIndex = edge.getTo();
 

--- a/src/main/java/edu/snu/mist/core/task/DefaultQueryIdGeneratorImpl.java
+++ b/src/main/java/edu/snu/mist/core/task/DefaultQueryIdGeneratorImpl.java
@@ -16,7 +16,7 @@
 package edu.snu.mist.core.task;
 
 import edu.snu.mist.core.parameters.QueryIdPrefix;
-import edu.snu.mist.formats.avro.AvroChainedDag;
+import edu.snu.mist.formats.avro.AvroOperatorChainDag;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
@@ -45,7 +45,7 @@ final class DefaultQueryIdGeneratorImpl implements QueryIdGenerator {
   }
 
   @Override
-  public String generate(final AvroChainedDag chainedDag) {
+  public String generate(final AvroOperatorChainDag avroOpChainDag) {
     final StringBuilder sb = new StringBuilder();
     sb.append(prefix);
     sb.append(numSubmittedQueries.getAndIncrement());

--- a/src/main/java/edu/snu/mist/core/task/DefaultQueryManagerImpl.java
+++ b/src/main/java/edu/snu/mist/core/task/DefaultQueryManagerImpl.java
@@ -19,7 +19,7 @@ import edu.snu.mist.common.graph.DAG;
 import edu.snu.mist.common.graph.GraphUtils;
 import edu.snu.mist.common.graph.MISTEdge;
 import edu.snu.mist.core.task.stores.QueryInfoStore;
-import edu.snu.mist.formats.avro.AvroChainedDag;
+import edu.snu.mist.formats.avro.AvroOperatorChainDag;
 import edu.snu.mist.formats.avro.QueryControlResult;
 import org.apache.reef.io.Tuple;
 
@@ -74,7 +74,7 @@ final class DefaultQueryManagerImpl implements QueryManager {
 
   /**
    * Default query manager in MistTask.
-   * @param dagGenerator the generator that generates the logical and execution dag from avro chained dag.
+   * @param dagGenerator the generator that generates the logical and execution dag from avro operator chain dag.
    * @param threadManager thread manager
    */
   @Inject
@@ -92,21 +92,21 @@ final class DefaultQueryManagerImpl implements QueryManager {
   }
 
   /**
-   * It converts the avro chained dag (query) to the execution dag,
+   * It converts the avro operator chain dag (query) to the execution dag,
    * and executes the sources in order to receives data streams.
-   * Before the queries are executed, it stores the avro chained dag into disk.
-   * We can regenerate the queries from the stored avro chained dag.
-   * @param tuple a pair of the query id and the avro chained dag
+   * Before the queries are executed, it stores the avro operator chain dag into disk.
+   * We can regenerate the queries from the stored avro operator chain dag.
+   * @param tuple a pair of the query id and the avro operator chain dag
    * @return submission result
    */
   @Override
-  public QueryControlResult create(final Tuple<String, AvroChainedDag> tuple) {
+  public QueryControlResult create(final Tuple<String, AvroOperatorChainDag> tuple) {
     final QueryControlResult queryControlResult = new QueryControlResult();
     queryControlResult.setQueryId(tuple.getKey());
     try {
-      // 1) Saves the avro chained dag to the PlanStore and
-      // converts the avro chained dag to the logical and execution dag
-      planStore.saveChainedDag(tuple);
+      // 1) Saves the avro operator chain dag to the PlanStore and
+      // converts the avro operator chain dag to the logical and execution dag
+      planStore.saveAvroOpChainDag(tuple);
       final LogicalAndExecutionDag logicalAndExecutionDag = dagGenerator.generate(tuple);
       // Store the logical dag in memory
       logicalDagMap.putIfAbsent(tuple.getKey(), logicalAndExecutionDag.getLogicalDag());

--- a/src/main/java/edu/snu/mist/core/task/QueryIdGenerator.java
+++ b/src/main/java/edu/snu/mist/core/task/QueryIdGenerator.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.mist.core.task;
 
-import edu.snu.mist.formats.avro.AvroChainedDag;
+import edu.snu.mist.formats.avro.AvroOperatorChainDag;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 /**
@@ -25,8 +25,8 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 public interface QueryIdGenerator {
   /**
    * Generates the query id.
-   * @param avroChainedDag the submitted query that is represented as a chained dag.
+   * @param avroOpChainDag the submitted query that is represented as a operator chain dag.
    * @return query id
    */
-  String generate(AvroChainedDag avroChainedDag);
+  String generate(AvroOperatorChainDag avroOpChainDag);
 }

--- a/src/main/java/edu/snu/mist/core/task/QueryManager.java
+++ b/src/main/java/edu/snu/mist/core/task/QueryManager.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.mist.core.task;
 
-import edu.snu.mist.formats.avro.AvroChainedDag;
+import edu.snu.mist.formats.avro.AvroOperatorChainDag;
 import edu.snu.mist.formats.avro.QueryControlResult;
 import org.apache.reef.io.Tuple;
 import org.apache.reef.tang.annotations.DefaultImplementation;
@@ -29,9 +29,9 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 public interface QueryManager extends AutoCloseable {
   /**
    * Start to the query.
-   * @param tuple the query id and the chained dag
+   * @param tuple the query id and the operator chain dag
    */
-  QueryControlResult create(Tuple<String, AvroChainedDag> tuple);
+  QueryControlResult create(Tuple<String, AvroOperatorChainDag> tuple);
 
   /**
    * Deletes the query corresponding to the queryId submitted by client.

--- a/src/main/java/edu/snu/mist/core/task/stores/QueryInfoStore.java
+++ b/src/main/java/edu/snu/mist/core/task/stores/QueryInfoStore.java
@@ -16,7 +16,7 @@
 package edu.snu.mist.core.task.stores;
 
 
-import edu.snu.mist.formats.avro.AvroChainedDag;
+import edu.snu.mist.formats.avro.AvroOperatorChainDag;
 import org.apache.reef.io.Tuple;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
@@ -25,18 +25,18 @@ import java.nio.ByteBuffer;
 import java.util.List;
 
 /**
- * This interface saves the information related to a query (the chained dag of a query and jar files).
+ * This interface saves the information related to a query (the operator chain dag of a query and jar files).
  * Also, this supports loading a logical plan and removing the plan and its corresponding jar files.
  */
 @DefaultImplementation(DiskQueryInfoStore.class)
 public interface QueryInfoStore {
   /**
-   * Saves the chained dag.
+   * Saves the operator chain dag.
    * @param tuple
    * @return true if saving is success. Otherwise return false.
    * @throws IOException
    */
-  boolean saveChainedDag(Tuple<String, AvroChainedDag> tuple) throws IOException;
+  boolean saveAvroOpChainDag(Tuple<String, AvroOperatorChainDag> tuple) throws IOException;
 
   /**
    * Saves the jar files and returns paths of the stored jar files.
@@ -47,15 +47,15 @@ public interface QueryInfoStore {
   List<String> saveJar(List<ByteBuffer> jarFiles) throws IOException;
 
   /**
-   * Loads the chained dag corresponding to the queryId.
+   * Loads the operator chain dag corresponding to the queryId.
    * @param queryId
-   * @return chained dag
+   * @return operator chain dag
    * @throws IOException
    */
-  AvroChainedDag load(String queryId) throws IOException;
+  AvroOperatorChainDag load(String queryId) throws IOException;
 
   /**
-   * Deletes the chained dag and its corresponding jar files.
+   * Deletes the operator chain dag and its corresponding jar files.
    * @param queryId
    * @throws IOException
    */

--- a/src/test/java/edu/snu/mist/api/MISTDefaultExecutionEnvironmentImplTest.java
+++ b/src/test/java/edu/snu/mist/api/MISTDefaultExecutionEnvironmentImplTest.java
@@ -58,7 +58,7 @@ public class MISTDefaultExecutionEnvironmentImplTest {
     }
 
     @Override
-    public QueryControlResult sendQueries(final AvroChainedDag chainedDag) throws AvroRemoteException {
+    public QueryControlResult sendQueries(final AvroOperatorChainDag operatorChainDag) throws AvroRemoteException {
       return new QueryControlResult(testQueryResult, true, testQueryResult);
     }
     @Override

--- a/src/test/java/edu/snu/mist/api/MISTQueryTest.java
+++ b/src/test/java/edu/snu/mist/api/MISTQueryTest.java
@@ -80,7 +80,7 @@ public final class MISTQueryTest {
 
     // Build a query
     final MISTQuery complexQuery = queryBuilder.build();
-    final Tuple<List<AvroVertexChain>, List<Edge>> serializedDAG = complexQuery.getAvroChainedDAG();
+    final Tuple<List<AvroVertexChain>, List<Edge>> serializedDAG = complexQuery.getAvroOperatorChainDag();
     final List<AvroVertexChain> vertices = serializedDAG.getKey();
     Assert.assertEquals(3, vertices.size());
 

--- a/src/test/java/edu/snu/mist/api/OperatorChainDagGeneratorTest.java
+++ b/src/test/java/edu/snu/mist/api/OperatorChainDagGeneratorTest.java
@@ -31,8 +31,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
-public final class ChainedDagGeneratorTest {
-  private static final Logger LOG = Logger.getLogger(ChainedDagGeneratorTest.class.getName());
+public final class OperatorChainDagGeneratorTest {
+  private static final Logger LOG = Logger.getLogger(OperatorChainDagGeneratorTest.class.getName());
 
   /**
    * Test complex chaining (branch and merge exist).
@@ -40,13 +40,13 @@ public final class ChainedDagGeneratorTest {
    * src1 -> op11 -> op12 -> union -> op14 -> op15 -> sink1
    * src2 -> op21 -> op22 ->       -> op23 ->      -> sink2.
    *
-   * should be converted to the expected chained DAG:
+   * should be converted to the expected operator chain DAG:
    * src1 -> [op11 -> op12] -> [op13] -> [op14 -> op15] -> sink1
    * src2 -> [op21 -> op22] ->        -> [op23] -> sink2.
    */
   @Test
   public void testComplexQueryPartitioning() throws InjectionException {
-    // Build a chained dag
+    // Build a operator chain dag
     final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
     final ContinuousStream<String> src1 =
         queryBuilder.socketTextStream(TestParameters.LOCAL_TEXT_SOCKET_SOURCE_CONF);
@@ -65,10 +65,10 @@ public final class ChainedDagGeneratorTest {
 
     final MISTQuery query = queryBuilder.build();
     final DAG<MISTStream, MISTEdge> dag = query.getDAG();
-    final ChainedDagGenerator chainedDagGenerator = new ChainedDagGenerator();
-    chainedDagGenerator.setOptimizedDag(dag);
+    final OperatorChainDagGenerator chainDagGenerator = new OperatorChainDagGenerator();
+    chainDagGenerator.setOptimizedDag(dag);
     final DAG<List<MISTStream>, MISTEdge>
-        chainedPlan = chainedDagGenerator.generateChainedDAG();
+        operatorChainDag = chainDagGenerator.generateOperatorChainDAG();
 
     final List<MISTStream> src1List = Arrays.asList(src1);
     final List<MISTStream> src2List = Arrays.asList(src2);
@@ -81,39 +81,39 @@ public final class ChainedDagGeneratorTest {
     final List<MISTStream> sink2List = Arrays.asList(sink2);
 
     // Check src1 -> [op11->op12] edge
-    final Map<List<MISTStream>, MISTEdge> e1 = chainedPlan.getEdges(src1List);
+    final Map<List<MISTStream>, MISTEdge> e1 = operatorChainDag.getEdges(src1List);
     final Map<List<MISTStream>, MISTEdge> result1 = new HashMap<>();
     result1.put(op11op12, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e1, result1);
     // Check src2 -> [op21->op22] edge
-    final Map<List<MISTStream>, MISTEdge> e2 = chainedPlan.getEdges(src2List);
+    final Map<List<MISTStream>, MISTEdge> e2 = operatorChainDag.getEdges(src2List);
     final Map<List<MISTStream>, MISTEdge> result2 = new HashMap<>();
     result2.put(op21op22, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e2, result2);
     // Check [op11->op12] -> [union] edge
-    final Map<List<MISTStream>, MISTEdge> e3 = chainedPlan.getEdges(op11op12);
+    final Map<List<MISTStream>, MISTEdge> e3 = operatorChainDag.getEdges(op11op12);
     final Map<List<MISTStream>, MISTEdge> result3 = new HashMap<>();
     result3.put(unionList, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e3, result3);
     // Check [op21->op22] -> [union] edge
-    final Map<List<MISTStream>, MISTEdge> e4 = chainedPlan.getEdges(op21op22);
+    final Map<List<MISTStream>, MISTEdge> e4 = operatorChainDag.getEdges(op21op22);
     final Map<List<MISTStream>, MISTEdge> result4 = new HashMap<>();
     result4.put(unionList, new MISTEdge(Direction.RIGHT));
     Assert.assertEquals(e4, result4);
     // Check [union] -> [op14->op15] edge
     // Check [union] -> [op23] edge
-    final Map<List<MISTStream>, MISTEdge> e5 = chainedPlan.getEdges(unionList);
+    final Map<List<MISTStream>, MISTEdge> e5 = operatorChainDag.getEdges(unionList);
     final Map<List<MISTStream>, MISTEdge> result5 = new HashMap<>();
     result5.put(op14op15, new MISTEdge(Direction.LEFT));
     result5.put(op23List, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e5, result5);
     // Check [op14->op15] -> sink1 edge
-    final Map<List<MISTStream>, MISTEdge> e6 = chainedPlan.getEdges(op14op15);
+    final Map<List<MISTStream>, MISTEdge> e6 = operatorChainDag.getEdges(op14op15);
     final Map<List<MISTStream>, MISTEdge> result6 = new HashMap<>();
     result6.put(sink1List, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e6, result6);
     // Check [op23] -> sink2 edge
-    final Map<List<MISTStream>, MISTEdge> e7 = chainedPlan.getEdges(op23List);
+    final Map<List<MISTStream>, MISTEdge> e7 = operatorChainDag.getEdges(op23List);
     final Map<List<MISTStream>, MISTEdge> result7 = new HashMap<>();
     result7.put(sink2List, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e7, result7);
@@ -140,22 +140,22 @@ public final class ChainedDagGeneratorTest {
 
     final MISTQuery query = queryBuilder.build();
     final DAG<MISTStream, MISTEdge> dag = query.getDAG();
-    final ChainedDagGenerator chainedDagGenerator = new ChainedDagGenerator();
-    chainedDagGenerator.setOptimizedDag(dag);
+    final OperatorChainDagGenerator chainDagGenerator = new OperatorChainDagGenerator();
+    chainDagGenerator.setOptimizedDag(dag);
     final DAG<List<MISTStream>, MISTEdge>
-        chainedPlan = chainedDagGenerator.generateChainedDAG();
+        operatorChainDag = chainDagGenerator.generateOperatorChainDAG();
 
     final List<MISTStream> src1List = Arrays.asList(src1);
     final List<MISTStream> opList = Arrays.asList(op11, op12, op13);
     final List<MISTStream> sinkList = Arrays.asList(sink1);
 
     // Check src1 -> [op11->op12->op13] edge
-    final Map<List<MISTStream>, MISTEdge> e1 = chainedPlan.getEdges(src1List);
+    final Map<List<MISTStream>, MISTEdge> e1 = operatorChainDag.getEdges(src1List);
     final Map<List<MISTStream>, MISTEdge> result1 = new HashMap<>();
     result1.put(opList, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e1, result1);
     // Check [op11->op12->op13] -> [sink1] edge
-    final Map<List<MISTStream>, MISTEdge> e2 = chainedPlan.getEdges(opList);
+    final Map<List<MISTStream>, MISTEdge> e2 = operatorChainDag.getEdges(opList);
     final Map<List<MISTStream>, MISTEdge> result2 = new HashMap<>();
     result2.put(sinkList, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e2, result2);
@@ -188,10 +188,10 @@ public final class ChainedDagGeneratorTest {
 
     final MISTQuery query = queryBuilder.build();
     final DAG<MISTStream, MISTEdge> dag = query.getDAG();
-    final ChainedDagGenerator chainedDagGenerator = new ChainedDagGenerator();
-    chainedDagGenerator.setOptimizedDag(dag);
+    final OperatorChainDagGenerator chainDagGenerator = new OperatorChainDagGenerator();
+    chainDagGenerator.setOptimizedDag(dag);
     final DAG<List<MISTStream>, MISTEdge>
-        chainedPlan = chainedDagGenerator.generateChainedDAG();
+        chainPlan = chainDagGenerator.generateOperatorChainDAG();
 
     // Expected outputs
     final List<MISTStream> src1List = Arrays.asList(src1);
@@ -204,31 +204,31 @@ public final class ChainedDagGeneratorTest {
     final List<MISTStream> sink3List = Arrays.asList(sink3);
 
     // Check src1 -> [op11->op12] edge
-    final Map<List<MISTStream>, MISTEdge> e1 = chainedPlan.getEdges(src1List);
+    final Map<List<MISTStream>, MISTEdge> e1 = chainPlan.getEdges(src1List);
     final Map<List<MISTStream>, MISTEdge> result1 = new HashMap<>();
     result1.put(op11op12, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e1, result1);
     // Check [op11->op12] -> [op13] edges
     //                    -> [op14]
     //                    -> [op15]
-    final Map<List<MISTStream>, MISTEdge> e2 = chainedPlan.getEdges(op11op12);
+    final Map<List<MISTStream>, MISTEdge> e2 = chainPlan.getEdges(op11op12);
     final Map<List<MISTStream>, MISTEdge> result2 = new HashMap<>();
     result2.put(op13List, new MISTEdge(Direction.LEFT));
     result2.put(op14List, new MISTEdge(Direction.LEFT));
     result2.put(op15List, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e2, result2);
     // Check [op14] -> [sink2] edge
-    final Map<List<MISTStream>, MISTEdge> e3 = chainedPlan.getEdges(op14List);
+    final Map<List<MISTStream>, MISTEdge> e3 = chainPlan.getEdges(op14List);
     final Map<List<MISTStream>, MISTEdge> result3 = new HashMap<>();
     result3.put(sink2List, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e3, result3);
     // Check [op13] -> [sink1] edge
-    final Map<List<MISTStream>, MISTEdge> e4 = chainedPlan.getEdges(op13List);
+    final Map<List<MISTStream>, MISTEdge> e4 = chainPlan.getEdges(op13List);
     final Map<List<MISTStream>, MISTEdge> result4 = new HashMap<>();
     result4.put(sink1List, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e4, result4);
     // Check [op15] -> [sink3] edge
-    final Map<List<MISTStream>, MISTEdge> e5 = chainedPlan.getEdges(op15List);
+    final Map<List<MISTStream>, MISTEdge> e5 = chainPlan.getEdges(op15List);
     final Map<List<MISTStream>, MISTEdge> result5 = new HashMap<>();
     result5.put(sink3List, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e5, result5);
@@ -242,7 +242,7 @@ public final class ChainedDagGeneratorTest {
    * src2 ---------> op21 -> op13 -> op14 -> sink1
    * src3 -----------------> op31 ->
    *
-   * should be converted to the expected chained dag:
+   * should be converted to the expected operator chain dag:
    * src1 -> [op11 -> op12] ->
    * src2 ---------> [op21] -> [op13] -> [op14] -> sink1
    * src3 -------------------> [op31] ->
@@ -266,10 +266,10 @@ public final class ChainedDagGeneratorTest {
 
     final MISTQuery query = queryBuilder.build();
     final DAG<MISTStream, MISTEdge> dag = query.getDAG();
-    final ChainedDagGenerator chainedDagGenerator = new ChainedDagGenerator();
-    chainedDagGenerator.setOptimizedDag(dag);
+    final OperatorChainDagGenerator chainDagGenerator = new OperatorChainDagGenerator();
+    chainDagGenerator.setOptimizedDag(dag);
     final DAG<List<MISTStream>, MISTEdge>
-        chainedPlan = chainedDagGenerator.generateChainedDAG();
+        operatorChainDag = chainDagGenerator.generateOperatorChainDAG();
 
     // Expected outputs
     final List<MISTStream> src1List = Arrays.asList(src1);
@@ -283,42 +283,42 @@ public final class ChainedDagGeneratorTest {
     final List<MISTStream> sink1List = Arrays.asList(sink1);
 
     // Check src1 -> [op11->op12] edge
-    final Map<List<MISTStream>, MISTEdge> e1 = chainedPlan.getEdges(src1List);
+    final Map<List<MISTStream>, MISTEdge> e1 = operatorChainDag.getEdges(src1List);
     final Map<List<MISTStream>, MISTEdge> result1 = new HashMap<>();
     result1.put(op11op12, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e1, result1);
     // Check src2 -> [op21] edge
-    final Map<List<MISTStream>, MISTEdge> e2 = chainedPlan.getEdges(src2List);
+    final Map<List<MISTStream>, MISTEdge> e2 = operatorChainDag.getEdges(src2List);
     final Map<List<MISTStream>, MISTEdge> result2 = new HashMap<>();
     result2.put(op21List, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e2, result2);
     // Check src3 -> [op31] edge
-    final Map<List<MISTStream>, MISTEdge> e3 = chainedPlan.getEdges(src3List);
+    final Map<List<MISTStream>, MISTEdge> e3 = operatorChainDag.getEdges(src3List);
     final Map<List<MISTStream>, MISTEdge> result3 = new HashMap<>();
     result3.put(op31List, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e3, result3);
     // Check [op11->op12] -> [op13] edge
-    final Map<List<MISTStream>, MISTEdge> e4 = chainedPlan.getEdges(op11op12);
+    final Map<List<MISTStream>, MISTEdge> e4 = operatorChainDag.getEdges(op11op12);
     final Map<List<MISTStream>, MISTEdge> result4 = new HashMap<>();
     result4.put(op13List, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e4, result4);
     // Check [op21] -> [op13] edge
-    final Map<List<MISTStream>, MISTEdge> e5 = chainedPlan.getEdges(op21List);
+    final Map<List<MISTStream>, MISTEdge> e5 = operatorChainDag.getEdges(op21List);
     final Map<List<MISTStream>, MISTEdge> result5 = new HashMap<>();
     result5.put(op13List, new MISTEdge(Direction.RIGHT));
     Assert.assertEquals(e5, result5);
     // Check [op13] -> [op14] edge
-    final Map<List<MISTStream>, MISTEdge> e6 = chainedPlan.getEdges(op13List);
+    final Map<List<MISTStream>, MISTEdge> e6 = operatorChainDag.getEdges(op13List);
     final Map<List<MISTStream>, MISTEdge> result6 = new HashMap<>();
     result6.put(op14List, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e6, result6);
     // Check [op31] -> [op14] edge
-    final Map<List<MISTStream>, MISTEdge> e7 = chainedPlan.getEdges(op31List);
+    final Map<List<MISTStream>, MISTEdge> e7 = operatorChainDag.getEdges(op31List);
     final Map<List<MISTStream>, MISTEdge> result7 = new HashMap<>();
     result7.put(op14List, new MISTEdge(Direction.RIGHT));
     Assert.assertEquals(e7, result7);
     // Check [op14] -> [sink1] edge
-    final Map<List<MISTStream>, MISTEdge> e8 = chainedPlan.getEdges(op14List);
+    final Map<List<MISTStream>, MISTEdge> e8 = operatorChainDag.getEdges(op14List);
     final Map<List<MISTStream>, MISTEdge> result8 = new HashMap<>();
     result8.put(sink1List, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e8, result8);
@@ -351,10 +351,10 @@ public final class ChainedDagGeneratorTest {
 
     final MISTQuery query = queryBuilder.build();
     final DAG<MISTStream, MISTEdge> dag = query.getDAG();
-    final ChainedDagGenerator chainedDagGenerator = new ChainedDagGenerator();
-    chainedDagGenerator.setOptimizedDag(dag);
+    final OperatorChainDagGenerator chainDagGenerator = new OperatorChainDagGenerator();
+    chainDagGenerator.setOptimizedDag(dag);
     final DAG<List<MISTStream>, MISTEdge>
-        chainedPlan = chainedDagGenerator.generateChainedDAG();
+        operatorChainDag = chainDagGenerator.generateOperatorChainDAG();
 
     // Expected outputs
     final List<MISTStream> src1List = Arrays.asList(src1);
@@ -367,41 +367,41 @@ public final class ChainedDagGeneratorTest {
     final List<MISTStream> sink1List = Arrays.asList(sink1);
 
     // Check src1 -> [opA] edge
-    final Map<List<MISTStream>, MISTEdge> e1 = chainedPlan.getEdges(src1List);
+    final Map<List<MISTStream>, MISTEdge> e1 = operatorChainDag.getEdges(src1List);
     final Map<List<MISTStream>, MISTEdge> result1 = new HashMap<>();
     result1.put(opAList, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e1, result1);
     // Check opA -> opB1 edges
     //           -> opB2
     //           -> opB3
-    final Map<List<MISTStream>, MISTEdge> e2 = chainedPlan.getEdges(opAList);
+    final Map<List<MISTStream>, MISTEdge> e2 = operatorChainDag.getEdges(opAList);
     final Map<List<MISTStream>, MISTEdge> result2 = new HashMap<>();
     result2.put(opB1List, new MISTEdge(Direction.LEFT));
     result2.put(opB2List, new MISTEdge(Direction.LEFT));
     result2.put(opB3List, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e2, result2);
     // Check opB1 -> [opC] edge
-    final Map<List<MISTStream>, MISTEdge> e3 = chainedPlan.getEdges(opB1List);
+    final Map<List<MISTStream>, MISTEdge> e3 = operatorChainDag.getEdges(opB1List);
     final Map<List<MISTStream>, MISTEdge> result3 = new HashMap<>();
     result3.put(opCList, new MISTEdge(Direction.RIGHT));
     Assert.assertEquals(e3, result3);
     // Check opB2 -> [opC] edge
-    final Map<List<MISTStream>, MISTEdge> e4 = chainedPlan.getEdges(opB2List);
+    final Map<List<MISTStream>, MISTEdge> e4 = operatorChainDag.getEdges(opB2List);
     final Map<List<MISTStream>, MISTEdge> result4 = new HashMap<>();
     result4.put(opCList, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e4, result4);
     // Check opC -> [opD] edge
-    final Map<List<MISTStream>, MISTEdge> e5 = chainedPlan.getEdges(opCList);
+    final Map<List<MISTStream>, MISTEdge> e5 = operatorChainDag.getEdges(opCList);
     final Map<List<MISTStream>, MISTEdge> result5 = new HashMap<>();
     result5.put(opDList, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e5, result5);
     // Check opB3 -> [opD] edge
-    final Map<List<MISTStream>, MISTEdge> e6 = chainedPlan.getEdges(opB3List);
+    final Map<List<MISTStream>, MISTEdge> e6 = operatorChainDag.getEdges(opB3List);
     final Map<List<MISTStream>, MISTEdge> result6 = new HashMap<>();
     result6.put(opDList, new MISTEdge(Direction.RIGHT));
     Assert.assertEquals(e6, result6);
     // Check opD -> [sink1] edge
-    final Map<List<MISTStream>, MISTEdge> e7 = chainedPlan.getEdges(opDList);
+    final Map<List<MISTStream>, MISTEdge> e7 = operatorChainDag.getEdges(opDList);
     final Map<List<MISTStream>, MISTEdge> result7 = new HashMap<>();
     result7.put(sink1List, new MISTEdge(Direction.LEFT));
     Assert.assertEquals(e7, result7);

--- a/src/test/java/edu/snu/mist/core/task/DefaultDagGeneratorImplTest.java
+++ b/src/test/java/edu/snu/mist/core/task/DefaultDagGeneratorImplTest.java
@@ -27,7 +27,7 @@ import edu.snu.mist.common.operators.ReduceByKeyOperator;
 import edu.snu.mist.common.sinks.NettyTextSink;
 import edu.snu.mist.common.sources.NettyTextDataGenerator;
 import edu.snu.mist.common.types.Tuple2;
-import edu.snu.mist.formats.avro.AvroChainedDag;
+import edu.snu.mist.formats.avro.AvroOperatorChainDag;
 import edu.snu.mist.formats.avro.AvroVertexChain;
 import edu.snu.mist.formats.avro.Edge;
 import edu.snu.mist.utils.TestParameters;
@@ -72,7 +72,7 @@ public final class DefaultDagGeneratorImplTest {
   }
 
   /**
-   * Round-trip test of de-serializing AvroChainedDag.
+   * Round-trip test of de-serializing AvroOperatorChainDag.
    * @throws org.apache.reef.tang.exceptions.InjectionException
    */
 
@@ -88,17 +88,17 @@ public final class DefaultDagGeneratorImplTest {
         .reduceByKey(0, String.class, (Integer x, Integer y) -> x + y)
         .textSocketOutput(TestParameters.HOST, TestParameters.SINK_PORT);
     final MISTQuery query = queryBuilder.build();
-    // Generate avro chained dag
-    final Tuple<List<AvroVertexChain>, List<Edge>> serializedDag = query.getAvroChainedDAG();
-    final AvroChainedDag.Builder chainedDagBuilder = AvroChainedDag.newBuilder();
-    final AvroChainedDag avroChainedDag = chainedDagBuilder
+    // Generate avro operator chain dag
+    final Tuple<List<AvroVertexChain>, List<Edge>> serializedDag = query.getAvroOperatorChainDag();
+    final AvroOperatorChainDag.Builder avroOpChainDagBuilder = AvroOperatorChainDag.newBuilder();
+    final AvroOperatorChainDag avroChainedDag = avroOpChainDagBuilder
         .setJarFilePaths(new LinkedList<>())
         .setAvroVertices(serializedDag.getKey())
         .setEdges(serializedDag.getValue())
         .build();
 
     final DagGenerator dagGenerator = Tang.Factory.getTang().newInjector().getInstance(DagGenerator.class);
-    final Tuple<String, AvroChainedDag> tuple = new Tuple<>("query-test", avroChainedDag);
+    final Tuple<String, AvroOperatorChainDag> tuple = new Tuple<>("query-test", avroChainedDag);
     final LogicalAndExecutionDag plan = dagGenerator.generate(tuple);
 
     // Test execution dag

--- a/src/test/java/edu/snu/mist/core/task/QueryIdGeneratorTest.java
+++ b/src/test/java/edu/snu/mist/core/task/QueryIdGeneratorTest.java
@@ -16,7 +16,7 @@
 package edu.snu.mist.core.task;
 
 import edu.snu.mist.core.parameters.QueryIdPrefix;
-import edu.snu.mist.formats.avro.AvroChainedDag;
+import edu.snu.mist.formats.avro.AvroOperatorChainDag;
 import junit.framework.Assert;
 import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.Tang;
@@ -35,10 +35,10 @@ public final class QueryIdGeneratorTest {
     final Injector injector = Tang.Factory.getTang().newInjector();
     final QueryIdGenerator queryIdGenerator = injector.getInstance(QueryIdGenerator.class);
     final String prefix = injector.getNamedInstance(QueryIdPrefix.class);
-    final AvroChainedDag chainedDag = new AvroChainedDag();
+    final AvroOperatorChainDag avroOpChainDag = new AvroOperatorChainDag();
     long submittedQueryNum = 0;
     while (submittedQueryNum < 10000) {
-      final String queryId = queryIdGenerator.generate(chainedDag);
+      final String queryId = queryIdGenerator.generate(avroOpChainDag);
       Assert.assertEquals(prefix + submittedQueryNum, queryId);
       submittedQueryNum++;
     }

--- a/src/test/java/edu/snu/mist/core/task/QueryManagerTest.java
+++ b/src/test/java/edu/snu/mist/core/task/QueryManagerTest.java
@@ -33,7 +33,7 @@ import edu.snu.mist.common.types.Tuple2;
 import edu.snu.mist.core.parameters.NumThreads;
 import edu.snu.mist.core.parameters.PlanStorePath;
 import edu.snu.mist.core.task.stores.QueryInfoStore;
-import edu.snu.mist.formats.avro.AvroChainedDag;
+import edu.snu.mist.formats.avro.AvroOperatorChainDag;
 import edu.snu.mist.formats.avro.Direction;
 import junit.framework.Assert;
 import org.apache.reef.io.Tuple;
@@ -133,8 +133,8 @@ public final class QueryManagerTest {
     final PhysicalSink sink2 = new PhysicalSinkImpl<>("sink2",
         null, new TestSink<Integer>(sink2Result, countDownAllOutputs));
 
-    // Fake chained dag of QueryManager
-    final Tuple<String, AvroChainedDag> tuple = new Tuple<>(queryId, new AvroChainedDag());
+    // Fake operator chain dag of QueryManager
+    final Tuple<String, AvroOperatorChainDag> tuple = new Tuple<>(queryId, new AvroOperatorChainDag());
 
     // Construct logical and execution dag
     constructLogicalAndExecutionDag(tuple, dag, logicalDag, src, sink1, sink2);
@@ -183,7 +183,7 @@ public final class QueryManagerTest {
    * Construct logical and execution dag.
    * Creates operators and adds source, dag vertices, edges and sinks to dag.
    */
-  private void constructLogicalAndExecutionDag(final Tuple<String, AvroChainedDag> tuple,
+  private void constructLogicalAndExecutionDag(final Tuple<String, AvroOperatorChainDag> tuple,
                                                final DAG<ExecutionVertex, MISTEdge> dag,
                                                final DAG<LogicalVertex, MISTEdge> logicalDag,
                                                final PhysicalSource src,
@@ -275,12 +275,12 @@ public final class QueryManagerTest {
    * QueryManager Builder.
    * It receives inputs tuple, physicalPlanGenerator, injector then makes query manager.
    */
-  private QueryManager queryManagerBuild(final Tuple<String, AvroChainedDag> tuple,
+  private QueryManager queryManagerBuild(final Tuple<String, AvroOperatorChainDag> tuple,
                                          final DagGenerator dagGenerator,
                                          final Injector injector) throws Exception {
     // Create mock PlanStore. It returns true and the above logical plan
     final QueryInfoStore planStore = mock(QueryInfoStore.class);
-    when(planStore.saveChainedDag(tuple)).thenReturn(true);
+    when(planStore.saveAvroOpChainDag(tuple)).thenReturn(true);
     when(planStore.load(tuple.getKey())).thenReturn(tuple.getValue());
 
     // Create QueryManager

--- a/src/test/java/edu/snu/mist/core/task/stores/QueryInfoStoreTest.java
+++ b/src/test/java/edu/snu/mist/core/task/stores/QueryInfoStoreTest.java
@@ -20,7 +20,7 @@ import edu.snu.mist.api.MISTQuery;
 import edu.snu.mist.api.MISTQueryBuilder;
 import edu.snu.mist.common.types.Tuple2;
 import edu.snu.mist.core.parameters.TempFolderPath;
-import edu.snu.mist.formats.avro.AvroChainedDag;
+import edu.snu.mist.formats.avro.AvroOperatorChainDag;
 import edu.snu.mist.formats.avro.AvroVertexChain;
 import edu.snu.mist.formats.avro.Edge;
 import edu.snu.mist.formats.avro.Vertex;
@@ -43,7 +43,7 @@ import java.util.List;
 
 public class QueryInfoStoreTest {
   /**
-   * Tests whether the PlanStore correctly saves, deletes and loads the chained dag.
+   * Tests whether the PlanStore correctly saves, deletes and loads the operator chain dag.
    * @throws InjectionException
    * @throws IOException
    */
@@ -84,22 +84,22 @@ public class QueryInfoStoreTest {
     }
 
     // Generate logical plan
-    final Tuple<List<AvroVertexChain>, List<Edge>> serializedDag = query.getAvroChainedDAG();
-    final AvroChainedDag.Builder chainedDagBuilder = AvroChainedDag.newBuilder();
-    final AvroChainedDag avroChainedDag = chainedDagBuilder
+    final Tuple<List<AvroVertexChain>, List<Edge>> serializedDag = query.getAvroOperatorChainDag();
+    final AvroOperatorChainDag.Builder avroOpChainDagBuilder = AvroOperatorChainDag.newBuilder();
+    final AvroOperatorChainDag avroOpChainDag = avroOpChainDagBuilder
         .setJarFilePaths(paths)
         .setAvroVertices(serializedDag.getKey())
         .setEdges(serializedDag.getValue())
         .build();
 
     // Store the chained dag
-    store.saveChainedDag(new Tuple<>(queryId, avroChainedDag));
+    store.saveAvroOpChainDag(new Tuple<>(queryId, avroOpChainDag));
     Assert.assertTrue(new File(tmpFolderPath, queryId + ".plan").exists());
 
-    final AvroChainedDag loadedDag = store.load(queryId);
-    Assert.assertEquals(avroChainedDag.getEdges(), loadedDag.getEdges());
-    Assert.assertEquals(avroChainedDag.getSchema(), loadedDag.getSchema());
-    testVerticesEqual(avroChainedDag.getAvroVertices(), loadedDag.getAvroVertices());
+    final AvroOperatorChainDag loadedDag = store.load(queryId);
+    Assert.assertEquals(avroOpChainDag.getEdges(), loadedDag.getEdges());
+    Assert.assertEquals(avroOpChainDag.getSchema(), loadedDag.getSchema());
+    testVerticesEqual(avroOpChainDag.getAvroVertices(), loadedDag.getAvroVertices());
     store.delete(queryId);
     Assert.assertFalse(new File(tmpFolderPath, queryId + ".plan").exists());
     for (final String path : paths) {


### PR DESCRIPTION
This PR addressed #469 by
* renaming `ChainedDAG` to `OperatorChainDAG`


Closes #469 