### PR TITLE
[MIST-752] Set polling execution model as a default value

### DIFF
--- a/src/main/java/edu/snu/mist/core/task/globalsched/parameters/GroupSchedModelType.java
+++ b/src/main/java/edu/snu/mist/core/task/globalsched/parameters/GroupSchedModelType.java
@@ -19,6 +19,6 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 @NamedParameter(doc = "The type of group scheduling execution model (blocking/nonblocking)",
-    short_name = "group_sched_model", default_value = "nonblocking")
+    short_name = "group_sched_model", default_value = "polling")
 public final class GroupSchedModelType implements Name<String> {
 }


### PR DESCRIPTION
This PR addressed #752 by 
* changing the default value of `GroupSchedModelType` to `polling`

Closes #752 