### PR TITLE
[MIST-978] Implement multi-query submission example

### DIFF
--- a/bin/run_example.sh
+++ b/bin/run_example.sh
@@ -45,6 +45,7 @@ case $1 in
   RuleBasedMQTTHelloMist) ;;
   RuleBasedMQTTNoiseSensing) ;;
   CepHRMonitoring) ;;
+  MqttFilterApplication) ;;
   *)
     echo "Invalid input. Here is an example for using this script."
     echo "If you want to run HelloMIST with sink source option, please type like below."

--- a/bin/submit_jar.sh
+++ b/bin/submit_jar.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Copyright (C) 2018 Seoul National University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Submit jar file to mist
+CLIENT_JAR=`echo $MIST_HOME/mist-client/target/mist-client-*-shaded.jar`
+
+CMD="java -cp $CLIENT_JAR edu.snu.mist.client.MistClient submit-jar $1 $2 $3"
+
+echo $CMD
+$CMD

--- a/mist-client/src/main/java/edu/snu/mist/client/MISTExecutionEnvironment.java
+++ b/mist-client/src/main/java/edu/snu/mist/client/MISTExecutionEnvironment.java
@@ -25,7 +25,7 @@ import java.util.List;
  * Execution Environment for MIST.
  * MIST Client can submit queries via this class.
  */
