### PR TITLE
[MIST-816] Fix ConcurrentModificationException when accessing ExecutionDags

### DIFF
--- a/src/main/java/edu/snu/mist/core/task/merging/MergingExecutionDags.java
+++ b/src/main/java/edu/snu/mist/core/task/merging/MergingExecutionDags.java
@@ -20,7 +20,7 @@ import edu.snu.mist.core.task.ExecutionDags;
 
 import javax.inject.Inject;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This class holds the physical execution dags that are merged.
@@ -34,7 +34,7 @@ public final class MergingExecutionDags implements ExecutionDags {
 
   @Inject
   private MergingExecutionDags() {
-    this.dagCollection = new HashSet<>();
+    this.dagCollection = new ConcurrentHashMap<>().newKeySet();
   }
 
   @Override


### PR DESCRIPTION
This PR addressed #816 by 
* using `ConcurrentHashMap` in `MergingExecutionDags`

Closes #816 