### PR TITLE
[MIST-651] Move classes related to query merging into merging package

### DIFF
--- a/src/main/java/edu/snu/mist/core/task/merging/VertexInfo.java
+++ b/src/main/java/edu/snu/mist/core/task/merging/VertexInfo.java
@@ -13,17 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.mist.core.task;
+package edu.snu.mist.core.task.merging;
 
 import edu.snu.mist.common.graph.DAG;
 import edu.snu.mist.common.graph.MISTEdge;
+import edu.snu.mist.core.task.ExecutionVertex;
 
 /**
  * Vertex info that contains a reference count of the vertex
  * and the *physical* execution dag that contains the vertex.
  * The physical execution dag can be merged with other dags.
  */
-public final class VertexInfo {
+final class VertexInfo {
 
   /**
    * Reference count of the execution vertex.

--- a/src/main/java/edu/snu/mist/core/task/merging/VertexInfoMap.java
+++ b/src/main/java/edu/snu/mist/core/task/merging/VertexInfoMap.java
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.mist.core.task;
+package edu.snu.mist.core.task.merging;
+
+import edu.snu.mist.core.task.ExecutionVertex;
 
 import javax.inject.Inject;
 import java.util.concurrent.ConcurrentHashMap;
@@ -21,7 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * This is a map that has an execution vertex as a key and a vertex info as a value.
  */
-public final class VertexInfoMap {
+final class VertexInfoMap {
 
   private final ConcurrentHashMap<ExecutionVertex, VertexInfo> map;
 


### PR DESCRIPTION
This PR addressed #651 by 
* moving `VertexInfo` and `VertexInfoMap` into `merging` package.

Closes #651 