### PR TITLE
[MIST-759] Remove equals and hashcode from DAG implementation

### DIFF
--- a/src/main/java/edu/snu/mist/common/graph/AdjacentListDAG.java
+++ b/src/main/java/edu/snu/mist/common/graph/AdjacentListDAG.java
@@ -82,6 +82,11 @@ public final class AdjacentListDAG<V, I> implements DAG<V, I> {
   }
 
   @Override
+  public boolean hasVertex(final V v) {
+    return adjacent.get(v) != null;
+  }
+
+  @Override
   public boolean isAdjacent(final V v1, final V v2) {
     final Map<V, I> adjs = adjacent.get(v1);
     return adjs.containsKey(v2);
@@ -192,45 +197,5 @@ public final class AdjacentListDAG<V, I> implements DAG<V, I> {
       throw new NoSuchElementException("No src vertex " + v);
     }
     return inDegree;
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    final AdjacentListDAG that = (AdjacentListDAG) o;
-
-    if (numEdges != that.numEdges) {
-      return false;
-    }
-    if (numVertices != that.numVertices) {
-      return false;
-    }
-    if (!adjacent.equals(that.adjacent)) {
-      return false;
-    }
-    if (!inDegrees.equals(that.inDegrees)) {
-      return false;
-    }
-    if (!rootVertices.equals(that.rootVertices)) {
-      return false;
-    }
-
-    return true;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = adjacent.hashCode();
-    result = 31 * result + inDegrees.hashCode();
-    result = 31 * result + numVertices;
-    result = 31 * result + numEdges;
-    result = 31 * result + rootVertices.hashCode();
-    return result;
   }
 }

--- a/src/main/java/edu/snu/mist/common/graph/DAG.java
+++ b/src/main/java/edu/snu/mist/common/graph/DAG.java
@@ -51,6 +51,12 @@ public interface DAG<V, I> {
   Collection<V> getVertices();
 
   /**
+   * Return true if it has the vertex v.
+   * @param v vertex
+   */
+  boolean hasVertex(V v);
+
+  /**
    * Checks whether there is an edge from the vertices v to w.
    * @param v src vertex
    * @param w dest vertex

--- a/src/main/java/edu/snu/mist/common/graph/GraphUtils.java
+++ b/src/main/java/edu/snu/mist/common/graph/GraphUtils.java
@@ -83,4 +83,47 @@ public final class GraphUtils {
     }
     return list.iterator();
   }
+
+  /**
+   * Compare two dags whether they are the same.
+   * @return true if they are the same
+   */
+  public static <V, I> boolean compareTwoDag(final DAG<V, I> dag1, final DAG<V, I> dag2) {
+    if (!(dag1.numberOfVertices() == dag2.numberOfVertices()
+        && dag1.numberOfEdges() == dag2.numberOfEdges())) {
+      return false;
+    }
+
+    boolean comp = true;
+    for (final V root : dag1.getRootVertices()) {
+      comp = dfsCompare(dag1, dag2, root) && comp;
+    }
+    return comp;
+  }
+
+  /**
+   * Helper function for comparing two dags whether they are the same.
+   * It traverses the dag in dfs order.
+   */
+  private static <V, I> boolean dfsCompare(final DAG<V, I> dag1,
+                                           final DAG<V, I> dag2,
+                                           final V dag1Vertex) {
+    if (!dag2.hasVertex(dag1Vertex)) {
+      return false;
+    }
+
+    final Map<V, I> dag1Edges = dag1.getEdges(dag1Vertex);
+    final Map<V, I> dag2Edges = dag2.getEdges(dag1Vertex);
+
+    if (dag2Edges == null || !dag1Edges.equals(dag2Edges)) {
+      return false;
+    }
+
+    boolean comp = true;
+    for (final Map.Entry<V, I> entry : dag1Edges.entrySet()) {
+      comp = dfsCompare(dag1, dag2, entry.getKey()) && comp;
+    }
+
+    return comp;
+  }
 }

--- a/src/main/java/edu/snu/mist/core/task/AdjacentListConcurrentMapDAG.java
+++ b/src/main/java/edu/snu/mist/core/task/AdjacentListConcurrentMapDAG.java
@@ -88,6 +88,11 @@ public final class AdjacentListConcurrentMapDAG<V, I> implements DAG<V, I> {
   }
 
   @Override
