### PR TITLE
[MIST-791] Test Time Shortening for DefaultGroupSourceManagerTest

### DIFF
--- a/src/main/java/edu/snu/mist/api/MISTQueryBuilder.java
+++ b/src/main/java/edu/snu/mist/api/MISTQueryBuilder.java
@@ -42,7 +42,7 @@ public final class MISTQueryBuilder {
   /**
    * Period of default watermark represented in milliseconds.
    */
-  private static final int DEFAULT_WATERMARK_PERIOD = 10000;
+  private static final int DEFAULT_WATERMARK_PERIOD = 1000;
 
   /**
    * Expected delay of default watermark represented in milliseconds.

--- a/src/test/java/edu/snu/mist/api/MISTQueryBuilderTest.java
+++ b/src/test/java/edu/snu/mist/api/MISTQueryBuilderTest.java
@@ -144,7 +144,7 @@ public class MISTQueryBuilderTest {
     // Check about watermark configuration
     final long period = injector.getNamedInstance(PeriodicWatermarkPeriod.class);
     final long delay = injector.getNamedInstance(PeriodicWatermarkDelay.class);
-    Assert.assertEquals(10000, period);
+    Assert.assertEquals(1000, period);
     Assert.assertEquals(0, delay);
   }
 
@@ -171,7 +171,7 @@ public class MISTQueryBuilderTest {
     // Check watermark configuration
     final long period = injector.getNamedInstance(PeriodicWatermarkPeriod.class);
     final long delay = injector.getNamedInstance(PeriodicWatermarkDelay.class);
-    Assert.assertEquals(10000, period);
+    Assert.assertEquals(1000, period);
     Assert.assertEquals(0, delay);
   }
 }

--- a/src/test/java/edu/snu/mist/core/task/deactivation/DefaultGroupSourceManagerTest.java
+++ b/src/test/java/edu/snu/mist/core/task/deactivation/DefaultGroupSourceManagerTest.java
@@ -164,7 +164,7 @@ public class DefaultGroupSourceManagerTest {
    * There is only one group, one query, one ExecutionDag for this test's test query.
    * @throws Exception
    */
-  @Test(timeout = 40000)
+  @Test(timeout = 5000)
   public void testDeactivation() throws Exception {
     final JavaConfigurationBuilder jcb = Tang.Factory.getTang().newConfigurationBuilder();
     jcb.bindNamedParameter(GroupId.class, "testGroup");


### PR DESCRIPTION
This PR addressed #791 by
- adding a test configuration for the DefaultGroupSourceManagerTest, which has a default watermark period of 100 ms.

Closes #791