### PR TITLE
[MIST-755] Fix Bug in DefaultDagGeneratorImpl

### DIFF
--- a/src/main/java/edu/snu/mist/core/task/DefaultDagGeneratorImpl.java
+++ b/src/main/java/edu/snu/mist/core/task/DefaultDagGeneratorImpl.java
@@ -115,18 +115,16 @@ final class DefaultDagGeneratorImpl implements DagGenerator {
       currExecutionVertex = createExecutionVertex(currVertex, urls, classLoader);
       created.put(currVertex, currExecutionVertex);
       executionDag.addVertex(currExecutionVertex);
+      // do dfs creation
+      for (final Map.Entry<ConfigVertex, MISTEdge> edges : configDag.getEdges(currVertex).entrySet()) {
+        final ConfigVertex childVertex = edges.getKey();
+        final MISTEdge edge = edges.getValue();
+        dfsCreation(currExecutionVertex, edge, childVertex, created, configDag, executionDag, urls, classLoader);
+      }
     } else {
       currExecutionVertex = created.get(currVertex);
     }
-
     executionDag.addEdge(parent, currExecutionVertex, parentEdge);
-
-    // do dfs creation
-    for (final Map.Entry<ConfigVertex, MISTEdge> edges : configDag.getEdges(currVertex).entrySet()) {
-      final ConfigVertex childVertex = edges.getKey();
-      final MISTEdge edge = edges.getValue();
-      dfsCreation(currExecutionVertex, edge, childVertex, created, configDag, executionDag, urls, classLoader);
-    }
   }
 
   /**


### PR DESCRIPTION
This address #755 by
- changing the `visited` set to `created` map, containing the corresponding configVertex and ExecutionVertex

Closes #755