### PR TITLE
[MIST-631] Implement QueryRemover that does not consider query merging

### DIFF
--- a/src/main/java/edu/snu/mist/core/task/queryRemovers/NoMergingAwareQueryRemover.java
+++ b/src/main/java/edu/snu/mist/core/task/queryRemovers/NoMergingAwareQueryRemover.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2017 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.core.task.queryRemovers;
+
+import edu.snu.mist.common.graph.DAG;
+import edu.snu.mist.common.graph.MISTEdge;
+import edu.snu.mist.core.task.ExecutionPlanDagMap;
+import edu.snu.mist.core.task.ExecutionVertex;
+import edu.snu.mist.core.task.PhysicalSource;
+
+import javax.inject.Inject;
+
+/**
+ * This removes the query from MIST.
+ * It does not think the queries are merged.
+ */
+final class NoMergingAwareQueryRemover implements QueryRemover {
+
+  /**
+   * The map that has the query id as a key and its execution dag as a value.
+   */
+  private final ExecutionPlanDagMap executionPlanDagMap;
+  
+  @Inject
+  private NoMergingAwareQueryRemover(final ExecutionPlanDagMap executionPlanDagMap) {
+    this.executionPlanDagMap = executionPlanDagMap;
+  }
+
+  /**
+   * Delete the query from the group.
+   * @param queryId query id
+   */
+  @Override
+  public synchronized void deleteQuery(final String queryId) {
+    final DAG<ExecutionVertex, MISTEdge> executionDag = executionPlanDagMap.remove(queryId);
+    for (final ExecutionVertex vertex : executionDag.getRootVertices()) {
+      final PhysicalSource src = (PhysicalSource)vertex;
+      try {
+        src.close();
+      } catch (final Exception e) {
+        e.printStackTrace();
+      }
+    }
+  }
+}

--- a/src/main/java/edu/snu/mist/core/task/queryStarters/NoMergingQueryStarter.java
+++ b/src/main/java/edu/snu/mist/core/task/queryStarters/NoMergingQueryStarter.java
@@ -17,6 +17,7 @@ package edu.snu.mist.core.task.queryStarters;
 
 import edu.snu.mist.common.graph.DAG;
 import edu.snu.mist.common.graph.MISTEdge;
+import edu.snu.mist.core.task.ExecutionPlanDagMap;
 import edu.snu.mist.core.task.ExecutionVertex;
 import edu.snu.mist.core.task.OperatorChainManager;
 import edu.snu.mist.core.task.PhysicalSource;
@@ -34,9 +35,16 @@ public final class NoMergingQueryStarter implements QueryStarter {
    */
   private final OperatorChainManager operatorChainManager;
 
+  /**
+   * The map that has a query id as a key and an execution dag as a value.
+   */
+  private final ExecutionPlanDagMap executionPlanDagMap;
+
   @Inject
-  private NoMergingQueryStarter(final OperatorChainManager operatorChainManager) {
+  private NoMergingQueryStarter(final OperatorChainManager operatorChainManager,
+                                final ExecutionPlanDagMap executionPlanDagMap) {
     this.operatorChainManager = operatorChainManager;
+    this.executionPlanDagMap = executionPlanDagMap;
   }
 
   /**
@@ -45,6 +53,7 @@ public final class NoMergingQueryStarter implements QueryStarter {
    */
   @Override
   public void start(final String queryId, final DAG<ExecutionVertex, MISTEdge> submittedDag) {
+    executionPlanDagMap.put(queryId, submittedDag);
     QueryStarterUtils.setUpOutputEmitters(operatorChainManager, submittedDag);
     // starts to receive input data stream from the sources
     for (final ExecutionVertex source : submittedDag.getRootVertices()) {


### PR DESCRIPTION
This PR addressed #631 by 
* implementing `NoMergingAwareQueryRemover` that does not consider query merging when removing queries. 

Closes #631 