### PR TITLE
[MIST-668, 669] Indicate the batch submission codes in normal execution path

### DIFF
--- a/src/main/avro/client_to_task_msg.avpr
+++ b/src/main/avro/client_to_task_msg.avpr
@@ -27,25 +27,25 @@
       "fields":
       [
         {
-          "name": "PubTopicGenerateFunc",
+          "name": "PubTopicGenerateFunc", /* TODO[DELETE] this code is for test */
           "type": "string",
           "default": "null"
         },
         {
-          "name": "SubTopicGenerateFunc",
+          "name": "SubTopicGenerateFunc", /* TODO[DELETE] this code is for test */
           "type": "string",
           "default": "null"
         },
         {
-          "name": "QueryGroupList",
+          "name": "QueryGroupList", /* TODO[DELETE] this code is for test */
           "type": {
             "type": "array",
             "items": "int"
           },
-          "default": "null"
+          "default": []
         },
         {
-          "name": "StartQueryNum",
+          "name": "StartQueryNum", /* TODO[DELETE] this code is for test */
           "type": "int",
           "default": 0
         },
@@ -220,7 +220,7 @@
           "type": "AvroOperatorChainDag"
         },
         {
-          "name": "batchSize",
+          "name": "batchSize", /* TODO[DELETE] this code is for test */
           "type": "int"
         }
       ],

--- a/src/main/java/edu/snu/mist/api/batchsub/BatchSubExecutionEnvironment.java
+++ b/src/main/java/edu/snu/mist/api/batchsub/BatchSubExecutionEnvironment.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 /**
+ * TODO[DELETE] this code is for test.
  * A execution environment that submit query in a batch.
  * It uses avro RPC for communication with the Driver and the Task.
  * First, it communicates with MIST Driver to get a list of MIST Tasks.

--- a/src/main/java/edu/snu/mist/api/batchsub/BatchSubmissionConfiguration.java
+++ b/src/main/java/edu/snu/mist/api/batchsub/BatchSubmissionConfiguration.java
@@ -20,6 +20,7 @@ import edu.snu.mist.common.functions.MISTFunction;
 import java.util.List;
 
 /**
+ * TODO[DELETE] this code is for test.
  * Configuration class for setting batch query submission.
  * Submitted query will be duplicated according to this configuration.
  */

--- a/src/main/java/edu/snu/mist/core/task/DefaultClientToTaskMessageImpl.java
+++ b/src/main/java/edu/snu/mist/core/task/DefaultClientToTaskMessageImpl.java
@@ -90,6 +90,9 @@ public final class DefaultClientToTaskMessageImpl implements ClientToTaskMessage
     return queryManager.create(new Tuple<>(queryId, chainDag));
   }
 
+  /**
+   *  TODO[DELETE] this code is for test.
+   */
   @Override
   public QueryControlResult sendBatchQueries(final AvroOperatorChainDag chainDag,
                                              final int batchSize) throws AvroRemoteException {

--- a/src/main/java/edu/snu/mist/core/task/GroupAwareQueryManagerImpl.java
+++ b/src/main/java/edu/snu/mist/core/task/GroupAwareQueryManagerImpl.java
@@ -180,6 +180,7 @@ public final class GroupAwareQueryManagerImpl implements QueryManager {
   }
 
   /**
+   * TODO[DELETE] this code is for test.
    * Start submitted queries in batch manner.
    * The operator chain dag will be duplicated for test.
    * @param tuple a pair of the query id and the avro operator chain dag

--- a/src/main/java/edu/snu/mist/core/task/QueryManager.java
+++ b/src/main/java/edu/snu/mist/core/task/QueryManager.java
@@ -35,6 +35,7 @@ public interface QueryManager extends AutoCloseable {
   QueryControlResult create(Tuple<String, AvroOperatorChainDag> tuple);
 
   /**
+   * TODO[DELETE] this code is for test.
    * Start submitted queries in batch manner.
    * The operator chain dag will be duplicated for test.
    * @param tuple the query id list and the operator chain dag

--- a/src/main/java/edu/snu/mist/core/task/batchsub/BatchQueryCreator.java
+++ b/src/main/java/edu/snu/mist/core/task/batchsub/BatchQueryCreator.java
@@ -42,6 +42,7 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
+ * TODO[DELETE] this code is for test.
  * A batch query creator class for supporting test.
  */
 public final class BatchQueryCreator {

--- a/src/main/java/edu/snu/mist/core/task/globalsched/GroupAwareGlobalSchedQueryManagerImpl.java
+++ b/src/main/java/edu/snu/mist/core/task/globalsched/GroupAwareGlobalSchedQueryManagerImpl.java
@@ -201,6 +201,7 @@ public final class GroupAwareGlobalSchedQueryManagerImpl implements QueryManager
   }
 
   /**
+   * TODO[DELETE] this code is for test.
    * Start submitted queries in batch manner.
    * The operator chain dag will be duplicated for test.
    * @param tuple a pair of the query id and the avro operator chain dag

--- a/src/main/java/edu/snu/mist/core/task/threadbased/ThreadBasedQueryManagerImpl.java
+++ b/src/main/java/edu/snu/mist/core/task/threadbased/ThreadBasedQueryManagerImpl.java
@@ -119,6 +119,7 @@ public final class ThreadBasedQueryManagerImpl implements QueryManager {
   }
 
   /**
+   * TODO[DELETE] this code is for test.
    * Start submitted queries in batch manner.
    * The operator chain dag will be duplicated for test.
    * @param tuple a pair of the query id and the avro operator chain dag

--- a/src/test/java/edu/snu/mist/api/batchsub/BatchSubExecutionEnvironmentTest.java
+++ b/src/test/java/edu/snu/mist/api/batchsub/BatchSubExecutionEnvironmentTest.java
@@ -37,6 +37,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
+ * TODO[DELETE] this code is for test.
  * The test class for BatchSubExecutionEnvironment.
  */
 public class BatchSubExecutionEnvironmentTest {

--- a/src/test/java/edu/snu/mist/core/task/batchsub/BatchSubQueryManagerTest.java
+++ b/src/test/java/edu/snu/mist/core/task/batchsub/BatchSubQueryManagerTest.java
@@ -56,6 +56,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
+ * TODO[DELETE] this code is for test.
  * Test batch submission in the query managers of option 1, 2, and 3.
  */
 public final class BatchSubQueryManagerTest {


### PR DESCRIPTION
This PR addressed #668, #669 by

- indicating the batch submission codes
- changing the default value of avro list

Closes #668, #669