### PR TITLE
[MIST-569] Make QueryStarter unaware of Group

### DIFF
--- a/src/main/java/edu/snu/mist/core/task/GroupAwareQueryManagerImpl.java
+++ b/src/main/java/edu/snu/mist/core/task/GroupAwareQueryManagerImpl.java
@@ -108,6 +108,7 @@ final class GroupAwareQueryManagerImpl implements QueryManager {
         final JavaConfigurationBuilder jcb = Tang.Factory.getTang().newConfigurationBuilder();
         jcb.bindNamedParameter(GroupId.class, groupId);
         jcb.bindNamedParameter(NumThreads.class, Integer.toString(numThreads));
+        jcb.bindImplementation(QueryStarter.class, ImmediateQueryMergingStarter.class);
         final Injector injector = Tang.Factory.getTang().newInjector(jcb.build());
         groupInfoMap.putIfAbsent(groupId, injector.getInstance(GroupInfo.class));
       }
@@ -115,11 +116,12 @@ final class GroupAwareQueryManagerImpl implements QueryManager {
       final GroupInfo groupInfo = groupInfoMap.get(groupId);
       groupInfo.addQueryIdToGroup(queryId);
       // Start the submitted dag
-      groupInfo.getQueryStarter().start(groupInfo, executionDag);
+      groupInfo.getQueryStarter().start(executionDag);
       queryControlResult.setIsSuccess(true);
       queryControlResult.setMsg(ResultMessage.submitSuccess(tuple.getKey()));
       return queryControlResult;
     } catch (final Exception e) {
+      e.printStackTrace();
       // [MIST-345] We need to release all of the information that is required for the query when it fails.
       LOG.log(Level.SEVERE, "An exception occurred while starting {0} query: {1}",
           new Object[] {tuple.getKey(), e.toString()});

--- a/src/main/java/edu/snu/mist/core/task/NoMergingQueryStarter.java
+++ b/src/main/java/edu/snu/mist/core/task/NoMergingQueryStarter.java
@@ -24,7 +24,7 @@ import javax.inject.Inject;
  * This query starter does not merge queries.
  * Instead, it executes them separately.
  */
-final class DefaultQueryStarter implements QueryStarter {
+final class NoMergingQueryStarter implements QueryStarter {
 
   /**
    * Operator chain manager that manages the operator chains.
@@ -32,7 +32,7 @@ final class DefaultQueryStarter implements QueryStarter {
   private final OperatorChainManager operatorChainManager;
 
   @Inject
-  private DefaultQueryStarter(final OperatorChainManager operatorChainManager) {
+  private NoMergingQueryStarter(final OperatorChainManager operatorChainManager) {
     this.operatorChainManager = operatorChainManager;
   }
 
@@ -41,7 +41,7 @@ final class DefaultQueryStarter implements QueryStarter {
    * and starts to receive input data stream from the sources.
    */
   @Override
-  public void start(final GroupInfo groupInfo, final DAG<ExecutionVertex, MISTEdge> submittedDag) {
+  public void start(final DAG<ExecutionVertex, MISTEdge> submittedDag) {
     QueryStarterUtils.setUpOutputEmitters(operatorChainManager, submittedDag);
     // starts to receive input data stream from the sources
     for (final ExecutionVertex source : submittedDag.getRootVertices()) {

--- a/src/main/java/edu/snu/mist/core/task/QueryStarter.java
+++ b/src/main/java/edu/snu/mist/core/task/QueryStarter.java
@@ -22,13 +22,12 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 /**
  * This interface represents a component that is responsible for starting and executing queries.
  */
-@DefaultImplementation(DefaultQueryStarter.class)
+@DefaultImplementation(ImmediateQueryMergingStarter.class)
 interface QueryStarter {
 
   /**
    * Start to execute the submitted query.
-   * @param groupInfo the group info that will contain the query
    * @param submittedDag the submitted dag
    */
-  void start(GroupInfo groupInfo, DAG<ExecutionVertex, MISTEdge> submittedDag);
+  void start(DAG<ExecutionVertex, MISTEdge> submittedDag);
 }

--- a/src/test/java/edu/snu/mist/core/task/ImmediateQueryMergingStarterTest.java
+++ b/src/test/java/edu/snu/mist/core/task/ImmediateQueryMergingStarterTest.java
@@ -52,11 +52,6 @@ public final class ImmediateQueryMergingStarterTest {
   private DagGenerator dagGenerator;
 
   /**
-   * Immediate query merging starter.
-   */
-  private ImmediateQueryMergingStarter queryMerger;
-
-  /**
    * A variable for creating configurations.
    */
   private int confCount = 0;
@@ -70,7 +65,6 @@ public final class ImmediateQueryMergingStarterTest {
   public void setUp() throws InjectionException, IOException {
     final Injector injector = Tang.Factory.getTang().newInjector();
     dagGenerator = Tang.Factory.getTang().newInjector().getInstance(DagGenerator.class);
-    queryMerger = injector.getInstance(ImmediateQueryMergingStarter.class);
   }
 
   @After
@@ -190,7 +184,7 @@ public final class ImmediateQueryMergingStarterTest {
     final DAG<ExecutionVertex, MISTEdge> query = generateSimpleQuery(source, operatorChain, sink);
     // Execute the query 1
     final GroupInfo groupInfo = generateGroupInfo(TestParameters.GROUP_ID);
-    queryMerger.start(groupInfo, query);
+    groupInfo.getQueryStarter().start(query);
     // Generate events for the query and check if the dag is executed correctly
     final String data1 = "Hello";
     source.send(data1);
@@ -224,8 +218,8 @@ public final class ImmediateQueryMergingStarterTest {
 
     // Execute two queries
     final GroupInfo groupInfo = generateGroupInfo(TestParameters.GROUP_ID);
-    queryMerger.start(groupInfo, query1);
-    queryMerger.start(groupInfo, query2);
+    groupInfo.getQueryStarter().start(query1);
+    groupInfo.getQueryStarter().start(query2);
 
     // Check
     final ExecutionDags<String> executionDags = groupInfo.getExecutionDags();
@@ -277,7 +271,7 @@ public final class ImmediateQueryMergingStarterTest {
 
     // Execute the query 1
     final GroupInfo groupInfo = generateGroupInfo(TestParameters.GROUP_ID);
-    queryMerger.start(groupInfo, query1);
+    groupInfo.getQueryStarter().start(query1);
 
     // The query 1 and 2 should be merged and the following dag should be created:
     // src1 -> oc1 -> sink1
@@ -288,7 +282,7 @@ public final class ImmediateQueryMergingStarterTest {
     expectedDag.addEdge(operatorChain1, sink2, query2.getEdges(operatorChain2).get(sink2));
 
     // Execute the query 2
-    queryMerger.start(groupInfo, query2);
+    groupInfo.getQueryStarter().start(query2);
 
     final ExecutionDags<String> executionDags = groupInfo.getExecutionDags();
     final DAG<ExecutionVertex, MISTEdge> mergedDag = executionDags.get(sourceConf);
@@ -335,10 +329,10 @@ public final class ImmediateQueryMergingStarterTest {
     // Execute the query 1
     final GroupInfo group1 = generateGroupInfo("g1");
     final GroupInfo group2 = generateGroupInfo("g2");
-    queryMerger.start(group1, query1);
+    group1.getQueryStarter().start(query1);
 
     // Execute the query 2
-    queryMerger.start(group2, query2);
+    group2.getQueryStarter().start(query2);
 
     final ExecutionDags<String> executionDags1 = group1.getExecutionDags();
     final ExecutionDags<String> executionDags2 = group2.getExecutionDags();
@@ -387,7 +381,7 @@ public final class ImmediateQueryMergingStarterTest {
 
     // Execute the query 1
     final GroupInfo groupInfo = generateGroupInfo(TestParameters.GROUP_ID);
-    queryMerger.start(groupInfo, query1);
+    groupInfo.getQueryStarter().start(query1);
 
     // The query 1 and 2 should be merged and the following dag should be created:
     // src1 -> oc1 -> sink1
@@ -401,7 +395,7 @@ public final class ImmediateQueryMergingStarterTest {
     expectedDag.addEdge(operatorChain2, sink2, query2.getEdges(operatorChain2).get(sink2));
 
     // Execute the query 2
-    queryMerger.start(groupInfo, query2);
+    groupInfo.getQueryStarter().start(query2);
 
     final ExecutionDags<String> executionDags = groupInfo.getExecutionDags();
     final DAG<ExecutionVertex, MISTEdge> mergedDag = executionDags.get(sourceConf);

--- a/src/test/java/edu/snu/mist/core/task/QueryManagerTest.java
+++ b/src/test/java/edu/snu/mist/core/task/QueryManagerTest.java
@@ -117,7 +117,7 @@ public final class QueryManagerTest {
     final EventGenerator eventGenerator =
         new PunctuatedEventGenerator(null, input -> false, null);
     final PhysicalSource src = new PhysicalSourceImpl("testSource",
-        null, dataGenerator, eventGenerator);
+        "conf", dataGenerator, eventGenerator);
 
     final JavaConfigurationBuilder jcb = Tang.Factory.getTang().newConfigurationBuilder();
     jcb.bindNamedParameter(NumThreads.class, Integer.toString(4));


### PR DESCRIPTION
This PR addressed #569 by 
* removing parameter `groupInfo` from `QueryStarter` 
* using `groupInfo.getQueryStarter()` to get `QueryStarter` instance. 

Closes #569 