### PR TITLE
[MIST-1008] Set AffinityEventProcessorFactory as a default event processor factory

### DIFF
--- a/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/eventprocessor/EventProcessorFactory.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/eventprocessor/EventProcessorFactory.java
@@ -20,7 +20,7 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 /**
  * This is a factory of event processor.
  */
-@DefaultImplementation(DefaultEventProcessorFactory.class)
+@DefaultImplementation(AffinityEventProcessorFactory.class)
 public interface EventProcessorFactory {
 
   /**


### PR DESCRIPTION
This PR resolves #1008 