### PR TITLE
[MIST-785] Process events from the operator queue until the queue becomes empty

### DIFF
--- a/src/main/java/edu/snu/mist/core/task/globalsched/NextGroupSelectorFactory.java
+++ b/src/main/java/edu/snu/mist/core/task/globalsched/NextGroupSelectorFactory.java
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 package edu.snu.mist.core.task.globalsched;
-import edu.snu.mist.core.task.globalsched.roundrobin.WeightedRRNextGroupSelectorFactory;
+import edu.snu.mist.core.task.globalsched.dispatch.DispatcherGroupSelectorFactory;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 /**
  * This is a factory class for NextGroupSelector.
  */
-@DefaultImplementation(WeightedRRNextGroupSelectorFactory.class)
+@DefaultImplementation(DispatcherGroupSelectorFactory.class)
 public interface NextGroupSelectorFactory {
   /**
    * Creates a new next group selector.


### PR DESCRIPTION
This PR addressed #785 by 
* fixing `GlobalSchedNonBlockingEventProcessor`

Closes #785 