### PR TITLE
[MIST-547] Add groupId to a query instead of sources

### DIFF
--- a/src/main/avro/client_to_task_msg.avpr
+++ b/src/main/avro/client_to_task_msg.avpr
@@ -27,6 +27,10 @@
       "fields":
       [
         {
+          "name": "GroupId",
+          "type": "string"
+        },
+        {
           "name": "JarFilePaths",
           "type":
           {

--- a/src/main/java/edu/snu/mist/api/MISTDefaultExecutionEnvironmentImpl.java
+++ b/src/main/java/edu/snu/mist/api/MISTDefaultExecutionEnvironmentImpl.java
@@ -112,6 +112,7 @@ public final class MISTDefaultExecutionEnvironmentImpl implements MISTExecutionE
         .setJarFilePaths(jarUploadResult.getPaths())
         .setAvroVertices(serializedDag.getKey())
         .setEdges(serializedDag.getValue())
+        .setGroupId(queryToSubmit.getGroupId())
         .build();
     final QueryControlResult queryControlResult = proxyToTask.sendQueries(operatorChainDag);
 

--- a/src/main/java/edu/snu/mist/api/MISTQuery.java
+++ b/src/main/java/edu/snu/mist/api/MISTQuery.java
@@ -38,4 +38,9 @@ public interface MISTQuery {
    * Get the DAG of the query.
    */
   DAG<MISTStream, MISTEdge> getDAG();
+
+  /**
+   * Get the group id.
+   */
+  String getGroupId();
 }

--- a/src/main/java/edu/snu/mist/api/MISTQueryBuilder.java
+++ b/src/main/java/edu/snu/mist/api/MISTQueryBuilder.java
@@ -50,6 +50,11 @@ public final class MISTQueryBuilder {
   private static final int DEFAULT_EXPECTED_DELAY = 0;
 
   /**
+   * The group id of the query.
+   */
+  private final String groupId;
+
+  /**
    * The default watermark configuration.
    */
   private WatermarkConfiguration getDefaultWatermarkConf() {
@@ -59,8 +64,9 @@ public final class MISTQueryBuilder {
         .build();
   }
 
-  public MISTQueryBuilder() {
+  public MISTQueryBuilder(final String groupId) {
     this.dag = new AdjacentListDAG<>();
+    this.groupId = groupId;
   }
 
   /**
@@ -146,6 +152,6 @@ public final class MISTQueryBuilder {
    * @return the query
    */
   public MISTQuery build() {
-    return new MISTQueryImpl(dag);
+    return new MISTQueryImpl(dag, groupId);
   }
 }

--- a/src/main/java/edu/snu/mist/api/MISTQueryImpl.java
+++ b/src/main/java/edu/snu/mist/api/MISTQueryImpl.java
@@ -36,10 +36,12 @@ public final class MISTQueryImpl implements MISTQuery {
    */
   private final DAG<MISTStream, MISTEdge> dag;
   private final AvroConfigurationSerializer serializer;
+  private final String groupId;
 
-  public MISTQueryImpl(final DAG<MISTStream, MISTEdge> dag) {
+  public MISTQueryImpl(final DAG<MISTStream, MISTEdge> dag, final String groupId) {
     this.dag = dag;
     this.serializer = new AvroConfigurationSerializer();
+    this.groupId = groupId;
   }
 
   @Override
@@ -115,5 +117,10 @@ public final class MISTQueryImpl implements MISTQuery {
   @Override
   public DAG<MISTStream, MISTEdge> getDAG() {
     return dag;
+  }
+
+  @Override
+  public String getGroupId() {
+    return groupId;
   }
 }

--- a/src/main/java/edu/snu/mist/api/datastreams/configurations/KafkaSourceConfiguration.java
+++ b/src/main/java/edu/snu/mist/api/datastreams/configurations/KafkaSourceConfiguration.java
@@ -17,7 +17,6 @@ package edu.snu.mist.api.datastreams.configurations;
 
 import edu.snu.mist.common.SerializeUtils;
 import edu.snu.mist.common.functions.MISTFunction;
-import edu.snu.mist.common.parameters.GroupId;
 import edu.snu.mist.common.parameters.KafkaTopic;
 import edu.snu.mist.common.parameters.SerializedKafkaConfig;
 import edu.snu.mist.common.parameters.SerializedTimestampExtractUdf;
@@ -41,11 +40,6 @@ import java.util.Set;
 public final class KafkaSourceConfiguration extends ConfigurationModuleBuilder {
 
   /**
-   * The group id of the source.
-   */
-  public static final RequiredParameter<String> GROUP_ID = new RequiredParameter<>();
-
-  /**
    * The kafka topic.
    */
   public static final RequiredParameter<String> KAFKA_TOPIC = new RequiredParameter<>();
@@ -66,7 +60,6 @@ public final class KafkaSourceConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalImpl<MISTFunction> TIMESTAMP_EXTRACT_FUNC = new OptionalImpl<>();
 
   private static final ConfigurationModule CONF = new KafkaSourceConfiguration()
-      .bindNamedParameter(GroupId.class, GROUP_ID)
       .bindNamedParameter(KafkaTopic.class, KAFKA_TOPIC)
       .bindNamedParameter(SerializedKafkaConfig.class, KAFKA_CONSUMER_CONFIG)
       .bindNamedParameter(SerializedTimestampExtractUdf.class, TIMESTAMP_EXTRACT_OBJECT)
@@ -87,7 +80,6 @@ public final class KafkaSourceConfiguration extends ConfigurationModuleBuilder {
    */
   public static final class KafkaSourceConfigurationBuilder {
 
-    private String groupId;
     private String kafkaTopic;
     private HashMap<String, Object> kafkaConfig;
     private MISTFunction<ConsumerRecord, Tuple<ConsumerRecord, Long>> extractFunc;
@@ -99,9 +91,6 @@ public final class KafkaSourceConfiguration extends ConfigurationModuleBuilder {
      * @return the configuration
      */
     public SourceConfiguration build() {
-      if (groupId == null) {
-        throw new IllegalArgumentException("The group id should not be null");
-      }
 
       if (extractFunc != null && extractFuncClass != null) {
         throw new IllegalArgumentException("Cannot bind both extractFunc and extractFuncClass");
@@ -111,14 +100,12 @@ public final class KafkaSourceConfiguration extends ConfigurationModuleBuilder {
         if (extractFunc == null && extractFuncClass == null) {
           // No extract function is set
           return new SourceConfiguration(CONF
-              .set(GROUP_ID, groupId)
               .set(KAFKA_TOPIC, kafkaTopic)
               .set(KAFKA_CONSUMER_CONFIG, SerializeUtils.serializeToString(kafkaConfig))
               .build(), SourceConfiguration.SourceType.KAFKA);
         } else if (extractFunc != null) {
           // Lambda object is set
           return new SourceConfiguration(CONF
-              .set(GROUP_ID, groupId)
               .set(KAFKA_TOPIC, kafkaTopic)
               .set(KAFKA_CONSUMER_CONFIG, SerializeUtils.serializeToString(kafkaConfig))
               .set(TIMESTAMP_EXTRACT_OBJECT, SerializeUtils.serializeToString(extractFunc))
@@ -126,7 +113,6 @@ public final class KafkaSourceConfiguration extends ConfigurationModuleBuilder {
         } else {
           // UDF class is set
           return new SourceConfiguration(Configurations.merge(CONF
-              .set(GROUP_ID, groupId)
               .set(KAFKA_TOPIC, kafkaTopic)
               .set(KAFKA_CONSUMER_CONFIG, SerializeUtils.serializeToString(kafkaConfig))
               .set(TIMESTAMP_EXTRACT_FUNC, extractFuncClass)
@@ -136,16 +122,6 @@ public final class KafkaSourceConfiguration extends ConfigurationModuleBuilder {
         e.printStackTrace();
         throw new RuntimeException(e);
       }
-    }
-
-    /**
-     * Set the group id.
-     * @param gid group id
-     * @return the configured SourceBuilder
-     */
-    public KafkaSourceConfigurationBuilder setGroupId(final String gid) {
-      groupId =  gid;
-      return this;
     }
 
     /**

--- a/src/main/java/edu/snu/mist/api/datastreams/configurations/MQTTSourceConfiguration.java
+++ b/src/main/java/edu/snu/mist/api/datastreams/configurations/MQTTSourceConfiguration.java
@@ -17,7 +17,6 @@ package edu.snu.mist.api.datastreams.configurations;
 
 import edu.snu.mist.common.SerializeUtils;
 import edu.snu.mist.common.functions.MISTFunction;
-import edu.snu.mist.common.parameters.GroupId;
 import edu.snu.mist.common.parameters.MQTTBrokerURI;
 import edu.snu.mist.common.parameters.MQTTTopic;
 import edu.snu.mist.common.parameters.SerializedTimestampExtractUdf;
@@ -34,11 +33,6 @@ import java.io.IOException;
  * This class is agnostic to which broker implementation the source uses.
  */
 public final class MQTTSourceConfiguration extends ConfigurationModuleBuilder {
-
-  /**
-   * The group id of the source.
-   */
-  public static final RequiredParameter<String> GROUP_ID = new RequiredParameter<>();
 
   /**
    * The parameter for MQTT broker URI.
@@ -61,7 +55,6 @@ public final class MQTTSourceConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalImpl<MISTFunction> TIMESTAMP_EXTRACT_FUNC = new OptionalImpl<>();
 
   private static final ConfigurationModule CONF = new MQTTSourceConfiguration()
-      .bindNamedParameter(GroupId.class, GROUP_ID)
       .bindNamedParameter(MQTTBrokerURI.class, MQTT_BROKER_URI)
       .bindNamedParameter(MQTTTopic.class, MQTT_TOPIC)
       .bindNamedParameter(SerializedTimestampExtractUdf.class, TIMESTAMP_EXTRACT_OBJECT)
@@ -81,7 +74,6 @@ public final class MQTTSourceConfiguration extends ConfigurationModuleBuilder {
    */
   public static final class MQTTSourceConfigurationBuilder {
 
-    private String groupId;
     private String mqttBrokerURI;
     private String mqttTopic;
     private MISTFunction<MqttMessage, Tuple<MqttMessage, Long>> extractFunc;
@@ -89,9 +81,6 @@ public final class MQTTSourceConfiguration extends ConfigurationModuleBuilder {
     private Configuration extractFuncConf;
 
     public SourceConfiguration build() {
-      if (groupId == null) {
-        throw new IllegalArgumentException("The group id should not be null");
-      }
 
       if (extractFunc != null && extractFuncClass != null) {
         throw new IllegalArgumentException("Cannot bind both extractFunc and extractFuncClass");
@@ -104,20 +93,17 @@ public final class MQTTSourceConfiguration extends ConfigurationModuleBuilder {
       try {
         if (extractFunc == null && extractFuncClass == null) {
           return new SourceConfiguration(CONF
-              .set(GROUP_ID, groupId)
               .set(MQTT_BROKER_URI, mqttBrokerURI)
               .set(MQTT_TOPIC, mqttTopic)
               .build(), SourceConfiguration.SourceType.MQTT);
         } else if (extractFunc != null && extractFuncClass == null) {
           return new SourceConfiguration(CONF
-              .set(GROUP_ID, groupId)
               .set(MQTT_BROKER_URI, mqttBrokerURI)
               .set(MQTT_TOPIC, mqttTopic)
               .set(TIMESTAMP_EXTRACT_OBJECT, SerializeUtils.serializeToString(extractFunc))
               .build(), SourceConfiguration.SourceType.MQTT);
         } else {
           return new SourceConfiguration(Configurations.merge(CONF
-              .set(GROUP_ID, groupId)
               .set(MQTT_BROKER_URI, mqttBrokerURI)
               .set(MQTT_TOPIC, mqttTopic)
               .set(TIMESTAMP_EXTRACT_FUNC, extractFuncClass)
@@ -127,16 +113,6 @@ public final class MQTTSourceConfiguration extends ConfigurationModuleBuilder {
         e.printStackTrace();
         throw new RuntimeException(e);
       }
-    }
-
-    /**
-     * Set the group id.
-     * @param gid group id
-     * @return the configured SourceBuilder
-     */
-    public MQTTSourceConfigurationBuilder setGroupId(final String gid) {
-      groupId =  gid;
-      return this;
     }
 
     /**

--- a/src/main/java/edu/snu/mist/api/datastreams/configurations/TextSocketSourceConfiguration.java
+++ b/src/main/java/edu/snu/mist/api/datastreams/configurations/TextSocketSourceConfiguration.java
@@ -17,7 +17,6 @@ package edu.snu.mist.api.datastreams.configurations;
 
 import edu.snu.mist.common.SerializeUtils;
 import edu.snu.mist.common.functions.MISTFunction;
-import edu.snu.mist.common.parameters.GroupId;
 import edu.snu.mist.common.parameters.SerializedTimestampExtractUdf;
 import edu.snu.mist.common.parameters.SocketServerIp;
 import edu.snu.mist.common.parameters.SocketServerPort;
@@ -34,11 +33,6 @@ import java.io.IOException;
  * The class represents the text socket source configuration.
  */
 public final class TextSocketSourceConfiguration extends ConfigurationModuleBuilder {
-
-  /**
-   * The group id of the source.
-   */
-  public static final RequiredParameter<String> GROUP_ID = new RequiredParameter<>();
 
   /**
    * The address of the socket source.
@@ -61,7 +55,6 @@ public final class TextSocketSourceConfiguration extends ConfigurationModuleBuil
   public static final OptionalImpl<MISTFunction> TIMESTAMP_EXTRACT_FUNC = new OptionalImpl<>();
 
   private static final ConfigurationModule CONF = new TextSocketSourceConfiguration()
-      .bindNamedParameter(GroupId.class, GROUP_ID)
       .bindNamedParameter(SocketServerIp.class, SOCKET_HOST_ADDR)
       .bindNamedParameter(SocketServerPort.class, SOCKET_HOST_PORT)
       .bindNamedParameter(SerializedTimestampExtractUdf.class, TIMESTAMP_EXTRACT_OBJECT)
@@ -82,7 +75,6 @@ public final class TextSocketSourceConfiguration extends ConfigurationModuleBuil
    */
   public static final class TextSocketSourceConfigurationBuilder {
 
-    private String groupId;
     private String socketServerAddr;
     private int socketServerPort;
     private MISTFunction<String, Tuple<String, Long>> extractFunc;
@@ -94,10 +86,6 @@ public final class TextSocketSourceConfiguration extends ConfigurationModuleBuil
      * @return the configuration
      */
     public SourceConfiguration build() {
-      if (groupId == null) {
-        throw new IllegalArgumentException("The group id should not be null");
-      }
-
       if (extractFunc != null && extractFuncClass != null) {
         throw new IllegalArgumentException("Cannot bind both extractFunc and extractFuncClass");
       }
@@ -105,7 +93,6 @@ public final class TextSocketSourceConfiguration extends ConfigurationModuleBuil
       if (extractFunc == null && extractFuncClass == null) {
         // No udf
         return new SourceConfiguration(CONF
-            .set(GROUP_ID, groupId)
             .set(SOCKET_HOST_ADDR, socketServerAddr)
             .set(SOCKET_HOST_PORT, socketServerPort)
             .build(), SourceConfiguration.SourceType.SOCKET);
@@ -113,7 +100,6 @@ public final class TextSocketSourceConfiguration extends ConfigurationModuleBuil
         // Lambda object is set
         try {
           return new SourceConfiguration(CONF
-              .set(GROUP_ID, groupId)
               .set(SOCKET_HOST_ADDR, socketServerAddr)
               .set(SOCKET_HOST_PORT, socketServerPort)
               .set(TIMESTAMP_EXTRACT_OBJECT, SerializeUtils.serializeToString(extractFunc))
@@ -125,22 +111,11 @@ public final class TextSocketSourceConfiguration extends ConfigurationModuleBuil
       } else {
         // Class binding
         return new SourceConfiguration(Configurations.merge(CONF
-            .set(GROUP_ID, groupId)
             .set(SOCKET_HOST_ADDR, socketServerAddr)
             .set(SOCKET_HOST_PORT, socketServerPort)
             .set(TIMESTAMP_EXTRACT_FUNC, extractFuncClass)
             .build(), extractFuncConf), SourceConfiguration.SourceType.SOCKET);
       }
-    }
-
-    /**
-     * Set the group id.
-     * @param gid group id
-     * @return the configured SourceBuilder
-     */
-    public TextSocketSourceConfigurationBuilder setGroupId(final String gid) {
-      groupId =  gid;
-      return this;
     }
 
     /**

--- a/src/main/java/edu/snu/mist/examples/HelloMist.java
+++ b/src/main/java/edu/snu/mist/examples/HelloMist.java
@@ -49,7 +49,7 @@ public final class HelloMist {
     final SourceConfiguration localTextSocketSourceConf =
         MISTExampleUtils.getLocalTextSocketSourceConf(sourceSocket);
 
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder("example-group");
     queryBuilder.socketTextStream(localTextSocketSourceConf)
         .filter(s -> s.startsWith("HelloMIST:"))
         .map(s -> s.substring("HelloMIST:".length()).trim())

--- a/src/main/java/edu/snu/mist/examples/JoinAndApplyStateful.java
+++ b/src/main/java/edu/snu/mist/examples/JoinAndApplyStateful.java
@@ -65,7 +65,7 @@ public final class JoinAndApplyStateful {
 
     final MISTBiPredicate<String, String> joinPred = (s1, s2) -> s1.equals(s2);
     final ApplyStatefulFunction<Tuple2<String, String>, String> applyStatefulFunction = new FoldStringTupleFunction();
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder("example-group");
     final ContinuousStream sourceStream1 = queryBuilder.socketTextStream(localTextSocketSource1Conf);
     final ContinuousStream sourceStream2 = queryBuilder.socketTextStream(localTextSocketSource2Conf);
 

--- a/src/main/java/edu/snu/mist/examples/KMeansClustering.java
+++ b/src/main/java/edu/snu/mist/examples/KMeansClustering.java
@@ -72,7 +72,7 @@ public final class KMeansClustering {
         };
     final ApplyStatefulFunction<Point, List<Cluster>> applyStatefulFunction = new KMeansFunction();
 
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder("example-group");
     queryBuilder.socketTextStream(localTextSocketSourceConf)
         // remove all space in the input string
         .map(s -> s.replaceAll(" ", ""))

--- a/src/main/java/edu/snu/mist/examples/KafkaSource.java
+++ b/src/main/java/edu/snu/mist/examples/KafkaSource.java
@@ -50,7 +50,7 @@ public final class KafkaSource {
     final SourceConfiguration localKafkaSourceConf =
         MISTExampleUtils.getLocalKafkaSourceConf("KafkaSource", sourceSocket);
 
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder("example-group");
     queryBuilder.kafkaStream(localKafkaSourceConf)
         .map(consumerRecord -> ((ConsumerRecord)consumerRecord).value())
         .textSocketOutput(MISTExampleUtils.SINK_HOSTNAME, MISTExampleUtils.SINK_PORT);

--- a/src/main/java/edu/snu/mist/examples/MISTExampleUtils.java
+++ b/src/main/java/edu/snu/mist/examples/MISTExampleUtils.java
@@ -66,7 +66,6 @@ public final class MISTExampleUtils {
     final String sourceHostname = sourceSocket[0];
     final int sourcePort = Integer.parseInt(sourceSocket[1]);
     return TextSocketSourceConfiguration.newBuilder()
-        .setGroupId("test_group")
         .setHostAddress(sourceHostname)
         .setHostPort(sourcePort)
         .build();
@@ -93,7 +92,6 @@ public final class MISTExampleUtils {
     kafkaConsumerConfig.put("key.deserializer", keyDeserializer);
     kafkaConsumerConfig.put("value.deserializer", valueDeserializer);
     return KafkaSourceConfiguration.newBuilder()
-        .setGroupId("test_group")
         .setTopic(topic)
         .setConsumerConfig(kafkaConsumerConfig)
         .build();
@@ -105,7 +103,6 @@ public final class MISTExampleUtils {
   public static SourceConfiguration getMQTTSourceConf(final String topic,
                                                       final String brokerURI) {
     return MQTTSourceConfiguration.newBuilder()
-        .setGroupId("test_group")
         .setTopic(topic)
         .setBrokerURI(brokerURI)
         .build();

--- a/src/main/java/edu/snu/mist/examples/MQTTNoiseSensing.java
+++ b/src/main/java/edu/snu/mist/examples/MQTTNoiseSensing.java
@@ -53,7 +53,7 @@ public final class MQTTNoiseSensing {
     final SourceConfiguration localMQTTSourceConf =
         MISTExampleUtils.getMQTTSourceConf("MISTExampleSub", brokerURI);
 
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder("example-group");
     final ContinuousStream<Integer> sensedData = queryBuilder.mqttStream(localMQTTSourceConf)
         .map((mqttMessage) -> Integer.parseInt(new String(mqttMessage.getPayload())));
 

--- a/src/main/java/edu/snu/mist/examples/QueryDeletion.java
+++ b/src/main/java/edu/snu/mist/examples/QueryDeletion.java
@@ -59,7 +59,7 @@ public final class QueryDeletion {
 
     // Simple reduce function.
     final MISTBiFunction<Integer, Integer, Integer> reduceFunction = (v1, v2) -> { return v1 + v2; };
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder("example-group");
     queryBuilder.socketTextStream(localTextSocketSourceConf)
         .filter(s -> isAlpha(s))
         .map(s -> new Tuple2(s, 1))

--- a/src/main/java/edu/snu/mist/examples/SessionWindow.java
+++ b/src/main/java/edu/snu/mist/examples/SessionWindow.java
@@ -63,7 +63,7 @@ public final class SessionWindow {
                       windowData.getStart() + ", window is ended at " + windowData.getEnd() + ".";
             };
 
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder("example-group");
     queryBuilder.socketTextStream(localTextSocketSourceConf)
             .window(new SessionWindowInformation(sessionInterval))
             .aggregateWindow(aggregateFunc)

--- a/src/main/java/edu/snu/mist/examples/UnionMist.java
+++ b/src/main/java/edu/snu/mist/examples/UnionMist.java
@@ -59,7 +59,7 @@ public final class UnionMist {
     // Simple reduce function.
     final MISTBiFunction<Integer, Integer, Integer> reduceFunction = (v1, v2) -> { return v1 + v2; };
 
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder("example-group");
     final ContinuousStream sourceStream1 = queryBuilder.socketTextStream(localTextSocketSource1Conf)
         .map(s -> new Tuple2(s, 1));
     final ContinuousStream sourceStream2 = queryBuilder.socketTextStream(localTextSocketSource2Conf)

--- a/src/main/java/edu/snu/mist/examples/WindowAndAggregate.java
+++ b/src/main/java/edu/snu/mist/examples/WindowAndAggregate.java
@@ -62,7 +62,7 @@ public final class WindowAndAggregate {
               windowData.getStart() + ", window is ended at " + windowData.getEnd() + ".";
         };
 
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder("example-group");
     queryBuilder.socketTextStream(localTextSocketSourceConf)
         .window(new TimeWindowInformation(windowSize, windowEmissionInterval))
         .aggregateWindow(aggregateFunc)

--- a/src/main/java/edu/snu/mist/examples/WordCount.java
+++ b/src/main/java/edu/snu/mist/examples/WordCount.java
@@ -57,7 +57,7 @@ public final class WordCount {
 
     // Simple reduce function.
     final MISTBiFunction<Integer, Integer, Integer> reduceFunction = (v1, v2) -> { return v1 + v2; };
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder("example-group");
     queryBuilder.socketTextStream(localTextSocketSourceConf)
         .filter(s -> isAlpha(s))
         .map(s -> new Tuple2(s, 1))

--- a/src/test/java/edu/snu/mist/api/LogicalDagOptimizerTest.java
+++ b/src/test/java/edu/snu/mist/api/LogicalDagOptimizerTest.java
@@ -49,7 +49,7 @@ public final class LogicalDagOptimizerTest {
    */
   @Test
   public void testConditionalBranch() throws InjectionException {
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder(TestParameters.GROUP_ID);
     final ContinuousStream<String> src1 =
         queryBuilder.socketTextStream(TestParameters.LOCAL_TEXT_SOCKET_SOURCE_CONF);
     final ContinuousStream<String> op1 = src1.filter((x) -> true);

--- a/src/test/java/edu/snu/mist/api/MISTDefaultExecutionEnvironmentImplTest.java
+++ b/src/test/java/edu/snu/mist/api/MISTDefaultExecutionEnvironmentImplTest.java
@@ -80,7 +80,7 @@ public class MISTDefaultExecutionEnvironmentImplTest {
         new InetSocketAddress(taskPortNum));
 
     // Step 2: Generate a new query
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder(TestParameters.GROUP_ID);
     queryBuilder.socketTextStream(TestParameters.LOCAL_TEXT_SOCKET_SOURCE_CONF)
         .flatMap(s -> Arrays.asList(s.split(" ")))
         .map(s -> new Tuple2<>(s, 1))

--- a/src/test/java/edu/snu/mist/api/MISTQueryBuilderTest.java
+++ b/src/test/java/edu/snu/mist/api/MISTQueryBuilderTest.java
@@ -48,15 +48,13 @@ public class MISTQueryBuilderTest {
    */
   @Test
   public void testNettyTextSourceSerializationWithoutUdf() throws InjectionException {
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder(TestParameters.GROUP_ID);
     final ContinuousStream<String> stream =
         queryBuilder.socketTextStream(TestParameters.LOCAL_TEXT_SOCKET_SOURCE_CONF);
     // check
     final Injector injector = Tang.Factory.getTang().newInjector(stream.getConfiguration());
-    final String groupId = injector.getNamedInstance(GroupId.class);
     final String deHost = injector.getNamedInstance(SocketServerIp.class);
     final int dePort = injector.getNamedInstance(SocketServerPort.class);
-    Assert.assertEquals(TestParameters.GROUP_ID, groupId);
     Assert.assertEquals(TestParameters.HOST, deHost);
     Assert.assertEquals(TestParameters.SERVER_PORT, dePort);
   }
@@ -68,21 +66,18 @@ public class MISTQueryBuilderTest {
   public void testNettyTextSourceSerializationWithUdf()
       throws InjectionException, IOException, ClassNotFoundException {
     final MISTFunction<String, Tuple<String, Long>> timestampExtFunc = s -> new Tuple<>(s, 1L);
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder(TestParameters.GROUP_ID);
     final ContinuousStream<String> stream =
         queryBuilder.socketTextStream(TextSocketSourceConfiguration.newBuilder()
-            .setGroupId(TestParameters.GROUP_ID)
             .setHostAddress(TestParameters.HOST)
             .setHostPort(TestParameters.SERVER_PORT)
             .setTimestampExtractionFunction(timestampExtFunc)
             .build());
     // check
     final Injector injector = Tang.Factory.getTang().newInjector(stream.getConfiguration());
-    final String groupId = injector.getNamedInstance(GroupId.class);
     final String deHost = injector.getNamedInstance(SocketServerIp.class);
     final int dePort = injector.getNamedInstance(SocketServerPort.class);
     final String seTimeFunc = injector.getNamedInstance(SerializedTimestampExtractUdf.class);
-    Assert.assertEquals(TestParameters.GROUP_ID, groupId);
     Assert.assertEquals(TestParameters.HOST, deHost);
     Assert.assertEquals(TestParameters.SERVER_PORT, dePort);
     Assert.assertEquals(SerializeUtils.serializeToString(timestampExtFunc), seTimeFunc);
@@ -96,21 +91,18 @@ public class MISTQueryBuilderTest {
       throws InjectionException, IOException, ClassNotFoundException {
     final Configuration funcConf = Tang.Factory.getTang().newConfigurationBuilder().build();
     final MISTFunction<String, Tuple<String, Long>> timestampExtFunc = s -> new Tuple<>(s, 1L);
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder(TestParameters.GROUP_ID);
     final ContinuousStream<String> stream =
         queryBuilder.socketTextStream(TextSocketSourceConfiguration.newBuilder()
-            .setGroupId(TestParameters.GROUP_ID)
             .setHostAddress(TestParameters.HOST)
             .setHostPort(TestParameters.SERVER_PORT)
             .setTimestampExtractionFunction(OperatorTestUtils.TestNettyTimestampExtractFunc.class, funcConf)
             .build());
     // check
     final Injector injector = Tang.Factory.getTang().newInjector(stream.getConfiguration());
-    final String groupId = injector.getNamedInstance(GroupId.class);
     final String deHost = injector.getNamedInstance(SocketServerIp.class);
     final int dePort = injector.getNamedInstance(SocketServerPort.class);
     final MISTFunction func = injector.getInstance(MISTFunction.class);
-    Assert.assertEquals(TestParameters.GROUP_ID, groupId);
     Assert.assertEquals(TestParameters.HOST, deHost);
     Assert.assertEquals(TestParameters.SERVER_PORT, dePort);
     Assert.assertTrue(func instanceof OperatorTestUtils.TestNettyTimestampExtractFunc);
@@ -134,21 +126,18 @@ public class MISTQueryBuilderTest {
     consumerConfig.put(groupKey, groupValue);
     consumerConfig.put(valueDeserializerKey, valueDeserializer);
 
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder(TestParameters.GROUP_ID);
     final ContinuousStream<ConsumerRecord<Integer, String>> kafkaSourceStream =
         queryBuilder.kafkaStream(KafkaSourceConfiguration.newBuilder()
-            .setGroupId(TestParameters.GROUP_ID)
             .setTopic(topic)
             .setConsumerConfig(consumerConfig)
             .build());
 
     // Check about source configuration
     final Injector injector = Tang.Factory.getTang().newInjector(kafkaSourceStream.getConfiguration());
-    final String groupId = injector.getNamedInstance(GroupId.class);
     final String desTopic = injector.getNamedInstance(KafkaTopic.class);
     final String seConsumerConfig = injector.getNamedInstance(SerializedKafkaConfig.class);
     final Map<String, Object> deConsumerConfig = SerializeUtils.deserializeFromString(seConsumerConfig);
-    Assert.assertEquals(TestParameters.GROUP_ID, groupId);
     Assert.assertEquals(topic, desTopic);
     Assert.assertEquals(consumerConfig, deConsumerConfig);
 
@@ -165,20 +154,17 @@ public class MISTQueryBuilderTest {
     final String expectedBrokerURI = "tcp://192.168.0.1:3386";
     final String expectedTopic = "region/system/subsystem/device/sensor";
 
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder(TestParameters.GROUP_ID);
     final ContinuousStream<MqttMessage> mqttSourceStream =
         queryBuilder.mqttStream(MQTTSourceConfiguration.newBuilder()
-            .setGroupId(TestParameters.GROUP_ID)
             .setBrokerURI(expectedBrokerURI)
             .setTopic(expectedTopic)
             .build());
 
     // Check source configuration
     final Injector injector = Tang.Factory.getTang().newInjector(mqttSourceStream.getConfiguration());
-    final String groupId = injector.getNamedInstance(GroupId.class);
     final String resultBrokerAddress = injector.getNamedInstance(MQTTBrokerURI.class);
     final String resultTopic = injector.getNamedInstance(MQTTTopic.class);
-    Assert.assertEquals(TestParameters.GROUP_ID, groupId);
     Assert.assertEquals(expectedBrokerURI, resultBrokerAddress);
     Assert.assertEquals(expectedTopic, resultTopic);
 

--- a/src/test/java/edu/snu/mist/api/MISTQueryTest.java
+++ b/src/test/java/edu/snu/mist/api/MISTQueryTest.java
@@ -64,7 +64,7 @@ public final class MISTQueryTest {
    */
   @Test
   public void mistComplexQuerySerializeTest() throws InjectionException, IOException, URISyntaxException {
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder(TestParameters.GROUP_ID);
     final ContinuousStream<String> sourceStream =
         queryBuilder.socketTextStream(TestParameters.LOCAL_TEXT_SOCKET_SOURCE_CONF,
             TestParameters.PUNCTUATED_WATERMARK_CONF);

--- a/src/test/java/edu/snu/mist/api/OperatorChainDagGeneratorTest.java
+++ b/src/test/java/edu/snu/mist/api/OperatorChainDagGeneratorTest.java
@@ -47,7 +47,7 @@ public final class OperatorChainDagGeneratorTest {
   @Test
   public void testComplexQueryPartitioning() throws InjectionException {
     // Build a operator chain dag
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder(TestParameters.GROUP_ID);
     final ContinuousStream<String> src1 =
         queryBuilder.socketTextStream(TestParameters.LOCAL_TEXT_SOCKET_SOURCE_CONF);
     final ContinuousStream<String> src2 =
@@ -129,7 +129,7 @@ public final class OperatorChainDagGeneratorTest {
    */
   @Test
   public void testSequentialChaining() throws InjectionException {
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder(TestParameters.GROUP_ID);
     final ContinuousStream<String> src1 =
         queryBuilder.socketTextStream(TestParameters.LOCAL_TEXT_SOCKET_SOURCE_CONF);
     final ContinuousStream<String> op11 = src1.filter((x) -> true);
@@ -172,7 +172,7 @@ public final class OperatorChainDagGeneratorTest {
    */
   @Test
   public void testBranchTest() throws InjectionException {
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder(TestParameters.GROUP_ID);
     final ContinuousStream<String> src1 =
         queryBuilder.socketTextStream(TestParameters.LOCAL_TEXT_SOCKET_SOURCE_CONF);
     final ContinuousStream<String> op11 = src1.filter((x) -> true);
@@ -246,7 +246,7 @@ public final class OperatorChainDagGeneratorTest {
    */
   @Test
   public void testMergingQueryPartitioning() throws InjectionException {
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder(TestParameters.GROUP_ID);
     final ContinuousStream<String> src1 =
         queryBuilder.socketTextStream(TestParameters.LOCAL_TEXT_SOCKET_SOURCE_CONF);
     final ContinuousStream<String> src2 =
@@ -334,7 +334,7 @@ public final class OperatorChainDagGeneratorTest {
    */
   @Test
   public void testForkAndMergeChaining() throws InjectionException {
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder(TestParameters.GROUP_ID);
     final ContinuousStream<String> src1 =
         queryBuilder.socketTextStream(TestParameters.LOCAL_TEXT_SOCKET_SOURCE_CONF);
     final ContinuousStream<String> opA = src1.filter((x) -> true);

--- a/src/test/java/edu/snu/mist/api/datastreams/ContinuousStreamTest.java
+++ b/src/test/java/edu/snu/mist/api/datastreams/ContinuousStreamTest.java
@@ -62,7 +62,7 @@ public final class ContinuousStreamTest {
 
   @Before
   public void setUp() {
-    queryBuilder = new MISTQueryBuilder();
+    queryBuilder = new MISTQueryBuilder(TestParameters.GROUP_ID);
     sourceStream = queryBuilder.socketTextStream(TestParameters.LOCAL_TEXT_SOCKET_SOURCE_CONF);
     filteredStream = sourceStream.filter(defaultFilter);
     filteredMappedStream = filteredStream.map(defaultMap);

--- a/src/test/java/edu/snu/mist/api/datastreams/WindowedStreamTest.java
+++ b/src/test/java/edu/snu/mist/api/datastreams/WindowedStreamTest.java
@@ -54,7 +54,7 @@ public class WindowedStreamTest {
 
   @Before
   public void setUp() {
-    queryBuilder = new MISTQueryBuilder();
+    queryBuilder = new MISTQueryBuilder(TestParameters.GROUP_ID);
     timeWindowedStream = queryBuilder.socketTextStream(TestParameters.LOCAL_TEXT_SOCKET_SOURCE_CONF)
         .map(s -> new Tuple2<>(s, 1))
         .window(new TimeWindowInformation(5000, 1000));

--- a/src/test/java/edu/snu/mist/core/task/DefaultDagGeneratorImplTest.java
+++ b/src/test/java/edu/snu/mist/core/task/DefaultDagGeneratorImplTest.java
@@ -79,7 +79,7 @@ public final class DefaultDagGeneratorImplTest {
   public void testPlanGenerator()
       throws InjectionException, IOException, URISyntaxException, ClassNotFoundException {
     // Generate a query
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder(TestParameters.GROUP_ID);
     queryBuilder.socketTextStream(TestParameters.LOCAL_TEXT_SOCKET_SOURCE_CONF)
         .flatMap(s -> Arrays.asList(s.split(" ")))
         .filter(s -> s.startsWith("A"))
@@ -91,6 +91,7 @@ public final class DefaultDagGeneratorImplTest {
     final Tuple<List<AvroVertexChain>, List<Edge>> serializedDag = query.getAvroOperatorChainDag();
     final AvroOperatorChainDag.Builder avroOpChainDagBuilder = AvroOperatorChainDag.newBuilder();
     final AvroOperatorChainDag avroChainedDag = avroOpChainDagBuilder
+        .setGroupId(TestParameters.GROUP_ID)
         .setJarFilePaths(new LinkedList<>())
         .setAvroVertices(serializedDag.getKey())
         .setEdges(serializedDag.getValue())

--- a/src/test/java/edu/snu/mist/core/task/PhysicalObjectGeneratorTest.java
+++ b/src/test/java/edu/snu/mist/core/task/PhysicalObjectGeneratorTest.java
@@ -76,7 +76,6 @@ public final class PhysicalObjectGeneratorTest {
   @Test
   public void testSuccessOfNettyTextDataGenerator() throws Exception {
     final Configuration conf = TextSocketSourceConfiguration.newBuilder()
-        .setGroupId("test_group")
         .setHostAddress("localhost")
         .setHostPort(13666)
         .build().getConfiguration();
@@ -89,7 +88,6 @@ public final class PhysicalObjectGeneratorTest {
   public void testSuccessOfNettyTextDataGeneratorWithClassBinding() throws Exception {
     final Configuration funcConf = Tang.Factory.getTang().newConfigurationBuilder().build();
     final Configuration conf = TextSocketSourceConfiguration.newBuilder()
-        .setGroupId("test_group")
         .setHostAddress("localhost")
         .setHostPort(13666)
         .setTimestampExtractionFunction(OperatorTestUtils.TestNettyTimestampExtractFunc.class, funcConf)
@@ -103,7 +101,6 @@ public final class PhysicalObjectGeneratorTest {
   public void testSuccessOfKafkaDataGenerator() throws Exception {
     final HashMap<String, Object> kafkaConsumerConf = new HashMap<>();
     final Configuration conf = KafkaSourceConfiguration.newBuilder()
-        .setGroupId("test_group")
         .setTopic("localhost")
         .setConsumerConfig(kafkaConsumerConf)
         .build().getConfiguration();
@@ -117,7 +114,6 @@ public final class PhysicalObjectGeneratorTest {
     final Configuration funcConf = Tang.Factory.getTang().newConfigurationBuilder().build();
     final HashMap<String, Object> kafkaConsumerConf = new HashMap<>();
     final Configuration conf = KafkaSourceConfiguration.newBuilder()
-        .setGroupId("test_group")
         .setTopic("localhost")
         .setConsumerConfig(kafkaConsumerConf)
         .setTimestampExtractionFunction(OperatorTestUtils.TestKafkaTimestampExtractFunc.class, funcConf)
@@ -130,7 +126,6 @@ public final class PhysicalObjectGeneratorTest {
   @Test
   public void testSuccessOfMQTTDataGenerator() throws Exception {
     final Configuration conf = MQTTSourceConfiguration.newBuilder()
-        .setGroupId("test_group")
         .setBrokerURI("tcp://localhost:12345")
         .setTopic("topic")
         .build().getConfiguration();
@@ -144,7 +139,6 @@ public final class PhysicalObjectGeneratorTest {
   public void testSuccessOfMQTTDataGeneratorWithClassBinding() throws Exception {
     final Configuration funcConf = Tang.Factory.getTang().newConfigurationBuilder().build();
     final Configuration conf = MQTTSourceConfiguration.newBuilder()
-        .setGroupId("test_group")
         .setBrokerURI("tcp://localhost:12345")
         .setTopic("topic")
         .setTimestampExtractionFunction(OperatorTestUtils.TestMQTTTimestampExtractFunc.class, funcConf)
@@ -188,7 +182,6 @@ public final class PhysicalObjectGeneratorTest {
         .setWatermarkPredicate(OperatorTestUtils.TestPredicate.class, funcConf)
         .build().getConfiguration();
     final Configuration srcConf = TextSocketSourceConfiguration.newBuilder()
-        .setGroupId("test_group")
         .setHostAddress("localhost")
         .setHostPort(13666)
         .setTimestampExtractionFunction(OperatorTestUtils.TestNettyTimestampExtractFunc.class, funcConf)
@@ -205,7 +198,6 @@ public final class PhysicalObjectGeneratorTest {
   @Test(expected=InjectionException.class)
   public void testInjectionExceptionOfOperator() throws IOException, InjectionException {
     final Configuration conf = TextSocketSourceConfiguration.newBuilder()
-        .setGroupId("test_group")
         .setHostAddress("localhost")
         .setHostPort(13666)
         .build().getConfiguration();
@@ -405,7 +397,6 @@ public final class PhysicalObjectGeneratorTest {
   @Test(expected=InjectionException.class)
   public void testInjectionExceptionOfSink() throws IOException, InjectionException {
     final Configuration conf = TextSocketSourceConfiguration.newBuilder()
-        .setGroupId("test_group")
         .setHostAddress("localhost")
         .setHostPort(13666)
         .build().getConfiguration();

--- a/src/test/java/edu/snu/mist/core/task/stores/QueryInfoStoreTest.java
+++ b/src/test/java/edu/snu/mist/core/task/stores/QueryInfoStoreTest.java
@@ -50,7 +50,7 @@ public class QueryInfoStoreTest {
   @Test
   public void diskStoreTest() throws InjectionException, IOException {
     // Generate a query
-    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder(TestParameters.GROUP_ID);
     queryBuilder.socketTextStream(TestParameters.LOCAL_TEXT_SOCKET_SOURCE_CONF)
         .flatMap(s -> Arrays.asList(s.split(" ")))
         .filter(s -> s.startsWith("A"))
@@ -87,6 +87,7 @@ public class QueryInfoStoreTest {
     final Tuple<List<AvroVertexChain>, List<Edge>> serializedDag = query.getAvroOperatorChainDag();
     final AvroOperatorChainDag.Builder avroOpChainDagBuilder = AvroOperatorChainDag.newBuilder();
     final AvroOperatorChainDag avroOpChainDag = avroOpChainDagBuilder
+        .setGroupId(TestParameters.GROUP_ID)
         .setJarFilePaths(paths)
         .setAvroVertices(serializedDag.getKey())
         .setEdges(serializedDag.getValue())

--- a/src/test/java/edu/snu/mist/utils/TestParameters.java
+++ b/src/test/java/edu/snu/mist/utils/TestParameters.java
@@ -33,19 +33,17 @@ public final class TestParameters {
   public static final String HOST = "localhost";
   public static final int SERVER_PORT = 13666;
   public static final int SINK_PORT = 13667;
-  public static final String GROUP_ID = "test_group";
   public static final String TOPIC = "mqttTopic";
+  public static final String GROUP_ID = "test-group";
 
   public static final SourceConfiguration LOCAL_TEXT_SOCKET_SOURCE_CONF =
       TextSocketSourceConfiguration.newBuilder()
-          .setGroupId(GROUP_ID)
           .setHostAddress(HOST)
           .setHostPort(SERVER_PORT)
           .build();
 
   public static final SourceConfiguration LOCAL_TEXT_SOCKET_EVENTTIME_SOURCE_CONF =
       TextSocketSourceConfiguration.newBuilder()
-          .setGroupId("test_group")
           .setHostAddress(HOST)
           .setHostPort(SERVER_PORT)
           .setTimestampExtractionFunction(input -> new Tuple<>(input.split(":")[0],


### PR DESCRIPTION
This PR addressed #547 by 
* removing `groupId` from sources
* adding `groupId` to `QueryBuilder`

Closes #547 