### PR TITLE
[MIST-885] Check the name of event squence

### DIFF
--- a/src/main/java/edu/snu/mist/api/cep/MISTCepQuery.java
+++ b/src/main/java/edu/snu/mist/api/cep/MISTCepQuery.java
@@ -153,14 +153,9 @@ public final class MISTCepQuery<T> {
 
         private boolean checkSequence() {
             final Set<String> eventNameSet = new HashSet<>();
-            for (final CepEvent<T> event : cepEventSequence) {
-                final String name = event.getEventName();
-                if (eventNameSet.contains(name)) {
-                    return false;
-                }
-                eventNameSet.add(name);
-            }
-            return true;
+            cepEventSequence.stream()
+                .forEach(e -> eventNameSet.add(e.getEventName()));
+            return cepEventSequence.size() == eventNameSet.size();
         }
 
         public MISTCepQuery<T> build() {


### PR DESCRIPTION
This PR addressed #885 by
- Adding checking code of same event name when the query is built.

Closes #885 