### PR TITLE
[MIST-642] Assign group weight in global scheduling execution model

### DIFF
--- a/src/main/java/edu/snu/mist/core/parameters/DefaultGroupWeight.java
+++ b/src/main/java/edu/snu/mist/core/parameters/DefaultGroupWeight.java
@@ -18,6 +18,6 @@ package edu.snu.mist.core.parameters;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
-@NamedParameter(doc = "The default value of the weight of the group", default_value = "1")
-public final class DefaultGroupWeight implements Name<Integer> {
+@NamedParameter(doc = "The default value of the weight of the group", default_value = "1.0")
+public final class DefaultGroupWeight implements Name<Double> {
 }

--- a/src/main/java/edu/snu/mist/core/task/globalsched/DefaultGlobalSchedGroupInfo.java
+++ b/src/main/java/edu/snu/mist/core/task/globalsched/DefaultGlobalSchedGroupInfo.java
@@ -75,7 +75,7 @@ final class DefaultGlobalSchedGroupInfo implements GlobalSchedGroupInfo {
   /**
    * The vruntime of the group.
    */
-  private long vruntime;
+  private double vruntime;
 
   @Inject
   private DefaultGlobalSchedGroupInfo(@Parameter(GroupId.class) final String groupId,
@@ -164,12 +164,12 @@ final class DefaultGlobalSchedGroupInfo implements GlobalSchedGroupInfo {
   }
 
   @Override
-  public long getVRuntime() {
+  public double getVRuntime() {
     return vruntime;
   }
 
   @Override
-  public void setVRuntime(final long vrt) {
+  public void setVRuntime(final double vrt) {
     vruntime = vrt;
   }
 

--- a/src/main/java/edu/snu/mist/core/task/globalsched/GlobalSchedGroupInfo.java
+++ b/src/main/java/edu/snu/mist/core/task/globalsched/GlobalSchedGroupInfo.java
@@ -89,11 +89,11 @@ public interface GlobalSchedGroupInfo extends AutoCloseable {
    * Get the vruntime of the group.
    * @return vruntime
    */
-  long getVRuntime();
+  double getVRuntime();
 
   /**
    * Set the vruntime of the group.
    * @param vruntime vruntime
    */
-  void setVRuntime(long vruntime);
+  void setVRuntime(double vruntime);
 }

--- a/src/main/java/edu/snu/mist/core/task/globalsched/cfs/CfsTimesliceCalculator.java
+++ b/src/main/java/edu/snu/mist/core/task/globalsched/cfs/CfsTimesliceCalculator.java
@@ -60,13 +60,13 @@ public final class CfsTimesliceCalculator implements GroupTimesliceCalculator {
 
   @Override
   public long calculateTimeslice(final GlobalSchedGroupInfo groupInfo) {
-    final long totalWeight = metric.getNumEventAndWeightMetric().getWeight();
-    final int groupWeight = groupInfo.getEventNumAndWeightMetric().getWeight();
+    final double totalWeight = metric.getNumEventAndWeightMetric().getWeight();
+    final double groupWeight = groupInfo.getEventNumAndWeightMetric().getWeight();
     final int numGroups = Math.max(1, metric.getNumGroups());
     long adjustCfsTimeslice = cfsTimeslice;
     if (cfsTimeslice / numGroups < minTimeslice) {
       adjustCfsTimeslice = minTimeslice * numGroups;
     }
-    return Math.max(minTimeslice, (long)(adjustCfsTimeslice * (groupWeight * 1.0 /totalWeight)));
+    return Math.max(minTimeslice, (long)(adjustCfsTimeslice * (groupWeight /totalWeight)));
   }
 }

--- a/src/main/java/edu/snu/mist/core/task/globalsched/cfs/VtimeBasedNextGroupSelector.java
+++ b/src/main/java/edu/snu/mist/core/task/globalsched/cfs/VtimeBasedNextGroupSelector.java
@@ -39,12 +39,12 @@ public final class VtimeBasedNextGroupSelector implements NextGroupSelector {
   /**
    * A Red-Black tree based map to pick a group that has the lowest virtual time.
    */
-  private final TreeMap<Long, Queue<GlobalSchedGroupInfo>> rbTreeMap;
+  private final TreeMap<Double, Queue<GlobalSchedGroupInfo>> rbTreeMap;
 
   /**
    * Default weight of the group.
    */
-  private final int defaultWeight;
+  private final double defaultWeight;
 
   /**
    * The minimum timeslice per group.
@@ -52,7 +52,7 @@ public final class VtimeBasedNextGroupSelector implements NextGroupSelector {
   private final long minTimeslice;
 
   @Inject
-  private VtimeBasedNextGroupSelector(@Parameter(DefaultGroupWeight.class) final int defaultWeight,
+  private VtimeBasedNextGroupSelector(@Parameter(DefaultGroupWeight.class) final double defaultWeight,
                                       @Parameter(MinTimeslice.class) final long minTimeslice,
                                       final MistPubSubEventHandler pubSubEventHandler) {
     this.rbTreeMap = new TreeMap<>();
@@ -67,7 +67,7 @@ public final class VtimeBasedNextGroupSelector implements NextGroupSelector {
    */
   private void addGroup(final GlobalSchedGroupInfo groupInfo) {
     synchronized (rbTreeMap) {
-      final long vruntime = groupInfo.getVRuntime();
+      final double vruntime = groupInfo.getVRuntime();
       Queue<GlobalSchedGroupInfo> queue = rbTreeMap.get(vruntime);
       if (queue == null) {
         rbTreeMap.put(vruntime, new LinkedList<>());
@@ -102,7 +102,7 @@ public final class VtimeBasedNextGroupSelector implements NextGroupSelector {
           e.printStackTrace();
         }
       }
-      final Map.Entry<Long, Queue<GlobalSchedGroupInfo>> entry = rbTreeMap.firstEntry();
+      final Map.Entry<Double, Queue<GlobalSchedGroupInfo>> entry = rbTreeMap.firstEntry();
       final Queue<GlobalSchedGroupInfo> queue = entry.getValue();
       final GlobalSchedGroupInfo groupInfo = queue.poll();
       if (queue.isEmpty()) {
@@ -120,8 +120,8 @@ public final class VtimeBasedNextGroupSelector implements NextGroupSelector {
   @Override
   public void reschedule(final GlobalSchedGroupInfo groupInfo) {
     final long endTime = System.nanoTime();
-    final long delta = calculateVRuntimeDelta(endTime - groupInfo.getLatestScheduledTime(), groupInfo);
-    final long adjustedVRuntime = groupInfo.getVRuntime() + delta;
+    final double delta = calculateVRuntimeDelta(endTime - groupInfo.getLatestScheduledTime(), groupInfo);
+    final double adjustedVRuntime = groupInfo.getVRuntime() + delta;
     groupInfo.setVRuntime(adjustedVRuntime);
     addGroup(groupInfo);
   }
@@ -132,7 +132,7 @@ public final class VtimeBasedNextGroupSelector implements NextGroupSelector {
    * @param groupInfo group info
    * @return delta vruntime
    */
-  private long calculateVRuntimeDelta(final long delta, final GlobalSchedGroupInfo groupInfo) {
+  private double calculateVRuntimeDelta(final long delta, final GlobalSchedGroupInfo groupInfo) {
     return Math.max(minTimeslice * defaultWeight / groupInfo.getEventNumAndWeightMetric().getWeight(),
     TimeUnit.NANOSECONDS.toMillis(delta) * defaultWeight / groupInfo.getEventNumAndWeightMetric().getWeight());
   }

--- a/src/main/java/edu/snu/mist/core/task/globalsched/metrics/CpuUtilMetric.java
+++ b/src/main/java/edu/snu/mist/core/task/globalsched/metrics/CpuUtilMetric.java
@@ -65,10 +65,6 @@ public final class CpuUtilMetric {
     return ewmaSystemCpuUtil.getCurrentEwma();
   }
 
-  public void setSystemCpuUtil(final double cpuUtil) {
-    this.systemCpuUtil = cpuUtil;
-  }
-
   public void updateSystemCpuUtil(final double cpuUtil) {
     this.systemCpuUtil = cpuUtil;
     this.ewmaSystemCpuUtil.updateAndTick(cpuUtil);
@@ -80,10 +76,6 @@ public final class CpuUtilMetric {
 
   public double getEwmaProcessCpuUtil() {
     return ewmaProcessCpuUtil.getCurrentEwma();
-  }
-
-  public void setProcessCpuUtil(final double processCpuUtil) {
-    this.processCpuUtil = processCpuUtil;
   }
 
   public void updateProcessCpuUtil(final double processCpuUtilParam) {

--- a/src/main/java/edu/snu/mist/core/task/globalsched/metrics/CpuUtilMetricEventHandler.java
+++ b/src/main/java/edu/snu/mist/core/task/globalsched/metrics/CpuUtilMetricEventHandler.java
@@ -67,11 +67,11 @@ public final class CpuUtilMetricEventHandler implements MetricTrackEventHandler 
 
       if (systemUtil != -1.0) {
         // If the monitoring was successful
-        globalMetrics.getCpuUtilMetric().setSystemCpuUtil(systemUtil);
+        globalMetrics.getCpuUtilMetric().updateSystemCpuUtil(systemUtil);
       }
       if (processUtil != -1.0) {
         // If the monitoring was successful
-        globalMetrics.getCpuUtilMetric().setProcessCpuUtil(processUtil);
+        globalMetrics.getCpuUtilMetric().updateProcessCpuUtil(processUtil);
       }
     }
   }

--- a/src/main/java/edu/snu/mist/core/task/globalsched/metrics/EventNumAndWeightMetric.java
+++ b/src/main/java/edu/snu/mist/core/task/globalsched/metrics/EventNumAndWeightMetric.java
@@ -40,18 +40,14 @@ public final class EventNumAndWeightMetric {
   /**
    * The weight used for scheduling.
    */
-  private volatile int weight;
+  private volatile double weight;
 
   @Inject
-  private EventNumAndWeightMetric(@Parameter(DefaultGroupWeight.class) final int weight,
+  private EventNumAndWeightMetric(@Parameter(DefaultGroupWeight.class) final double weight,
                                   @Parameter(GlobalNumEventAlpha.class) final double numEventAlpha) {
     this.numEvents = 0;
     this.ewmaNumEvents = new EWMA(numEventAlpha);
     this.weight = weight;
-  }
-
-  public void setNumEvents(final long numEventsParam) {
-    this.numEvents = numEventsParam;
   }
 
   public void updateNumEvents(final long numEventsParam) {
@@ -67,27 +63,46 @@ public final class EventNumAndWeightMetric {
     return ewmaNumEvents.getCurrentEwma();
   }
 
-  public int getWeight() {
+  public double getWeight() {
     return weight;
   }
 
-  public void setWeight(final int weight) {
+  public void setWeight(final double weight) {
     this.weight = weight;
   }
 
   @Override
   public boolean equals(final Object o) {
-    if (!(o instanceof EventNumAndWeightMetric)) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final EventNumAndWeightMetric eventNumMetric = (EventNumAndWeightMetric) o;
-    return this.numEvents == eventNumMetric.getNumEvents() &&
-        this.ewmaNumEvents.equals(eventNumMetric.getEwmaNumEvents()) &&
-        this.weight == eventNumMetric.getWeight();
+
+    final EventNumAndWeightMetric that = (EventNumAndWeightMetric) o;
+
+    if (numEvents != that.numEvents) {
+      return false;
+    }
+    if (Double.compare(that.weight, weight) != 0) {
+      return false;
+    }
+    if (ewmaNumEvents != null ? !ewmaNumEvents.equals(that.ewmaNumEvents) : that.ewmaNumEvents != null) {
+      return false;
+    }
+
+    return true;
   }
 
   @Override
   public int hashCode() {
-    return ((Long) this.numEvents).hashCode() * 32 + ((Integer) this.weight).hashCode() * 22;
+    int result;
+    long temp;
+    result = (int) (numEvents ^ (numEvents >>> 32));
+    result = 31 * result + (ewmaNumEvents != null ? ewmaNumEvents.hashCode() : 0);
+    temp = Double.doubleToLongBits(weight);
+    result = 31 * result + (int) (temp ^ (temp >>> 32));
+    return result;
   }
 }

--- a/src/main/java/edu/snu/mist/core/task/globalsched/metrics/EventNumAndWeightMetricEventHandler.java
+++ b/src/main/java/edu/snu/mist/core/task/globalsched/metrics/EventNumAndWeightMetricEventHandler.java
@@ -55,8 +55,9 @@ public final class EventNumAndWeightMetricEventHandler implements MetricTrackEve
   @Override
   public void onNext(final MetricTrackEvent metricTrackEvent) {
     long totalNumEvent = 0;
-    int totalWeight = 0;
-    for (final GlobalSchedGroupInfo groupInfo : groupInfoMap.values()) {
+    double totalWeight = 0;
+    final Collection<GlobalSchedGroupInfo> groupInfos = groupInfoMap.values();
+    for (final GlobalSchedGroupInfo groupInfo : groupInfos) {
       // Track the number of event per each group
       long groupNumEvent = 0;
       for (final DAG<ExecutionVertex, MISTEdge> dag : groupInfo.getExecutionDags().values()) {
@@ -68,15 +69,15 @@ public final class EventNumAndWeightMetricEventHandler implements MetricTrackEve
         }
       }
       final EventNumAndWeightMetric metric = groupInfo.getEventNumAndWeightMetric();
-      metric.setNumEvents(groupNumEvent);
+      metric.updateNumEvents(groupNumEvent);
       totalNumEvent += groupNumEvent;
 
-      // TODO: [MIST-617] Add group weight adding process into GlobalSchedMetricTracker
-      final int weightToSet = 1;
-      metric.setWeight(weightToSet);
-      totalWeight += weightToSet;
+      // Set the weight per group
+      final double weight = metric.getEwmaNumEvents();
+      metric.setWeight(weight);
+      totalWeight += weight;
     }
-    globalMetrics.getNumEventAndWeightMetric().setNumEvents(totalNumEvent);
+    globalMetrics.getNumEventAndWeightMetric().updateNumEvents(totalNumEvent);
     globalMetrics.getNumEventAndWeightMetric().setWeight(totalWeight);
   }
 }

--- a/src/main/java/edu/snu/mist/core/task/globalsched/metrics/GlobalSchedGlobalMetrics.java
+++ b/src/main/java/edu/snu/mist/core/task/globalsched/metrics/GlobalSchedGlobalMetrics.java
@@ -76,5 +76,4 @@ public final class GlobalSchedGlobalMetrics {
   public void setNumGroups(final int groups) {
     numGroups = groups;
   }
-
 }

--- a/src/test/java/edu/snu/mist/core/task/globalsched/EventNumAndWeightMetricEventHandlerTest.java
+++ b/src/test/java/edu/snu/mist/core/task/globalsched/EventNumAndWeightMetricEventHandlerTest.java
@@ -20,6 +20,7 @@ import edu.snu.mist.common.graph.DAG;
 import edu.snu.mist.common.graph.MISTEdge;
 import edu.snu.mist.common.parameters.GroupId;
 import edu.snu.mist.core.task.*;
+import edu.snu.mist.core.task.globalsched.metrics.EventNumAndWeightMetric;
 import edu.snu.mist.core.task.globalsched.metrics.EventNumAndWeightMetricEventHandler;
 import edu.snu.mist.core.task.globalsched.metrics.GlobalSchedGlobalMetrics;
 import edu.snu.mist.core.task.merging.MergingExecutionDags;
@@ -58,15 +59,22 @@ public final class EventNumAndWeightMetricEventHandlerTest {
   }
 
   /**
-   * Test that a metric track event handler can track the total event number metric properly.
+   * Test that a metric track event handler can track the total event number and weight metric properly.
    */
-  @Test(timeout = 1000L)
-  public void testEventNumMetricTracking() throws Exception {
+  @Test
+  public void testEventNumAndWeightMetricTracking() throws Exception {
 
     final GlobalSchedGroupInfo groupInfoA = generateGroupInfo("GroupA");
     final GlobalSchedGroupInfo groupInfoB = generateGroupInfo("GroupB");
     final ExecutionDags executionDagsA = groupInfoA.getExecutionDags();
     final ExecutionDags executionDagsB = groupInfoB.getExecutionDags();
+
+    final Injector injector1 = Tang.Factory.getTang().newInjector();
+    final EventNumAndWeightMetric expectedA = injector1.getInstance(EventNumAndWeightMetric.class);
+    final Injector injector2 = Tang.Factory.getTang().newInjector();
+    final EventNumAndWeightMetric expectedB = injector2.getInstance(EventNumAndWeightMetric.class);
+    final Injector injector3 = Tang.Factory.getTang().newInjector();
+    final EventNumAndWeightMetric expectedTotal = injector3.getInstance(EventNumAndWeightMetric.class);
 
     // two dags in group A:
     // srcA1 -> opA1 -> sinkA1
@@ -119,10 +127,17 @@ public final class EventNumAndWeightMetricEventHandlerTest {
     opA.addNextEvent(generateTestEvent(), Direction.LEFT);
 
     // wait the tracker for a while
+    expectedA.updateNumEvents(1);
+    expectedB.updateNumEvents(0);
+    expectedTotal.updateNumEvents(1);
+    expectedA.setWeight(expectedA.getEwmaNumEvents());
+    expectedB.setWeight(expectedB.getEwmaNumEvents());
+    expectedTotal.setWeight(expectedA.getEwmaNumEvents() + expectedB.getEwmaNumEvents());
+
     metricPubSubEventHandler.getPubSubEventHandler().onNext(new MetricTrackEvent());
-    Assert.assertEquals(1, metric.getNumEventAndWeightMetric().getNumEvents());
-    Assert.assertEquals(1, groupInfoA.getEventNumAndWeightMetric().getNumEvents());
-    Assert.assertEquals(0, groupInfoB.getEventNumAndWeightMetric().getNumEvents());
+    Assert.assertEquals(expectedTotal, metric.getNumEventAndWeightMetric());
+    Assert.assertEquals(expectedA, groupInfoA.getEventNumAndWeightMetric());
+    Assert.assertEquals(expectedB, groupInfoB.getEventNumAndWeightMetric());
 
     // add a few events to the operator chains in group B
     opB1.addNextEvent(generateTestEvent(), Direction.LEFT);
@@ -130,25 +145,17 @@ public final class EventNumAndWeightMetricEventHandlerTest {
     opB2.addNextEvent(generateTestEvent(), Direction.LEFT);
 
     // wait the tracker for a while
-    metricPubSubEventHandler.getPubSubEventHandler().onNext(new MetricTrackEvent());
-    Assert.assertEquals(4, metric.getNumEventAndWeightMetric().getNumEvents());
-    Assert.assertEquals(1, groupInfoA.getEventNumAndWeightMetric().getNumEvents());
-    Assert.assertEquals(3, groupInfoB.getEventNumAndWeightMetric().getNumEvents());
-  }
-
-  /**
-   * Test that a metric track event handler can track the weight metric properly.
-   */
-  @Test(timeout = 1000L)
-  public void testWeightMetricTracking() throws Exception {
-    // TODO: [MIST-617] Add group weight adding process into GlobalSchedMetricTracker
-    final GlobalSchedGroupInfo groupInfoA = generateGroupInfo("GroupA");
-    final GlobalSchedGroupInfo groupInfoB = generateGroupInfo("GroupB");
+    expectedA.updateNumEvents(1);
+    expectedB.updateNumEvents(3);
+    expectedTotal.updateNumEvents(4);
+    expectedA.setWeight(expectedA.getEwmaNumEvents());
+    expectedB.setWeight(expectedB.getEwmaNumEvents());
+    expectedTotal.setWeight(expectedA.getEwmaNumEvents() + expectedB.getEwmaNumEvents());
 
     metricPubSubEventHandler.getPubSubEventHandler().onNext(new MetricTrackEvent());
-    Assert.assertEquals(2, metric.getNumEventAndWeightMetric().getWeight());
-    Assert.assertEquals(1, groupInfoA.getEventNumAndWeightMetric().getWeight());
-    Assert.assertEquals(1, groupInfoB.getEventNumAndWeightMetric().getWeight());
+    Assert.assertEquals(expectedTotal, metric.getNumEventAndWeightMetric());
+    Assert.assertEquals(expectedA, groupInfoA.getEventNumAndWeightMetric());
+    Assert.assertEquals(expectedB, groupInfoB.getEventNumAndWeightMetric());
   }
 
   /**

--- a/src/test/java/edu/snu/mist/core/task/globalsched/cfs/VtimeBasedNextGroupSelectorTest.java
+++ b/src/test/java/edu/snu/mist/core/task/globalsched/cfs/VtimeBasedNextGroupSelectorTest.java
@@ -15,8 +15,11 @@
  */
 package edu.snu.mist.core.task.globalsched.cfs;
 
+import com.google.common.util.concurrent.AtomicDouble;
 import edu.snu.mist.core.task.MistPubSubEventHandler;
-import edu.snu.mist.core.task.globalsched.*;
+import edu.snu.mist.core.task.globalsched.GlobalSchedGroupInfo;
+import edu.snu.mist.core.task.globalsched.GroupEvent;
+import edu.snu.mist.core.task.globalsched.NextGroupSelector;
 import edu.snu.mist.core.task.globalsched.metrics.EventNumAndWeightMetric;
 import junit.framework.Assert;
 import org.apache.reef.tang.Injector;
@@ -24,8 +27,6 @@ import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.wake.impl.PubSubEventHandler;
 import org.junit.Test;
-
-import java.util.concurrent.atomic.AtomicLong;
 
 import static org.mockito.Mockito.*;
 
@@ -46,10 +47,10 @@ public final class VtimeBasedNextGroupSelectorTest {
     final GlobalSchedGroupInfo group3 = mock(GlobalSchedGroupInfo.class);
     final GlobalSchedGroupInfo group4 = mock(GlobalSchedGroupInfo.class);
 
-    when(group1.getVRuntime()).thenReturn(0L);
-    when(group2.getVRuntime()).thenReturn(2L);
-    when(group3.getVRuntime()).thenReturn(1L);
-    when(group4.getVRuntime()).thenReturn(0L);
+    when(group1.getVRuntime()).thenReturn(0.0);
+    when(group2.getVRuntime()).thenReturn(2.0);
+    when(group3.getVRuntime()).thenReturn(1.0);
+    when(group4.getVRuntime()).thenReturn(0.0);
 
     final Injector injector = Tang.Factory.getTang().newInjector();
     final NextGroupSelector selector = injector.getInstance(VtimeBasedNextGroupSelector.class);
@@ -85,18 +86,18 @@ public final class VtimeBasedNextGroupSelectorTest {
     final EventNumAndWeightMetric metric =
         Tang.Factory.getTang().newInjector().getInstance(EventNumAndWeightMetric.class);
 
-    final AtomicLong group1AdjustVRuntime = new AtomicLong(0);
+    final AtomicDouble group1AdjustVRuntime = new AtomicDouble(0);
     doAnswer((invocation) -> {
         Object[] args = invocation.getArguments();
-        group1AdjustVRuntime.set((long)args[0]);
+        group1AdjustVRuntime.set((double)args[0]);
         return null;
     }).when(group1).setVRuntime(anyLong());
     
     when(group1.getVRuntime()).thenAnswer((invocation) -> group1AdjustVRuntime.get());
     when(group1.getEventNumAndWeightMetric()).thenReturn(metric);
-    when(group2.getVRuntime()).thenReturn(2L);
-    when(group3.getVRuntime()).thenReturn(1L);
-    when(group4.getVRuntime()).thenReturn(0L);
+    when(group2.getVRuntime()).thenReturn(2.0);
+    when(group3.getVRuntime()).thenReturn(1.0);
+    when(group4.getVRuntime()).thenReturn(0.0);
 
     final Injector injector = Tang.Factory.getTang().newInjector();
     final NextGroupSelector selector = injector.getInstance(VtimeBasedNextGroupSelector.class);


### PR DESCRIPTION
This PR addressed #642 by 
* setting the EMWA of events as the weight of the group 

Closes #642