### PR TITLE
[MIST-773] Resolve possible NullPointException in MQTTDataGenerator

### DIFF
--- a/src/main/java/edu/snu/mist/common/sources/MQTTDataGenerator.java
+++ b/src/main/java/edu/snu/mist/common/sources/MQTTDataGenerator.java
@@ -67,7 +67,7 @@ public final class MQTTDataGenerator implements DataGenerator<MqttMessage> {
    * @param message the message to emit
    */
   void emitData(final MqttMessage message) {
-    if (!closed.get()) {
+    if (!closed.get() && eventGenerator != null) {
       eventGenerator.emitData(message);
     }
   }


### PR DESCRIPTION
This PR resolves #773 via
* Forwarding MQTT message only if `eventGenerator` is not `null`.

Closes #773.