-public interface MISTExecutionEnvironment {
+public interface MISTExecutionEnvironment extends AutoCloseable {
   /**
    * Submit the query and its corresponding jar files to MIST.
    * @param queryToSubmit a query to be submitted.

--- a/mist-client/src/main/java/edu/snu/mist/client/MistClient.java
+++ b/mist-client/src/main/java/edu/snu/mist/client/MistClient.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.client;
+
+import edu.snu.mist.formats.avro.JarUploadResult;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public final class MistClient {
+
+  private MistClient() {
+
+  }
+
+  public static void main(final String[] args) throws IOException {
+    if (args.length < 4) {
+      System.out.println("Please enter the command-line parameters: ");
+      System.out.println("submit-jar $jar_path$ $driver_address$ $driver_port$");
+      return;
+    }
+
+    final String type = args[0];
+    if (type.compareToIgnoreCase("submit-jar") == 0) {
+      final String jarPath = args[1];
+      final File file = new File(jarPath);
+
+      if (!file.exists()) {
+        System.out.println("File " + jarPath + " does not exist");
+        return;
+      }
+
+      final String address = args[2];
+      final int port = Integer.valueOf(args[3]);
+
+      try (final MISTExecutionEnvironment ee = new MISTDefaultExecutionEnvironmentImpl(address, port)) {
+        final JarUploadResult result = ee.submitJar(Arrays.asList(jarPath));
+        if (result.getIsSuccess()) {
+          System.out.println("App identifier: " + result.getIdentifier());
+          return;
+        } else {
+          System.out.println("Submission failed: " + result.getMsg());
+        }
+      } catch (final Exception e) {
+        e.printStackTrace();
+      }
+    } else {
+      System.out.println("Not supported operation");
+      return;
+    }
+  }
+}

--- a/mist-examples/src/main/java/edu/snu/mist/examples/MISTExampleUtils.java
+++ b/mist-examples/src/main/java/edu/snu/mist/examples/MISTExampleUtils.java
@@ -127,16 +127,20 @@ public final class MISTExampleUtils {
     final String driverHostname = driverSocket[0];
     final int driverPort = Integer.parseInt(driverSocket[1]);
 
-    final MISTExecutionEnvironment executionEnvironment =
-        new MISTDefaultExecutionEnvironmentImpl(driverHostname, driverPort);
+    try (final MISTExecutionEnvironment executionEnvironment =
+        new MISTDefaultExecutionEnvironmentImpl(driverHostname, driverPort)) {
 
-    // Upload jar
-    final String jarFilePath = getJarFilePath();
-    final List<String> jarFilePaths = Arrays.asList(jarFilePath);
-    final JarUploadResult result = executionEnvironment.submitJar(jarFilePaths);
-    queryBuilder.setApplicationId(result.getIdentifier());
+      // Upload jar
+      final String jarFilePath = getJarFilePath();
+      final List<String> jarFilePaths = Arrays.asList(jarFilePath);
+      final JarUploadResult result = executionEnvironment.submitJar(jarFilePaths);
+      queryBuilder.setApplicationId(result.getIdentifier());
 
-    return executionEnvironment.submitQuery(queryBuilder.build());
+      return executionEnvironment.submitQuery(queryBuilder.build());
+    } catch (final Exception e) {
+      e.printStackTrace();
+      throw new RuntimeException(e);
+    }
   }
 
   public static CommandLine getDefaultCommandLine(final JavaConfigurationBuilder jcb) {

--- a/mist-examples/src/main/java/edu/snu/mist/examples/MqttFilterApplication.java
+++ b/mist-examples/src/main/java/edu/snu/mist/examples/MqttFilterApplication.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.snu.mist.examples;
+
+import edu.snu.mist.client.APIQueryControlResult;
+import edu.snu.mist.client.MISTDefaultExecutionEnvironmentImpl;
+import edu.snu.mist.client.MISTExecutionEnvironment;
+import edu.snu.mist.client.MISTQueryBuilder;
+import edu.snu.mist.client.datastreams.configurations.MQTTSourceConfiguration;
+import edu.snu.mist.client.datastreams.configurations.SourceConfiguration;
+import edu.snu.mist.common.functions.MISTFunction;
+import edu.snu.mist.common.functions.MISTPredicate;
+import edu.snu.mist.examples.parameters.*;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.JavaConfigurationBuilder;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.tang.formats.CommandLine;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+/**
+ * Submit a query that filters prefix strings.
+ * We can submit multiple different queries that filter different strings from this class.
+ * To do this, we first submit the mist-example jar file to MIST.
+ *
+ * Required parameters:
+ * -bu: broker address (default value: localhost:1883)
+ * -source_topic: mqtt source topic
+ * -sink_topic: mqtt sink topic
+ * -filtered_string: filtered string prefix
+ * -app_id: application identifier
+ */
+public final class MqttFilterApplication {
+
+  public static APIQueryControlResult submitQuery(final Configuration configuration)
+      throws IOException, InjectionException, URISyntaxException {
+    final Injector injector = Tang.Factory.getTang().newInjector(configuration);
+    final String brokerURI = injector.getNamedInstance(TestMQTTBrokerURI.class);
+    final String sourceTopic = injector.getNamedInstance(MqttSourceTopic.class);
+    final String sinkTopic = injector.getNamedInstance(MqttSinkTopic.class);
+    final String filteredString = injector.getNamedInstance(FilteredString.class);
+    final String appId = injector.getNamedInstance(ApplicationIdentifier.class);
+
+    final SourceConfiguration mqttSourceConf = new MQTTSourceConfiguration.MQTTSourceConfigurationBuilder()
+        .setBrokerURI(brokerURI)
+        .setTopic(sourceTopic)
+        .build();
+
+    final MISTQueryBuilder queryBuilder = new MISTQueryBuilder();
+    queryBuilder.setApplicationId(appId)
+        .mqttStream(mqttSourceConf)
+        .map(new MqttMessageToStringFunc())
+        .filter(new FilterFunc(filteredString))
+        .map(new MapFunc(filteredString))
+        .mqttOutput(brokerURI, sinkTopic);
+
+    final String[] driverSocket =
+        Tang.Factory.getTang().newInjector(configuration).getNamedInstance(DriverAddress.class).split(":");
+    final String driverHostname = driverSocket[0];
+    final int driverPort = Integer.parseInt(driverSocket[1]);
+
+    try (final MISTExecutionEnvironment executionEnvironment =
+        new MISTDefaultExecutionEnvironmentImpl(driverHostname, driverPort)) {
+      return executionEnvironment.submitQuery(queryBuilder.build());
+    } catch (final Exception e) {
+      e.printStackTrace();
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Set the environment(Hostname and port of driver, source, and sink) and submit a query.
+   * @param args command line parameters
+   * @throws Exception
+   */
+  public static void main(final String[] args) throws Exception {
+    final JavaConfigurationBuilder jcb = Tang.Factory.getTang().newConfigurationBuilder();
+
+    final CommandLine commandLine = MISTExampleUtils.getDefaultCommandLine(jcb)
+        .registerShortNameOfClass(NettySourceAddress.class) // Additional parameter
+        .registerShortNameOfClass(MqttSourceTopic.class)
+        .registerShortNameOfClass(MqttSinkTopic.class)
+        .registerShortNameOfClass(FilteredString.class)
+        .registerShortNameOfClass(ApplicationIdentifier.class)
+        .processCommandLine(args);
+
+    if (commandLine == null) {  // Option '?' was entered and processCommandLine printed the help.
+      return;
+    }
+
+    final APIQueryControlResult result = submitQuery(jcb.build());
+    System.out.println("Query submission result: " + result.getQueryId());
+
+  }
+
+  /**
+   * Must not be instantiated.
+   */
+  private MqttFilterApplication() {
+  }
+
+  @NamedParameter(short_name = "filtered_string", default_value = "HelloMIST:")
+  public static final class FilteredString implements Name<String> {
+    // do nothing
+  }
+
+  public static final class MqttMessageToStringFunc implements MISTFunction<MqttMessage, String> {
+
+    @Override
+    public String apply(final MqttMessage mqttMessage) {
+      return new String(mqttMessage.getPayload());
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      return o instanceof MqttMessageToStringFunc;
+    }
+
+    @Override
+    public int hashCode() {
+      return 1;
+    }
+  }
+
+  public static final class FilterFunc implements MISTPredicate<String> {
+
+    private final String filteredStr;
+
+    public FilterFunc(final String filteredStr) {
+      this.filteredStr = filteredStr;
+    }
+
+    @Override
+    public boolean test(final String s) {
+      return s.startsWith(filteredStr);
+    }
+
+    // WE must override equals and hashcode to allow query merging
+    // Two queries will be merged in MIST when the UDFs equal
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      final FilterFunc that = (FilterFunc) o;
+
+      if (filteredStr != null ? !filteredStr.equals(that.filteredStr) : that.filteredStr != null) {
+        return false;
+      }
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      return filteredStr != null ? filteredStr.hashCode() : 0;
+    }
+  }
+
+  public static final class MapFunc implements MISTFunction<String, MqttMessage> {
+    private final String prefix;
+    public MapFunc(final String prefix) {
+      this.prefix = prefix;
+    }
+
+    @Override
+    public MqttMessage apply(final String s) {
+      return new MqttMessage(s.substring(prefix.length()).trim().getBytes());
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      final MapFunc mapFunc = (MapFunc) o;
+
+      if (prefix != null ? !prefix.equals(mapFunc.prefix) : mapFunc.prefix != null) {
+        return false;
+      }
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      return prefix != null ? prefix.hashCode() : 0;
+    }
+  }
+}

--- a/mist-examples/src/main/java/edu/snu/mist/examples/parameters/ApplicationIdentifier.java
+++ b/mist-examples/src/main/java/edu/snu/mist/examples/parameters/ApplicationIdentifier.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.examples.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "application identifier for submitting query", short_name = "app_id")
+public final class ApplicationIdentifier implements Name<String> {
+}

--- a/mist-examples/src/main/java/edu/snu/mist/examples/parameters/MqttSinkTopic.java
+++ b/mist-examples/src/main/java/edu/snu/mist/examples/parameters/MqttSinkTopic.java
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * A package for defining batch query submission to support test.
- */
-package edu.snu.mist.client.batchsub;
+package edu.snu.mist.examples.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "mqtt sink topic", short_name = "sink_topic", default_value = "/sink")
+public final class MqttSinkTopic implements Name<String> {
+}

--- a/mist-examples/src/main/java/edu/snu/mist/examples/parameters/MqttSourceTopic.java
+++ b/mist-examples/src/main/java/edu/snu/mist/examples/parameters/MqttSourceTopic.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.examples.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "mqtt source topic", short_name = "source_topic", default_value = "/src")
+public final class MqttSourceTopic implements Name<String> {
+}


### PR DESCRIPTION
This PR addressed #978 by 
* implementing `MqttFilterApplication`, which can create multiple queries that filters user-defined prefix 
* implementing `MistClient` for jar submission 

To run the `MqttFilterApplication`, we first submit the mist-example jar file 
```
./bin/submit_jar.sh $mist-example-jar-file-path$ $driver_address$ $driver_rpc_port$
```

Then, it will return the app identifier
```
App identifier: 0
```

We can use this app identifier to submit multiple stream queries for the app 
```
./bin/run_example.sh MqttFilterApplication -source_topic $source_topic$ -sink_topic $sink_topic$ -filtered_string "HelloMIST:" -app_id 0
```

We submit a stream query  of the `app 0` that filters "HelloMIST" strings. 


Closes #978 