### PR TITLE
[MIST-726] Change batch submission logic to receive groupId instead of query number

### DIFF
--- a/src/main/avro/client_to_task_msg.avpr
+++ b/src/main/avro/client_to_task_msg.avpr
@@ -37,17 +37,12 @@
           "default": "null"
         },
         {
-          "name": "QueryGroupList", /* TODO[DELETE] this code is for test */
+          "name": "GroupIdList", /* TODO[DELETE] this code is for test */
           "type": {
             "type": "array",
-            "items": "int"
+            "items": "string"
           },
           "default": []
-        },
-        {
-          "name": "StartQueryNum", /* TODO[DELETE] this code is for test */
-          "type": "int",
-          "default": 0
         },
         {
           "name": "GroupId",

--- a/src/main/java/edu/snu/mist/api/batchsub/BatchSubExecutionEnvironment.java
+++ b/src/main/java/edu/snu/mist/api/batchsub/BatchSubExecutionEnvironment.java
@@ -122,11 +122,10 @@ public final class BatchSubExecutionEnvironment {
             SerializeUtils.serializeToString(batchSubConfig.getPubTopicGenerateFunc()))
         .setSubTopicGenerateFunc(
             SerializeUtils.serializeToString(batchSubConfig.getSubTopicGenerateFunc()))
-        .setQueryGroupList(batchSubConfig.getQueryGroupList())
-        .setStartQueryNum(batchSubConfig.getStartQueryNum())
+        .setGroupIdList(batchSubConfig.getGroupIdList())
         .build();
     final QueryControlResult queryControlResult =
-        proxyToTask.sendBatchQueries(operatorChainDag, batchSubConfig.getBatchSize());
+        proxyToTask.sendBatchQueries(operatorChainDag, batchSubConfig.getGroupIdList().size());
 
     // Transform QueryControlResult to APIQueryControlResult
     final APIQueryControlResult apiQueryControlResult =

--- a/src/main/java/edu/snu/mist/api/batchsub/BatchSubmissionConfiguration.java
+++ b/src/main/java/edu/snu/mist/api/batchsub/BatchSubmissionConfiguration.java
@@ -28,61 +28,39 @@ import java.util.Set;
 public final class BatchSubmissionConfiguration {
 
   /**
-   * A function generates MQTT sink topic to publish from a group id and query number.
+   * A function generates MQTT sink topic to publish from a group id and query id.
    * The first parameter should be group Id.
    */
-  private final MISTBiFunction<String, Integer, String> pubTopicGenerateFunc;
+  private final MISTBiFunction<String, String, String> pubTopicGenerateFunc;
 
   /**
-   * A function generates a set of MQTT sink topic to subscribe from a group id and query number.
+   * A function generates a set of MQTT sink topic to subscribe from a group id and query id.
    * The first parameter should be group Id.
    */
-  private final MISTBiFunction<String, Integer, Set<String>> subTopicGenerateFunc;
+  private final MISTBiFunction<String, String, Set<String>> subTopicGenerateFunc;
 
   /**
-   * A list represents the number of queries per each groups.
+   * A list of group id.
    */
-  private final List<Integer> queryGroupList;
+  private final List<String> groupIdList;
 
-  /**
-   * A query number represents the starting point of query group list.
-   */
-  private final int startQueryNum;
-
-  /**
-   * A batch size represents how many queries will be generated.
-   */
-  private final int batchSize;
-
-  public BatchSubmissionConfiguration(final MISTBiFunction<String, Integer, Set<String>> subTopicGenerateFunc,
-                                      final MISTBiFunction<String, Integer, String> pubTopicGenerateFunc,
-                                      final List<Integer> queryGroupList,
-                                      final int startQueryNum,
-                                      final int batchSize) {
+  public BatchSubmissionConfiguration(final MISTBiFunction<String, String, Set<String>> subTopicGenerateFunc,
+                                      final MISTBiFunction<String, String, String> pubTopicGenerateFunc,
+                                      final List<String> groupIdList) {
     this.subTopicGenerateFunc = subTopicGenerateFunc;
     this.pubTopicGenerateFunc = pubTopicGenerateFunc;
-    this.queryGroupList = queryGroupList;
-    this.startQueryNum = startQueryNum;
-    this.batchSize = batchSize;
+    this.groupIdList = groupIdList;
   }
 
-  public MISTBiFunction<String, Integer, String> getPubTopicGenerateFunc() {
+  public MISTBiFunction<String, String, String> getPubTopicGenerateFunc() {
     return pubTopicGenerateFunc;
   }
 
-  public MISTBiFunction<String, Integer, Set<String>> getSubTopicGenerateFunc() {
+  public MISTBiFunction<String, String, Set<String>> getSubTopicGenerateFunc() {
     return subTopicGenerateFunc;
   }
 
-  public List<Integer> getQueryGroupList() {
-    return queryGroupList;
-  }
-
-  public int getStartQueryNum() {
-    return startQueryNum;
-  }
-
-  public int getBatchSize() {
-    return batchSize;
+  public List<String> getGroupIdList() {
+    return groupIdList;
   }
 }

--- a/src/test/java/edu/snu/mist/api/batchsub/BatchSubExecutionEnvironmentTest.java
+++ b/src/test/java/edu/snu/mist/api/batchsub/BatchSubExecutionEnvironmentTest.java
@@ -78,39 +78,37 @@ public class BatchSubExecutionEnvironmentTest {
     // Step 3: Send a query in batch manner and check whether the query comes to the task correctly
     final BatchSubExecutionEnvironment executionEnvironment = new BatchSubExecutionEnvironment(
         driverHost, driverPortNum);
-    final MISTBiFunction<String, Integer, String> pubTopicGenerateFunc = (groupId, queryNum) ->
+    final MISTBiFunction<String, String, String> pubTopicGenerateFunc = (groupId, queryId) ->
         new StringBuilder("/group")
             .append(groupId)
             .append("/device")
-            .append(queryNum + 2)
+            .append(queryId)
             .append("/pub")
             .toString();
-    final MISTBiFunction<String, Integer, Set<String>> subTopicGenerateFunc = (groupId, queryNum) -> {
+    final MISTBiFunction<String, String, Set<String>> subTopicGenerateFunc = (groupId, queryId) -> {
       final Set<String> topicList = new HashSet<>();
       topicList.add(
           new StringBuilder("/group")
               .append(groupId)
               .append("/device")
-              .append(queryNum + 3)
+              .append(queryId + "_1")
               .append("/sub")
               .toString());
       topicList.add(
           new StringBuilder("/group")
               .append(groupId)
               .append("/device")
-              .append(queryNum + 4)
+              .append(queryId + "_2")
               .append("/sub")
               .toString());
       return topicList;
     };
-    final List<Integer> queryGroupList = new LinkedList<>();
-    queryGroupList.add(10);
-    queryGroupList.add(20);
-    final int startQueryNum = 2;
-    final int batchSize = 27;
+    final List<String> queryGroupList = new LinkedList<>();
+    queryGroupList.add("1");
+    queryGroupList.add("2");
 
     final BatchSubmissionConfiguration batchConf = new BatchSubmissionConfiguration(
-        subTopicGenerateFunc, pubTopicGenerateFunc, queryGroupList, startQueryNum, batchSize);
+        subTopicGenerateFunc, pubTopicGenerateFunc, queryGroupList);
     final APIQueryControlResult batchResult =
         executionEnvironment.batchSubmit(query, batchConf, tempJarFile.toString());
     Assert.assertEquals(batchResult.getQueryId(), testQueryResult);


### PR DESCRIPTION
This PR addressed #726 by 
* changing the batch submission logic to receive gorupId list instead of query number list to support multi-source queries.

Closes #726