### PR TITLE
[MIST-505] Fix URL protocol issues with raw jar file path

### DIFF
--- a/src/main/java/edu/snu/mist/common/SerializeUtils.java
+++ b/src/main/java/edu/snu/mist/common/SerializeUtils.java
@@ -18,6 +18,7 @@ package edu.snu.mist.common;
 import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.List;
 
@@ -86,11 +87,11 @@ public final class SerializeUtils {
    * @param paths list of string
    * @return url array
    **/
-  public static URL[] getURLs(final List<String> paths) throws MalformedURLException {
+  public static URL[] getJarFileURLs(final List<String> paths) throws MalformedURLException {
     final URL[] urls = new URL[paths.size()];
     for (int i = 0; i < paths.size(); i++) {
       final String jarFilePath = paths.get(i);
-      final URL url = new URL(jarFilePath);
+      final URL url = Paths.get(jarFilePath).toUri().toURL();
       urls[i] = url;
     }
     return urls;

--- a/src/main/java/edu/snu/mist/core/task/DefaultDagGeneratorImpl.java
+++ b/src/main/java/edu/snu/mist/core/task/DefaultDagGeneratorImpl.java
@@ -93,7 +93,7 @@ final class DefaultDagGeneratorImpl implements DagGenerator {
     final DAG<LogicalVertex, MISTEdge> logicalDAG = new AdjacentListDAG<>();
 
     // Get a class loader
-    final URL[] urls = SerializeUtils.getURLs(avroOpChainDag.getJarFilePaths());
+    final URL[] urls = SerializeUtils.getJarFileURLs(avroOpChainDag.getJarFilePaths());
     final ClassLoader classLoader = classLoaderProvider.newInstance(urls);
 
     // Deserialize vertices


### PR DESCRIPTION
This PR fixes URL protocol issues of omitting `file://` prefix, when raw linux file path is used for jar file path.

Closes #505.