### PR TITLE
[MIST-1035] Implement group-unaware query allocation algorithms for testing

### DIFF
--- a/mist-core/src/main/java/edu/snu/mist/core/master/TaskLoadUpdater.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/TaskLoadUpdater.java
@@ -15,6 +15,7 @@
  */
 package edu.snu.mist.core.master;
 
+import edu.snu.mist.core.master.allocation.QueryAllocationManager;
 import edu.snu.mist.formats.avro.IPAddress;
 import edu.snu.mist.formats.avro.MasterToTaskMessage;
 import org.apache.avro.AvroRemoteException;
@@ -55,6 +56,7 @@ public class TaskLoadUpdater implements Runnable {
         final double updatedCpuLoad = (Double) proxyToTask.getTaskLoad();
         final TaskInfo taskInfo = queryAllocationManager.getTaskInfo(entry.getKey());
         taskInfo.setCpuLoad(updatedCpuLoad);
+        LOG.log(Level.INFO, "Task {0} updated its load: {1}", new Object[]{entry.getValue(), updatedCpuLoad});
       } catch (final AvroRemoteException e) {
         LOG.log(Level.INFO, "Remote error occured during connecting to task " + entry.getKey().toString());
       }

--- a/mist-core/src/main/java/edu/snu/mist/core/master/allocation/AbstractQueryAllocationManager.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/allocation/AbstractQueryAllocationManager.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.core.master.allocation;
+
+import edu.snu.mist.core.master.TaskInfo;
+import edu.snu.mist.formats.avro.IPAddress;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * The abstract class which supports common functionalities of QAMs.
+ */
+public abstract class AbstractQueryAllocationManager implements QueryAllocationManager {
+
+  /**
+   * The map which contains task info for each task.
+   */
+  protected final ConcurrentMap<IPAddress, TaskInfo> taskInfoMap;
+
+  protected AbstractQueryAllocationManager() {
+    this.taskInfoMap = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public TaskInfo getTaskInfo(final IPAddress taskAddress) {
+    return taskInfoMap.get(taskAddress);
+  }
+
+  @Override
+  public TaskInfo addTaskInfo(final IPAddress taskAddress, final TaskInfo taskInfo) {
+    return taskInfoMap.putIfAbsent(taskAddress, taskInfo);
+  }
+}

--- a/mist-core/src/main/java/edu/snu/mist/core/master/allocation/ApplicationAwareQueryAllocationManager.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/allocation/ApplicationAwareQueryAllocationManager.java
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.mist.core.master;
+package edu.snu.mist.core.master.allocation;
 
+import edu.snu.mist.core.master.TaskInfo;
 import edu.snu.mist.core.parameters.OverloadedTaskThreshold;
 import edu.snu.mist.formats.avro.IPAddress;
 import org.apache.reef.tang.annotations.Parameter;
@@ -29,17 +30,12 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * The app-allocation manager which allocates queries in application-aware way.
  */
-public final class ApplicationAwareQueryAllocationManager implements QueryAllocationManager {
+public final class ApplicationAwareQueryAllocationManager extends AbstractQueryAllocationManager {
 
   /**
    * The map which maintains the app-task list information.
    */
   private final ConcurrentMap<String, List<IPAddress>> appTaskListMap;
-
-  /**
-   * The map which maintains task info.
-   */
-  private final ConcurrentMap<IPAddress, TaskInfo> taskInfoMap;
 
   /**
    * The threshold for determining overloaded task.
@@ -49,8 +45,8 @@ public final class ApplicationAwareQueryAllocationManager implements QueryAlloca
   @Inject
   private ApplicationAwareQueryAllocationManager(
       @Parameter(OverloadedTaskThreshold.class) final double overloadedTaskThreshold) {
+    super();
     this.appTaskListMap = new ConcurrentHashMap<>();
-    this.taskInfoMap = new ConcurrentHashMap<>();
     this.overloadedTaskThreshold = overloadedTaskThreshold;
   }
 
@@ -94,15 +90,5 @@ public final class ApplicationAwareQueryAllocationManager implements QueryAlloca
       }
     }
     return minLoadTask;
-  }
-
-  @Override
-  public TaskInfo getTaskInfo(final IPAddress taskAddress) {
-    return taskInfoMap.get(taskAddress);
-  }
-
-  @Override
-  public TaskInfo addTaskInfo(final IPAddress taskAddress, final TaskInfo taskInfo) {
-    return taskInfoMap.putIfAbsent(taskAddress, taskInfo);
   }
 }

--- a/mist-core/src/main/java/edu/snu/mist/core/master/allocation/PowerOfTwoQueryAllocationManager.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/allocation/PowerOfTwoQueryAllocationManager.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.core.master.allocation;
+
+import edu.snu.mist.core.master.TaskInfo;
+import edu.snu.mist.formats.avro.IPAddress;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * The group-unaware QAM which adopts Power-Of-Two allocation algorithm.
+ */
+public final class PowerOfTwoQueryAllocationManager extends AbstractQueryAllocationManager {
+
+  /**
+   * The list of MistTasks which is necessary for query scheduling.
+   */
+  private final List<IPAddress> taskList;
+
+  @Inject
+  private PowerOfTwoQueryAllocationManager() {
+    super();
+    this.taskList = new CopyOnWriteArrayList<>();
+  }
+
+  @Override
+  public IPAddress getAllocatedTask(final String appId) {
+    final List<IPAddress> copiedList = new ArrayList<>(taskList);
+    Collections.shuffle(copiedList);
+    final IPAddress task0 = copiedList.get(0);
+    final IPAddress task1 = copiedList.get(1);
+    if (this.taskInfoMap.get(task0).getCpuLoad() < this.taskInfoMap.get(task1).getCpuLoad()) {
+      return task0;
+    } else {
+      return task1;
+    }
+  }
+
+  @Override
+  public TaskInfo addTaskInfo(final IPAddress taskAddress, final TaskInfo taskInfo) {
+    this.taskList.add(taskAddress);
+    return super.addTaskInfo(taskAddress, taskInfo);
+  }
+}

--- a/mist-core/src/main/java/edu/snu/mist/core/master/allocation/PowerOfTwoQueryAllocationManager.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/allocation/PowerOfTwoQueryAllocationManager.java
@@ -19,9 +19,8 @@ import edu.snu.mist.core.master.TaskInfo;
 import edu.snu.mist.formats.avro.IPAddress;
 
 import javax.inject.Inject;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -34,18 +33,28 @@ public final class PowerOfTwoQueryAllocationManager extends AbstractQueryAllocat
    */
   private final List<IPAddress> taskList;
 
+  /**
+   * The random object.
+   */
+  private final Random random;
+
   @Inject
   private PowerOfTwoQueryAllocationManager() {
     super();
     this.taskList = new CopyOnWriteArrayList<>();
+    this.random = new Random();
   }
 
   @Override
   public IPAddress getAllocatedTask(final String appId) {
-    final List<IPAddress> copiedList = new ArrayList<>(taskList);
-    Collections.shuffle(copiedList);
-    final IPAddress task0 = copiedList.get(0);
-    final IPAddress task1 = copiedList.get(1);
+    int index0, index1;
+    index0 = random.nextInt(taskList.size());
+    index1 = random.nextInt(taskList.size());
+    while (index1 == index0) {
+      index1 = random.nextInt(taskList.size());
+    }
+    final IPAddress task0 = taskList.get(index0);
+    final IPAddress task1 = taskList.get(index1);
     if (this.taskInfoMap.get(task0).getCpuLoad() < this.taskInfoMap.get(task1).getCpuLoad()) {
       return task0;
     } else {

--- a/mist-core/src/main/java/edu/snu/mist/core/master/allocation/QueryAllocationManager.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/allocation/QueryAllocationManager.java
@@ -13,15 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.snu.mist.core.master;
+package edu.snu.mist.core.master.allocation;
 
+import edu.snu.mist.core.master.TaskInfo;
 import edu.snu.mist.formats.avro.IPAddress;
-import org.apache.reef.tang.annotations.DefaultImplementation;
 
 /**
  * This is the interface for classes which is in charge of application-aware query allocation.
  */
-@DefaultImplementation(ApplicationAwareQueryAllocationManager.class)
 public interface QueryAllocationManager {
 
   /**

--- a/mist-core/src/main/java/edu/snu/mist/core/master/allocation/RoundRobinQueryAllocationManager.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/allocation/RoundRobinQueryAllocationManager.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.core.master.allocation;
+
+import edu.snu.mist.core.master.TaskInfo;
+import edu.snu.mist.formats.avro.IPAddress;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * The group-unaware round-robin query allocation scheduler.
+ */
+public final class RoundRobinQueryAllocationManager extends AbstractQueryAllocationManager {
+
+  /**
+   * The list of MistTasks which would be used for Round-Robin scheduling algorithm.
+   */
+  private final List<IPAddress> taskList;
+
+  /**
+   * The AtomicInteger used for round-robin scheduling.
+   */
+  private final AtomicInteger currentIndex;
+
+  @Inject
+  private RoundRobinQueryAllocationManager() {
+    super();
+    this.taskList = new CopyOnWriteArrayList<>();
+    this.currentIndex = new AtomicInteger();
+  }
+
+  @Override
+  public IPAddress getAllocatedTask(final String appId) {
+    final int myIndex = currentIndex.getAndIncrement() % taskList.size();
+    return taskList.get(myIndex);
+  }
+
+  @Override
+  public TaskInfo addTaskInfo(final IPAddress taskAddress, final TaskInfo taskInfo) {
+    final TaskInfo t = super.addTaskInfo(taskAddress, taskInfo);
+    taskList.add(taskAddress);
+    return t;
+  }
+}

--- a/mist-core/src/main/java/edu/snu/mist/core/master/allocation/package-info.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/allocation/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * The package for interface and implementation of QueryAllocationManager.
+ */
+package edu.snu.mist.core.master.allocation;

--- a/mist-core/src/main/java/edu/snu/mist/core/parameters/QueryAllocationOption.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/parameters/QueryAllocationOption.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.core.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * The query allocation option.
+ */
+@NamedParameter(doc = "The query allocation option.", short_name = "qa", default_value = "aa")
+public class QueryAllocationOption implements Name<String> {
+}

--- a/mist-core/src/main/java/edu/snu/mist/core/rpc/DefaultClientToMasterMessageImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/rpc/DefaultClientToMasterMessageImpl.java
@@ -16,7 +16,7 @@
 package edu.snu.mist.core.rpc;
 
 import edu.snu.mist.core.master.ApplicationCodeManager;
-import edu.snu.mist.core.master.QueryAllocationManager;
+import edu.snu.mist.core.master.allocation.QueryAllocationManager;
 import edu.snu.mist.formats.avro.ClientToMasterMessage;
 import edu.snu.mist.formats.avro.JarUploadResult;
 import edu.snu.mist.formats.avro.QuerySubmitInfo;

--- a/mist-core/src/main/java/edu/snu/mist/core/rpc/DefaultDriverToMasterMessageImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/rpc/DefaultDriverToMasterMessageImpl.java
@@ -16,7 +16,7 @@
 package edu.snu.mist.core.rpc;
 
 import edu.snu.mist.core.master.ProxyToTaskMap;
-import edu.snu.mist.core.master.QueryAllocationManager;
+import edu.snu.mist.core.master.allocation.QueryAllocationManager;
 import edu.snu.mist.core.master.TaskInfo;
 import edu.snu.mist.core.master.TaskLoadUpdater;
 import edu.snu.mist.core.parameters.TaskInfoGatherPeriod;

--- a/mist-core/src/test/java/edu/snu/mist/core/master/QueryAllocationManagerTest.java
+++ b/mist-core/src/test/java/edu/snu/mist/core/master/QueryAllocationManagerTest.java
@@ -15,6 +15,8 @@
  */
 package edu.snu.mist.core.master;
 
+import edu.snu.mist.core.master.allocation.ApplicationAwareQueryAllocationManager;
+import edu.snu.mist.core.master.allocation.QueryAllocationManager;
 import edu.snu.mist.core.parameters.OverloadedTaskThreshold;
 import edu.snu.mist.formats.avro.IPAddress;
 import org.apache.reef.tang.Injector;


### PR DESCRIPTION
This PR resolves #1035 via
* Implement round-robin and power-of-two query allocation algorithms.
* Add command line option for selecting query allocation algorithms.

Closes #1035.