### PR TITLE
[MIST-948] Prevent the frequent reassignment of the same group

### DIFF
--- a/src/main/java/edu/snu/mist/core/driver/MistGroupSchedulingTaskConfigs.java
+++ b/src/main/java/edu/snu/mist/core/driver/MistGroupSchedulingTaskConfigs.java
@@ -73,6 +73,7 @@ public final class MistGroupSchedulingTaskConfigs {
 
   private final boolean pinning;
   private final long processingTimeout;
+  private final long groupPinningTime;
 
   @Inject
   private MistGroupSchedulingTaskConfigs(
@@ -92,6 +93,7 @@ public final class MistGroupSchedulingTaskConfigs {
       @Parameter(GroupIsolationEnabled.class) final boolean groupIsolation,
       @Parameter(IsolationTriggerPeriod.class) final long isolationTriggerPeriod,
       @Parameter(UnderloadedGroupThreshold.class) final double underloadedGroupThreshold,
+      @Parameter(GroupPinningTime.class) final long groupPinningTime,
       @Parameter(ProcessingTimeout.class) final long processingTimeout) {
     this.epaType = epaType;
     this.cpuUtilLowThreshold = cpuUtilLowThreshold;
@@ -105,6 +107,7 @@ public final class MistGroupSchedulingTaskConfigs {
     this.dispatcherThreadNum = dispatcherThreadNum;
     this.groupAssignerType = groupAssignerType;
     this.rebalancing = rebalancing;
+    this.groupPinningTime = groupPinningTime;
     this.rebalancingPeriod = rebalancingPeriod;
     this.groupIsolation = groupIsolation;
     this.isolationTriggerPeriod = isolationTriggerPeriod;
@@ -193,6 +196,7 @@ public final class MistGroupSchedulingTaskConfigs {
     jcb.bindNamedParameter(IsolationTriggerPeriod.class, Long.toString(isolationTriggerPeriod));
     jcb.bindNamedParameter(UnderloadedGroupThreshold.class, Double.toString(underloadedGroupThreshold));
     jcb.bindNamedParameter(ProcessingTimeout.class, Long.toString(processingTimeout));
+    jcb.bindNamedParameter(GroupPinningTime.class, Long.toString(groupPinningTime));
 
     return Configurations.merge(getConfigurationForExecutionModel(), jcb.build());
   }
@@ -220,6 +224,7 @@ public final class MistGroupSchedulingTaskConfigs {
         .registerShortNameOfClass(IsolationTriggerPeriod.class)
         .registerShortNameOfClass(UnderloadedGroupThreshold.class)
         .registerShortNameOfClass(ProcessingTimeout.class)
-        .registerShortNameOfClass(Pinning.class);
+        .registerShortNameOfClass(Pinning.class)
+        .registerShortNameOfClass(GroupPinningTime.class);
   }
 }

--- a/src/main/java/edu/snu/mist/core/task/groupAware/DefaultGroupImpl.java
+++ b/src/main/java/edu/snu/mist/core/task/groupAware/DefaultGroupImpl.java
@@ -67,16 +67,16 @@ final class DefaultGroupImpl implements Group {
    */
   private final AtomicLong totalProcessingEvent;
   /**
-   * The latest rebalance time.
+   * The latest moved time.
    */
-  private long latestRebalanceTime;
+  private long latestMovedTime;
 
   @Inject
   private DefaultGroupImpl(@Parameter(GroupId.class) final String groupId) {
     this.groupId = groupId;
     this.activeQueryQueue = new ConcurrentLinkedQueue<>();
     this.eventProcessor = new AtomicReference<>(null);
-    this.latestRebalanceTime = System.nanoTime();
+    this.latestMovedTime = System.currentTimeMillis();
     this.totalProcessingEvent = new AtomicLong(0);
   }
 
@@ -228,8 +228,8 @@ final class DefaultGroupImpl implements Group {
   }
 
   @Override
-  public void setLatestRebalanceTime(final long rebalanceTime) {
-    latestRebalanceTime = rebalanceTime;
+  public void setLatestMovedTime(final long t) {
+    latestMovedTime = t;
   }
 
   @Override
@@ -244,8 +244,8 @@ final class DefaultGroupImpl implements Group {
   }
 
   @Override
-  public long getLatestRebalanceTime() {
-    return latestRebalanceTime;
+  public long getLatestMovedTime() {
+    return latestMovedTime;
   }
 
   @Override

--- a/src/main/java/edu/snu/mist/core/task/groupAware/Group.java
+++ b/src/main/java/edu/snu/mist/core/task/groupAware/Group.java
@@ -130,14 +130,14 @@ public interface Group extends AutoCloseable {
   boolean isSplited();
 
   /**
-   * Get latest rebalance time.
+   * Get the latest time that the group is assigned to another event processor.
    */
-  long getLatestRebalanceTime();
+  long getLatestMovedTime();
 
   /**
-   * Set latest rebalance time.
+   * Set the latest time that the group is assigned to another event processor.
    */
-  void setLatestRebalanceTime(long t);
+  void setLatestMovedTime(long t);
 
   /**
    * The number of remaining events.

--- a/src/main/java/edu/snu/mist/core/task/groupaware/parameters/GroupPinningTime.java
+++ b/src/main/java/edu/snu/mist/core/task/groupaware/parameters/GroupPinningTime.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.core.task.groupaware.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "The default group pinning time (sec)", short_name = "group_pinning_time", default_value = "300")
+public final class GroupPinningTime implements Name<Long> {
+}


### PR DESCRIPTION
This PR addressed #948 by 
* prevent a group from being reassigned if it has been moved before `groupPinningTime` second. 
* prevent multiple groups from being reassigned, splitted, or merged for cache localities 

Closes #948 