### PR TITLE
[MIST-587] Add ExecutionVertex in VertexInfo

### DIFF
--- a/src/main/java/edu/snu/mist/core/task/ImmediateQueryMergingStarter.java
+++ b/src/main/java/edu/snu/mist/core/task/ImmediateQueryMergingStarter.java
@@ -79,7 +79,7 @@ final class ImmediateQueryMergingStarter implements QueryStarter {
 
     // Create vertex info map
     for (final ExecutionVertex ev : executionPlan.getVertices()) {
-      final VertexInfo vertexInfo = new VertexInfo(submittedDag);
+      final VertexInfo vertexInfo = new VertexInfo(submittedDag, ev);
       vertexInfoMap.put(ev, vertexInfo);
     }
 

--- a/src/main/java/edu/snu/mist/core/task/VertexInfo.java
+++ b/src/main/java/edu/snu/mist/core/task/VertexInfo.java
@@ -31,18 +31,27 @@ final class VertexInfo {
   private int refCount;
 
   /**
+   * The physical execution vertex that is referenced by the vertex of the query plan.
+   */
+  private final ExecutionVertex physicalExecutionVertex;
+
+  /**
    * Physical execution DAG that holds the execution vertex.
    * This dag can be merged with other dags, so we need to update it when it is merged.
    */
   private DAG<ExecutionVertex, MISTEdge> physicalExecutionDag;
 
-  public VertexInfo(final DAG<ExecutionVertex, MISTEdge> physicalExecutionDag) {
-    this(1, physicalExecutionDag);
+  public VertexInfo(final DAG<ExecutionVertex, MISTEdge> physicalExecutionDag,
+                    final ExecutionVertex physicalExecutionVertex) {
+    this(1, physicalExecutionDag, physicalExecutionVertex);
   }
 
-  public VertexInfo(final int refCount, final DAG<ExecutionVertex, MISTEdge> physicalExecutionDag) {
+  public VertexInfo(final int refCount,
+                    final DAG<ExecutionVertex, MISTEdge> physicalExecutionDag,
+                    final ExecutionVertex physicalExecutionVertex) {
     this.refCount = refCount;
     this.physicalExecutionDag = physicalExecutionDag;
+    this.physicalExecutionVertex = physicalExecutionVertex;
   }
 
   /**
@@ -59,6 +68,14 @@ final class VertexInfo {
    */
   public void setRefCount(final int count) {
     refCount = count;
+  }
+
+  /**
+   * Get the physical execution vertex.
+   * @return physical execution vertex
+   */
+  public ExecutionVertex getPhysicalExecutionVertex() {
+    return physicalExecutionVertex;
   }
 
   /**

--- a/src/test/java/edu/snu/mist/core/task/ImmediateQueryMergingStarterTest.java
+++ b/src/test/java/edu/snu/mist/core/task/ImmediateQueryMergingStarterTest.java
@@ -288,15 +288,21 @@ public final class ImmediateQueryMergingStarterTest {
     Assert.assertEquals(Arrays.asList(data), result1);
     Assert.assertEquals(Arrays.asList(data), result2);
 
-    // Check reference count of the execution vertices
+    // Check reference count and physical vertex of the execution vertices
     Assert.assertEquals(query1Plan, executionPlanDagMap.get("q1"));
     Assert.assertEquals(query2Plan, executionPlanDagMap.get("q2"));
     Assert.assertEquals(2, vertexInfoMap.get(src1).getRefCount());
+    Assert.assertEquals(src1, vertexInfoMap.get(src1).getPhysicalExecutionVertex());
     Assert.assertEquals(2, vertexInfoMap.get(src2).getRefCount());
+    Assert.assertEquals(src1, vertexInfoMap.get(src2).getPhysicalExecutionVertex());
     Assert.assertEquals(2, vertexInfoMap.get(operatorChain1).getRefCount());
+    Assert.assertEquals(operatorChain1, vertexInfoMap.get(operatorChain1).getPhysicalExecutionVertex());
     Assert.assertEquals(2, vertexInfoMap.get(operatorChain2).getRefCount());
+    Assert.assertEquals(operatorChain1, vertexInfoMap.get(operatorChain2).getPhysicalExecutionVertex());
     Assert.assertEquals(1, vertexInfoMap.get(sink1).getRefCount());
+    Assert.assertEquals(sink1, vertexInfoMap.get(sink1).getPhysicalExecutionVertex());
     Assert.assertEquals(1, vertexInfoMap.get(sink2).getRefCount());
+    Assert.assertEquals(sink2, vertexInfoMap.get(sink2).getPhysicalExecutionVertex());
   }
 
   /**
@@ -377,15 +383,21 @@ public final class ImmediateQueryMergingStarterTest {
     Assert.assertEquals(Arrays.asList(data1), result1);
     Assert.assertEquals(Arrays.asList(data2), result2);
 
-    // Check reference count of the execution vertices
+    // Check reference count and physical vertex of the execution vertices
     Assert.assertEquals(query1Plan, executionPlanDagMap.get("q1"));
     Assert.assertEquals(query2Plan, executionPlanDagMap.get("q2"));
     Assert.assertEquals(2, vertexInfoMap.get(src1).getRefCount());
+    Assert.assertEquals(src1, vertexInfoMap.get(src1).getPhysicalExecutionVertex());
     Assert.assertEquals(2, vertexInfoMap.get(src2).getRefCount());
+    Assert.assertEquals(src1, vertexInfoMap.get(src2).getPhysicalExecutionVertex());
     Assert.assertEquals(1, vertexInfoMap.get(operatorChain1).getRefCount());
+    Assert.assertEquals(operatorChain1, vertexInfoMap.get(operatorChain1).getPhysicalExecutionVertex());
     Assert.assertEquals(1, vertexInfoMap.get(operatorChain2).getRefCount());
+    Assert.assertEquals(operatorChain2, vertexInfoMap.get(operatorChain2).getPhysicalExecutionVertex());
     Assert.assertEquals(1, vertexInfoMap.get(sink1).getRefCount());
+    Assert.assertEquals(sink1, vertexInfoMap.get(sink1).getPhysicalExecutionVertex());
     Assert.assertEquals(1, vertexInfoMap.get(sink2).getRefCount());
+    Assert.assertEquals(sink2, vertexInfoMap.get(sink2).getPhysicalExecutionVertex());
   }
 
   /**


### PR DESCRIPTION
This PR addressed #587 by 
* adding `ExecutionVertex` as a parameter of the constructor of `VertexInfo`.

Closes #587 