+  public boolean hasVertex(final V v) {
+    return adjacent.get(v) != null;
+  }
+
+  @Override
   public boolean isAdjacent(final V v1, final V v2) {
     final Map<V, I> adjs = adjacent.get(v1);
     return adjs.containsKey(v2);
@@ -187,41 +192,5 @@ public final class AdjacentListConcurrentMapDAG<V, I> implements DAG<V, I> {
       throw new NoSuchElementException("No src vertex " + v);
     }
     return inDegree;
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    final AdjacentListConcurrentMapDAG that = (AdjacentListConcurrentMapDAG) o;
-
-    if (numEdges != that.numEdges) {
-      return false;
-    }
-    if (numVertices != that.numVertices) {
-      return false;
-    }
-    if (adjacent != null ? !adjacent.equals(that.adjacent) : that.adjacent != null) {
-      return false;
-    }
-    if (inDegrees != null ? !inDegrees.equals(that.inDegrees) : that.inDegrees != null) {
-      return false;
-    }
-
-    return true;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = adjacent != null ? adjacent.hashCode() : 0;
-    result = 31 * result + (inDegrees != null ? inDegrees.hashCode() : 0);
-    result = 31 * result + numVertices;
-    result = 31 * result + numEdges;
-    return result;
   }
 }

--- a/src/test/java/edu/snu/mist/common/GraphUtilsTest.java
+++ b/src/test/java/edu/snu/mist/common/GraphUtilsTest.java
@@ -55,7 +55,7 @@ public final class GraphUtilsTest {
    * Copy from src graph to dest graph.
    */
   @Test
-  public void copyGraphTest() {
+  public void testCopyGraph() {
     final DAG<Integer, Direction> destDAG = new AdjacentListDAG<>();
     GraphUtils.copy(srcDAG, destDAG);
 
@@ -74,7 +74,7 @@ public final class GraphUtilsTest {
    * Test whether GraphUtils.topologicalSort(dag) sorts the DAG correctly by topological order.
    */
   @Test
-  public void topologicalSortTest() {
+  public void testTopologicalSort() {
     final Iterator<Integer> vertices = GraphUtils.topologicalSort(srcDAG);
     int vertexNum = 0;
     while (vertices.hasNext()) {
@@ -85,5 +85,22 @@ public final class GraphUtilsTest {
       vertexNum += 1;
     }
     Assert.assertEquals("Vertex number should be 7", 7, vertexNum);
+  }
+
+  /**
+   * Test whether GraphUtils.compareTwoDag compares the two dags correctly.
+   */
+  @Test
+  public void testCompareDag() {
+    final DAG<Integer, Direction> dag2 = new AdjacentListDAG<>();
+    GraphUtils.copy(srcDAG, dag2);
+
+    Assert.assertTrue(GraphUtils.compareTwoDag(srcDAG, dag2));
+
+    dag2.addVertex(10);
+    Assert.assertFalse(GraphUtils.compareTwoDag(srcDAG, dag2));
+
+    srcDAG.addVertex(9);
+    Assert.assertFalse(GraphUtils.compareTwoDag(srcDAG, dag2));
   }
 }

--- a/src/test/java/edu/snu/mist/core/task/merging/ImmediateQueryMergingStarterTest.java
+++ b/src/test/java/edu/snu/mist/core/task/merging/ImmediateQueryMergingStarterTest.java
@@ -177,7 +177,7 @@ public final class ImmediateQueryMergingStarterTest {
     expectedDags.add(query);
     Assert.assertEquals(expectedDags, executionDags.values());
     // Check reference count of the execution vertices
-    Assert.assertEquals(query, executionPlanDagMap.get("q1"));
+    Assert.assertTrue(GraphUtils.compareTwoDag(query, executionPlanDagMap.get("q1")));
     checkReferenceCountOfExecutionVertices(query, vertexInfoMap, 1);
   }
 
@@ -253,8 +253,8 @@ public final class ImmediateQueryMergingStarterTest {
     Assert.assertEquals(expectedDags, executionDags.values());
 
     // Check reference count of the execution vertices
-    Assert.assertEquals(query1, executionPlanDagMap.get("q1"));
-    Assert.assertEquals(query2, executionPlanDagMap.get("q2"));
+    Assert.assertTrue(GraphUtils.compareTwoDag(query1, executionPlanDagMap.get("q1")));
+    Assert.assertTrue(GraphUtils.compareTwoDag(query2, executionPlanDagMap.get("q2")));
     checkReferenceCountOfExecutionVertices(query1, vertexInfoMap, 1);
     checkReferenceCountOfExecutionVertices(query2, vertexInfoMap, 1);
   }
@@ -323,11 +323,11 @@ public final class ImmediateQueryMergingStarterTest {
 
     final DAG<ExecutionVertex, MISTEdge> mergedDag = srcAndDagMap.get(sourceConf);
     Assert.assertEquals(1, srcAndDagMap.size());
-    Assert.assertEquals(expectedDag, mergedDag);
+    Assert.assertTrue(GraphUtils.compareTwoDag(expectedDag, mergedDag));
 
     // Check execution dags
     final Collection<DAG<ExecutionVertex, MISTEdge>> expectedDags = new HashSet<>();
-    expectedDags.add(expectedDag);
+    expectedDags.add(mergedDag);
     Assert.assertEquals(expectedDags, executionDags.values());
 
     // Generate events for the merged query and check if the dag is executed correctly
@@ -341,8 +341,8 @@ public final class ImmediateQueryMergingStarterTest {
     Assert.assertEquals(Arrays.asList(data), result2);
 
     // Check reference count and physical vertex of the execution vertices
-    Assert.assertEquals(query1Plan, executionPlanDagMap.get("q1"));
-    Assert.assertEquals(query2Plan, executionPlanDagMap.get("q2"));
+    Assert.assertTrue(GraphUtils.compareTwoDag(query1Plan, executionPlanDagMap.get("q1")));
+    Assert.assertTrue(GraphUtils.compareTwoDag(query2Plan, executionPlanDagMap.get("q2")));
     Assert.assertEquals(2, vertexInfoMap.get(src1).getRefCount());
     Assert.assertEquals(src1, vertexInfoMap.get(src1).getPhysicalExecutionVertex());
     Assert.assertEquals(2, vertexInfoMap.get(src2).getRefCount());
@@ -426,11 +426,11 @@ public final class ImmediateQueryMergingStarterTest {
 
     final DAG<ExecutionVertex, MISTEdge> mergedDag = srcAndDagMap.get(sourceConf);
     Assert.assertEquals(1, srcAndDagMap.size());
-    Assert.assertEquals(expectedDag, mergedDag);
+    Assert.assertTrue(GraphUtils.compareTwoDag(expectedDag, mergedDag));
 
     // Check execution dags
     final Collection<DAG<ExecutionVertex, MISTEdge>> expectedDags = new HashSet<>();
-    expectedDags.add(expectedDag);
+    expectedDags.add(mergedDag);
     Assert.assertEquals(expectedDags, executionDags.values());
 
     // Generate events for the merged query and check if the dag is executed correctly
@@ -453,8 +453,8 @@ public final class ImmediateQueryMergingStarterTest {
     Assert.assertEquals(Arrays.asList(data2), result2);
 
     // Check reference count and physical vertex of the execution vertices
-    Assert.assertEquals(query1Plan, executionPlanDagMap.get("q1"));
-    Assert.assertEquals(query2Plan, executionPlanDagMap.get("q2"));
+    Assert.assertTrue(GraphUtils.compareTwoDag(query1Plan, executionPlanDagMap.get("q1")));
+    Assert.assertTrue(GraphUtils.compareTwoDag(query2Plan, executionPlanDagMap.get("q2")));
     Assert.assertEquals(2, vertexInfoMap.get(src1).getRefCount());
     Assert.assertEquals(src1, vertexInfoMap.get(src1).getPhysicalExecutionVertex());
     Assert.assertEquals(2, vertexInfoMap.get(src2).getRefCount());


### PR DESCRIPTION
This PR addressed #759 by 
* removing `equals()` and `hashcode()` methods from DAG implementation 
* implementing `compareTwoDag(dag1, dag2)` method that checks if the two dags are the same

Closes #759 