### PR TITLE
[MIST-1034] Decouple storing of query configurations and query states

### DIFF
--- a/mist-client/src/main/java/edu/snu/mist/client/MISTDefaultExecutionEnvironmentImpl.java
+++ b/mist-client/src/main/java/edu/snu/mist/client/MISTDefaultExecutionEnvironmentImpl.java
@@ -98,6 +98,7 @@ public final class MISTDefaultExecutionEnvironmentImpl implements MISTExecutionE
     final AvroDag.Builder avroDagBuilder = AvroDag.newBuilder();
     final AvroDag avroDag = avroDagBuilder
         .setAppId(queryToSubmit.getApplicationId())
+        .setQueryId(querySubmitInfo.getQueryId())
         .setJarPaths(querySubmitInfo.getJarPaths())
         .setAvroVertices(serializedDag.getKey())
         .setEdges(serializedDag.getValue())

--- a/mist-client/src/test/java/edu/snu/mist/client/utils/MockMasterServer.java
+++ b/mist-client/src/test/java/edu/snu/mist/client/utils/MockMasterServer.java
@@ -51,6 +51,7 @@ public class MockMasterServer implements ClientToMasterMessage {
   @Override
   public QuerySubmitInfo getQuerySubmitInfo(final String appId) throws AvroRemoteException {
     return QuerySubmitInfo.newBuilder()
+        .setQueryId("query_0")
         .setJarPaths(new ArrayList())
         .setTask(new IPAddress(taskHost, taskPortNum))
         .build();

--- a/mist-common/src/main/avro/checkpoint_manager.avpr
+++ b/mist-common/src/main/avro/checkpoint_manager.avpr
@@ -119,12 +119,16 @@
       [
         {
           "name": "VertexState",
-          "type": {
-            "type": "map",
-            "values": [
-              "boolean", "int", "long", "float", "double", "string", "bytes"
-            ]
-          }
+          "type":
+          [
+            {
+              "type": "map",
+              "values": [
+                "boolean", "int", "long", "float", "double", "string", "bytes"
+              ]
+            },
+            "null"
+          ]
         },
         {
           "name": "LatestCheckpointTimestamp",

--- a/mist-common/src/main/avro/checkpoint_manager.avpr
+++ b/mist-common/src/main/avro/checkpoint_manager.avpr
@@ -23,28 +23,42 @@
   "types":
   [
     {
-      "name": "AvroConfigDag",
       "type": "record",
+      "name": "AvroDag",
       "fields":
       [
         {
-          "name": "AvroConfigVertices",
-          "type": {
+          "name": "AppId",
+          "type": "string"
+        },
+        {
+          "name": "QueryId",
+          "type": "string"
+        },
+        {
+          "name": "JarPaths",
+          "type":
+          {
+            "type": "array",
+            "items": "string"
+          }
+        },
+        {
+          "name": "AvroVertices",
+          "type":
+          {
             "type": "array",
             "items":
             {
-              "name": "AvroConfigVertex",
+              "name": "AvroVertex",
               "type": "record",
               "fields":
               [
                 {
-                  "name": "Id",
-                  "type": "string"
-                },
-                {
-                  "name": "Type",
-                  "type": {
-                    "name": "AvroConfigVertexType",
+                  "name": "AvroVertexType",
+                  "type":
+                  {
+                    "name": "AvroVertexTypeEnum",
                     "type": "enum",
                     "symbols": ["SOURCE", "OPERATOR", "SINK"]
                   }
@@ -56,37 +70,30 @@
                     "type": "map",
                     "values": "string"
                   }
-                },
-                {
-                  "name": "State",
-                  "type":
-                  {
-                    "type": "map",
-                    "values":
-                    [
-                      "boolean", "int", "long", "float", "double", "string", "bytes"
-                    ]
-                  }
-                },
-                {
-                  "name": "LatestCheckpointTimestamp",
-                  "type": "long",
-                  "default": 0
                 }
               ]
             }
           }
         },
         {
-          "name": "AvroConfigMISTEdges",
-          "type": {
+          "name": "Edges",
+          "type":
+          {
             "type": "array",
             "items":
             {
-              "name": "AvroConfigMISTEdge",
+              "name": "Edge",
               "type": "record",
               "fields":
               [
+                {
+                  "name": "From",
+                  "type": "int"
+                },
+                {
+                  "name": "To",
+                  "type": "int"
+                },
                 {
                   "name": "Direction",
                   "type": {
@@ -96,19 +103,46 @@
                   }
                 },
                 {
-                  "name": "Index",
+                  "name": "BranchIndex",
                   "type": "int"
-                },
-                {
-                  "name": "FromVertexIndex",
-                  "type": "int"
-                },
-                {
-                 "name": "ToVertexIndex",
-                 "type": "int"
                 }
               ]
             }
+          }
+        }
+      ]
+    },
+    {
+      "name": "StateWithTimestamp",
+      "type": "record",
+      "fields":
+      [
+        {
+          "name": "VertexState",
+          "type": {
+            "type": "map",
+            "values": [
+              "boolean", "int", "long", "float", "double", "string", "bytes"
+            ]
+          }
+        },
+        {
+          "name": "LatestCheckpointTimestamp",
+          "type": "long",
+          "default": 0
+        }
+      ]
+    },
+    {
+      "name": "QueryCheckpoint",
+      "type": "record",
+      "fields":
+      [
+        {
+          "name": "QueryState",
+          "type": {
+            "type": "array",
+            "items": "StateWithTimestamp"
           }
         }
       ]
@@ -119,33 +153,19 @@
       "fields":
       [
         {
-          "name": "AvroConfigDags",
-          "type":
-          {
-            "type": "map",
-            "values": "AvroConfigDag"
-          }
-        },
-        {
-          "name": "MinimumLatestCheckpointTimestamp",
-          "type": "long",
-          "default": 0
-        },
-        {
-          "name": "JarFilePaths",
-          "type":
-          {
-            "type": "array",
-            "items": "string"
-          }
-        },
-        {
           "name": "GroupId",
           "type": "string"
         },
         {
-          "name": "ApplicationId",
-          "type": "string"
+          "name": "QueryCheckpointMap",
+          "type": {
+            "type": "map",
+            "values": "QueryCheckpoint"
+          }
+        },
+        {
+          "name": "MinimumLatestCheckpointTimestamp",
+          "type": "long"
         }
       ]
     },
@@ -169,18 +189,6 @@
       ]
     }
   ],
-  "messages":
-  {
-    "checkpointGroup":
-    {
-      "request":
-      [
-        {
-          "name": "groupInfoCheckpoint",
-          "type": "GroupCheckpoint"
-        }
-      ],
-      "response": "CheckpointResult"
-    }
+  "messages": {
   }
 }

--- a/mist-common/src/main/avro/client_to_master_msg.avpr
+++ b/mist-common/src/main/avro/client_to_master_msg.avpr
@@ -66,6 +66,10 @@
             "type": "array",
             "items": "string"
           }
+        },
+        {
+          "name": "queryId",
+          "type": "string"
         }
       ]
     },

--- a/mist-common/src/main/avro/client_to_task_msg.avpr
+++ b/mist-common/src/main/avro/client_to_task_msg.avpr
@@ -31,6 +31,10 @@
           "type": "string"
         },
         {
+          "name": "QueryId",
+          "type": "string"
+        },
+        {
           "name": "JarPaths",
           "type":
           {

--- a/mist-core/src/main/java/edu/snu/mist/core/rpc/DefaultClientToMasterMessageImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/rpc/DefaultClientToMasterMessageImpl.java
@@ -25,6 +25,7 @@ import org.apache.avro.AvroRemoteException;
 import javax.inject.Inject;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Logger;
 
 /**
@@ -44,13 +45,17 @@ public final class DefaultClientToMasterMessageImpl implements ClientToMasterMes
    */
   private final ApplicationCodeManager appCodeManager;
 
-
+  /**
+   *
+   */
+  private final AtomicLong queryIdGenerator;
 
   @Inject
   private DefaultClientToMasterMessageImpl(final QueryAllocationManager queryAllocationManager,
                                            final ApplicationCodeManager appCodeManager) {
     this.queryAllocationManager = queryAllocationManager;
     this.appCodeManager = appCodeManager;
+    this.queryIdGenerator = new AtomicLong();
   }
 
   @Override
@@ -64,6 +69,7 @@ public final class DefaultClientToMasterMessageImpl implements ClientToMasterMes
     return QuerySubmitInfo.newBuilder()
         .setJarPaths(appCodeManager.getJarPaths(appId))
         .setTask(queryAllocationManager.getAllocatedTask(appId))
+        .setQueryId(String.valueOf(queryIdGenerator.getAndIncrement()))
         .build();
   }
 }

--- a/mist-core/src/main/java/edu/snu/mist/core/rpc/DefaultClientToTaskMessageImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/rpc/DefaultClientToTaskMessageImpl.java
@@ -21,7 +21,6 @@ import edu.snu.mist.formats.avro.AvroDag;
 import edu.snu.mist.formats.avro.ClientToTaskMessage;
 import edu.snu.mist.formats.avro.QueryControlResult;
 import org.apache.avro.AvroRemoteException;
-import org.apache.reef.io.Tuple;
 
 import javax.inject.Inject;
 import java.util.logging.Logger;
@@ -39,22 +38,15 @@ public final class DefaultClientToTaskMessageImpl implements ClientToTaskMessage
    */
   private final QueryManager queryManager;
 
-  /**
-   * A generator of query id.
-   */
-  private final QueryIdGenerator queryIdGenerator;
-
   @Inject
   private DefaultClientToTaskMessageImpl(final QueryIdGenerator queryIdGenerator,
                                          final QueryManager queryManager) {
-    this.queryIdGenerator = queryIdGenerator;
     this.queryManager = queryManager;
   }
 
   @Override
   public QueryControlResult sendQueries(final AvroDag avroDag) throws AvroRemoteException {
-    final String queryId = queryIdGenerator.generate(avroDag);
-    return queryManager.create(new Tuple<>(queryId, avroDag));
+    return queryManager.create(avroDag);
   }
 
   @Override

--- a/mist-core/src/main/java/edu/snu/mist/core/task/ConfigDagGenerator.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/ConfigDagGenerator.java
@@ -18,6 +18,7 @@ package edu.snu.mist.core.task;
 import edu.snu.mist.common.graph.DAG;
 import edu.snu.mist.common.graph.MISTEdge;
 import edu.snu.mist.formats.avro.AvroDag;
+import edu.snu.mist.formats.avro.QueryCheckpoint;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 /**
@@ -33,4 +34,12 @@ public interface ConfigDagGenerator {
    * @return configuration dag
    */
   DAG<ConfigVertex, MISTEdge> generate(AvroDag avroDag);
+
+  /**
+   * Generates the configuration dag from the avro dag with checkpointed states.
+   * @param avroDag the dag that is serialized by Avro
+   * @param checkpointedStates checkpointed states.
+   * @return
+   */
+  DAG<ConfigVertex, MISTEdge> generateWithCheckpointedStates(AvroDag avroDag, QueryCheckpoint checkpointedStates);
 }

--- a/mist-core/src/main/java/edu/snu/mist/core/task/DefaultConfigDagGeneratorImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/DefaultConfigDagGeneratorImpl.java
@@ -92,7 +92,7 @@ public final class DefaultConfigDagGeneratorImpl implements ConfigDagGenerator {
         final AvroVertex avroVertex = avroVertices.get(i);
         final StateWithTimestamp vertexStateWithTimestamp = queryState.get(i);
         final ExecutionVertex.Type type = getVertexType(avroVertex);
-        // Create a config vertex with
+        // Create a config vertex with checkpointed states.
         final ConfigVertex configVertex = new ConfigVertex(
             Long.toString(configVertexId.getAndIncrement()),
             type,

--- a/mist-core/src/main/java/edu/snu/mist/core/task/QueryManager.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/QueryManager.java
@@ -36,13 +36,13 @@ import java.util.List;
 public interface QueryManager extends AutoCloseable {
   /**
    * Start to the query.
-   * @param avroDag the query id and the avro dag
+   * @param avroDag the avro dag
    */
   QueryControlResult create(AvroDag avroDag);
 
   /**
    * Start to the query with the checkpointed states.
-   * @param avroDag the query id and the avro dag
+   * @param avroDag the avro dag
    * @param checkpointedStates the checkpointed states
    */
   QueryControlResult createWithCheckpointedStates(AvroDag avroDag, QueryCheckpoint checkpointedStates);
@@ -64,7 +64,7 @@ public interface QueryManager extends AutoCloseable {
    * @return
    */
   ApplicationInfo createApplication(String appId,
-                                        List<String> jarFilePath) throws InjectionException;
+                                    List<String> jarFilePath) throws InjectionException;
 
   /**
    * Deletes the query corresponding to the queryId submitted by client.

--- a/mist-core/src/main/java/edu/snu/mist/core/task/QueryManager.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/QueryManager.java
@@ -20,8 +20,8 @@ import edu.snu.mist.common.graph.MISTEdge;
 import edu.snu.mist.core.task.groupaware.ApplicationInfo;
 import edu.snu.mist.core.task.groupaware.GroupAwareQueryManagerImpl;
 import edu.snu.mist.formats.avro.AvroDag;
+import edu.snu.mist.formats.avro.QueryCheckpoint;
 import edu.snu.mist.formats.avro.QueryControlResult;
-import org.apache.reef.io.Tuple;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.tang.exceptions.InjectionException;
 
@@ -36,9 +36,16 @@ import java.util.List;
 public interface QueryManager extends AutoCloseable {
   /**
    * Start to the query.
-   * @param tuple the query id and the avro dag
+   * @param avroDag the query id and the avro dag
    */
-  QueryControlResult create(Tuple<String, AvroDag> tuple);
+  QueryControlResult create(AvroDag avroDag);
+
+  /**
+   * Start to the query with the checkpointed states.
+   * @param avroDag the query id and the avro dag
+   * @param checkpointedStates the checkpointed states
+   */
+  QueryControlResult createWithCheckpointedStates(AvroDag avroDag, QueryCheckpoint checkpointedStates);
 
   /**
    * Create a query (this is for checkpointing).

--- a/mist-core/src/main/java/edu/snu/mist/core/task/checkpointing/CheckpointManager.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/checkpointing/CheckpointManager.java
@@ -17,6 +17,7 @@ package edu.snu.mist.core.task.checkpointing;
 
 import edu.snu.mist.core.task.groupaware.ApplicationInfo;
 import edu.snu.mist.core.task.groupaware.Group;
+import edu.snu.mist.formats.avro.AvroDag;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 import java.io.IOException;
@@ -28,6 +29,14 @@ import java.io.IOException;
  */
 @DefaultImplementation(DefaultCheckpointManagerImpl.class)
 public interface CheckpointManager {
+
+  /**
+   * Store the given query to the disk.
+   * @param avroDag
+   * @return
+   */
+  boolean storeQuery(final AvroDag avroDag);
+
   /**
    * Recover a stored group in this MIST Task.
    * @param groupId

--- a/mist-core/src/main/java/edu/snu/mist/core/task/checkpointing/DefaultCheckpointManagerImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/checkpointing/DefaultCheckpointManagerImpl.java
@@ -103,7 +103,7 @@ public final class DefaultCheckpointManagerImpl implements CheckpointManager {
 
     for (final AvroDag avroDag : dagList) {
       final QueryCheckpoint queryCheckpoint = queryCheckpointMap.get(avroDag.getQueryId());
-      // Recover the query groups.
+      // Recover each query in the group.
       queryManager.createWithCheckpointedStates(avroDag, queryCheckpoint);
     }
   }

--- a/mist-core/src/main/java/edu/snu/mist/core/task/checkpointing/DefaultCheckpointManagerImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/checkpointing/DefaultCheckpointManagerImpl.java
@@ -15,20 +15,20 @@
  */
 package edu.snu.mist.core.task.checkpointing;
 
-import edu.snu.mist.common.graph.AdjacentListDAG;
-import edu.snu.mist.common.graph.DAG;
-import edu.snu.mist.common.graph.MISTEdge;
-import edu.snu.mist.core.task.ConfigVertex;
-import edu.snu.mist.core.task.ExecutionVertex;
+import edu.snu.mist.core.task.Query;
 import edu.snu.mist.core.task.QueryManager;
 import edu.snu.mist.core.task.groupaware.*;
 import edu.snu.mist.core.task.stores.GroupCheckpointStore;
-import edu.snu.mist.formats.avro.*;
+import edu.snu.mist.formats.avro.AvroDag;
+import edu.snu.mist.formats.avro.CheckpointResult;
+import edu.snu.mist.formats.avro.QueryCheckpoint;
 import org.apache.reef.io.Tuple;
+import org.apache.reef.tang.InjectionFuture;
 
 import javax.inject.Inject;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -59,101 +59,53 @@ public final class DefaultCheckpointManagerImpl implements CheckpointManager {
   private final GroupAllocationTableModifier groupAllocationTableModifier;
 
   /**
-   * The query manager for the task.
-   */
-  private final QueryManager queryManager;
+   * The query manager for the task. Use InjectionFuture to avoid cyclic injection.
+   **/
+  private final InjectionFuture<QueryManager> queryManagerFuture;
 
   @Inject
   private DefaultCheckpointManagerImpl(final ApplicationMap applicationMap,
                                        final GroupMap groupMap,
                                        final GroupCheckpointStore groupCheckpointStore,
                                        final GroupAllocationTableModifier groupAllocationTableModifier,
-                                       final QueryManager queryManager) {
+                                       final InjectionFuture<QueryManager> queryManagerFuture) {
     this.applicationMap = applicationMap;
     this.groupMap = groupMap;
     this.checkpointStore = groupCheckpointStore;
     this.groupAllocationTableModifier = groupAllocationTableModifier;
-    this.queryManager = queryManager;
+    this.queryManagerFuture = queryManagerFuture;
+  }
+
+  @Override
+  public boolean storeQuery(final AvroDag avroDag) {
+    return checkpointStore.saveQuery(avroDag);
   }
 
   @Override
   public void recoverGroup(final String groupId) throws IOException {
-    final GroupCheckpoint checkpoint;
+    final Map<String, QueryCheckpoint> queryCheckpointMap;
+    final List<AvroDag> dagList;
+    final QueryManager queryManager = queryManagerFuture.get();
     try {
-      checkpoint = checkpointStore.loadGroupCheckpoint(groupId);
+      // Load the queries.
+      final List<String> queryIdListInGroup = new ArrayList<>();
+      for (final Query query : groupMap.get(groupId).getQueries()) {
+        queryIdListInGroup.add(query.getId());
+      }
+      dagList = checkpointStore.loadSavedQueries(queryIdListInGroup);
+      // Load the states.
+      queryCheckpointMap = checkpointStore.loadSavedGroupState(groupId).getQueryCheckpointMap();
     } catch (final FileNotFoundException ie) {
       LOG.log(Level.WARNING, "Failed in loading app {0}, this app may not exist in the checkpoint store.",
           new Object[]{groupId});
       return;
     }
 
-    // Construct a ConfigDag for each query and submit it.
-    // The submission process is almost the same to create(), except that it uses a ConfigDag instead of an AvroDag.
-    for (final Map.Entry<String, AvroConfigDag> entry : checkpoint.getAvroConfigDags().entrySet()) {
-      final String queryId = entry.getKey();
-      LOG.log(Level.INFO, "Query with id {0} is being submitted during recovery of group id {1}",
-          new Object[]{queryId, groupId});
-      final AvroConfigDag dag = entry.getValue();
-      final List<AvroConfigVertex> vertexList = dag.getAvroConfigVertices();
-      final List<AvroConfigMISTEdge> edgeList = dag.getAvroConfigMISTEdges();
-
-      // Construct a ConfigDag(DAG<ConfigVertex, MISTEdge>) from an AvroConfigDag.
-      final DAG<ConfigVertex, MISTEdge> configDag = new AdjacentListDAG<>();
-
-      for (final AvroConfigVertex vertex : vertexList) {
-        configDag.addVertex(convertToConfigVertex(vertex));
-      }
-
-      for (final AvroConfigMISTEdge edge : edgeList) {
-        final AvroConfigVertex fromVertex = vertexList.get(edge.getFromVertexIndex());
-        final AvroConfigVertex toVertex = vertexList.get(edge.getToVertexIndex());
-        configDag.addEdge(convertToConfigVertex(fromVertex), convertToConfigVertex(toVertex),
-            new MISTEdge(edge.getDirection(), edge.getIndex()));
-      }
-
-      // Submit the query with the ConfigDag. This is almost the same to create().
-      try {
-        if (LOG.isLoggable(Level.FINE)) {
-          LOG.log(Level.FINE, "Recover Query [groupId: {0}, qid: {1}]",
-              new Object[]{groupId, queryId});
-        }
-
-        // Add the query info to the queryManager.
-        final List<String> jarFilePaths = checkpoint.getJarFilePaths();
-        final String appId = checkpoint.getApplicationId();
-        final ApplicationInfo applicationInfo;
-        if (applicationMap.containsKey(appId)) {
-          applicationInfo = applicationMap.get(appId);
-        } else {
-          applicationInfo =
-              queryManager.createApplication(checkpoint.getApplicationId(), jarFilePaths);
-        }
-        // Waiting for group information being added
-        while (applicationInfo.getGroups().isEmpty()) {
-          Thread.sleep(100);
-        }
-        // Start the submitted dag
-        queryManager.createAndStartQuery(queryId, applicationInfo, configDag);
-      } catch (final Exception e) {
-        e.printStackTrace();
-        // [MIST-345] We need to release all of the information that is required for the query when it fails.
-        LOG.log(Level.SEVERE, "An exception occurred while recovering {0} query: {1}",
-            new Object[] {groupId, e.toString()});
-      }
+    for (final AvroDag avroDag : dagList) {
+      final QueryCheckpoint queryCheckpoint = queryCheckpointMap.get(avroDag.getQueryId());
+      // Recover the query groups.
+      queryManager.createWithCheckpointedStates(avroDag, queryCheckpoint);
     }
-  }
-
-  private ConfigVertex convertToConfigVertex(final AvroConfigVertex vertex) {
-    final ExecutionVertex.Type type;
-    if (vertex.getType() == AvroConfigVertexType.SOURCE) {
-      type = ExecutionVertex.Type.SOURCE;
-    } else if (vertex.getType() == AvroConfigVertexType.OPERATOR) {
-      type = ExecutionVertex.Type.OPERATOR;
-    } else {
-      type = ExecutionVertex.Type.SINK;
-    }
-    return new ConfigVertex(vertex.getId(), type,
-        vertex.getConfiguration(), vertex.getState(), vertex.getLatestCheckpointTimestamp());
   }
 
   @Override
@@ -166,7 +118,7 @@ public final class DefaultCheckpointManagerImpl implements CheckpointManager {
       return false;
     }
     final CheckpointResult result =
-        checkpointStore.saveGroupCheckpoint(new Tuple<>(groupId, group));
+        checkpointStore.checkpointGroupStates(new Tuple<>(groupId, group));
     return result.getIsSuccess();
   }
 

--- a/mist-core/src/main/java/edu/snu/mist/core/task/stores/DefaultGroupCheckpointStore.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/stores/DefaultGroupCheckpointStore.java
@@ -106,7 +106,8 @@ public final class DefaultGroupCheckpointStore implements GroupCheckpointStore {
     try {
       final File storedFile = getQueryStoreFile(queryId);
       if (storedFile.exists()) {
-        throw new IllegalStateException("A query with the same ID already exists! Query ID should be unique");
+        storedFile.delete();
+        LOG.log(Level.INFO, "Deleting a duplicate query file");
       } else {
         storedFile.getParentFile().mkdirs();
         final DataFileWriter<AvroDag> dataFileWriter = new DataFileWriter<>(avroDagDatumWriter);

--- a/mist-core/src/main/java/edu/snu/mist/core/task/stores/DefaultGroupCheckpointStore.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/stores/DefaultGroupCheckpointStore.java
@@ -22,6 +22,7 @@ import edu.snu.mist.core.task.DefaultPhysicalOperatorImpl;
 import edu.snu.mist.core.task.ExecutionDag;
 import edu.snu.mist.core.task.ExecutionVertex;
 import edu.snu.mist.core.task.groupaware.Group;
+import edu.snu.mist.formats.avro.AvroDag;
 import edu.snu.mist.formats.avro.CheckpointResult;
 import edu.snu.mist.formats.avro.GroupCheckpoint;
 import org.apache.avro.file.DataFileReader;
@@ -36,6 +37,8 @@ import org.apache.reef.tang.annotations.Parameter;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -46,20 +49,32 @@ public final class DefaultGroupCheckpointStore implements GroupCheckpointStore {
   private final String tmpFolderPath;
 
   /**
+   * A writer that stores avro dag datum writer.
+   */
+  private final DatumWriter<AvroDag> avroDagDatumWriter;
+
+  /**
+   * A reader that reads stored avro dags.
+   */
+  private final DatumReader<AvroDag> avroDagDatumReader;
+
+  /**
    * A writer that stores ApplicationInfoCheckpoint.
    */
-  private final DatumWriter<GroupCheckpoint> datumWriter;
+  private final DatumWriter<GroupCheckpoint> groupCheckpointDatumWriter;
 
   /**
    * A reader that reads stored ApplicationInfoCheckpoint.
    */
-  private final DatumReader<GroupCheckpoint> datumReader;
+  private final DatumReader<GroupCheckpoint> groupCheckpointDatumReader;
 
   @Inject
   private DefaultGroupCheckpointStore(@Parameter(SharedStorePath.class) final String tmpFolderpath) {
     this.tmpFolderPath = tmpFolderpath;
-    this.datumWriter = new SpecificDatumWriter<>(GroupCheckpoint.class);
-    this.datumReader = new SpecificDatumReader<>(GroupCheckpoint.class);
+    this.avroDagDatumWriter = new SpecificDatumWriter<>(AvroDag.class);
+    this.avroDagDatumReader = new SpecificDatumReader<>(AvroDag.class);
+    this.groupCheckpointDatumWriter = new SpecificDatumWriter<>(GroupCheckpoint.class);
+    this.groupCheckpointDatumReader = new SpecificDatumReader<>(GroupCheckpoint.class);
     // Create a folder that stores the dags and jar files
     final File folder = new File(tmpFolderPath);
     if (!folder.exists()) {
@@ -75,13 +90,40 @@ public final class DefaultGroupCheckpointStore implements GroupCheckpointStore {
 
   private File getGroupCheckpointFile(final String groupId) {
     final StringBuilder sb = new StringBuilder(groupId);
-    sb.append(".groupcp");
+    sb.append(".checkpoint");
     return new File(tmpFolderPath, sb.toString());
   }
 
+  private File getQueryStoreFile(final String queryId) {
+    final StringBuilder sb = new StringBuilder(queryId);
+    sb.append(".query");
+    return new File(tmpFolderPath, sb.toString());
+  }
 
   @Override
-  public CheckpointResult saveGroupCheckpoint(final Tuple<String, Group> tuple) {
+  public boolean saveQuery(final AvroDag avroDag) {
+    final String queryId = avroDag.getQueryId();
+    try {
+      final File storedFile = getQueryStoreFile(queryId);
+      if (storedFile.exists()) {
+        throw new IllegalStateException("A query with the same ID already exists! Query ID should be unique");
+      } else {
+        storedFile.getParentFile().mkdirs();
+        final DataFileWriter<AvroDag> dataFileWriter = new DataFileWriter<>(avroDagDatumWriter);
+        dataFileWriter.create(avroDag.getSchema(), storedFile);
+        dataFileWriter.append(avroDag);
+        dataFileWriter.close();
+        LOG.log(Level.INFO, "Query {0} has been stored to disk.", queryId);
+      }
+      return true;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return false;
+    }
+  }
+
+  @Override
+  public CheckpointResult checkpointGroupStates(final Tuple<String, Group> tuple) {
     final String groupId = tuple.getKey();
     final Group group = tuple.getValue();
     final GroupCheckpoint checkpoint = group.checkpoint();
@@ -94,7 +136,7 @@ public final class DefaultGroupCheckpointStore implements GroupCheckpointStore {
       }
       if (!storedFile.exists()) {
         storedFile.getParentFile().mkdirs();
-        final DataFileWriter<GroupCheckpoint> dataFileWriter = new DataFileWriter<>(datumWriter);
+        final DataFileWriter<GroupCheckpoint> dataFileWriter = new DataFileWriter<>(groupCheckpointDatumWriter);
         dataFileWriter.create(checkpoint.getSchema(), storedFile);
         dataFileWriter.append(checkpoint);
         dataFileWriter.close();
@@ -124,16 +166,15 @@ public final class DefaultGroupCheckpointStore implements GroupCheckpointStore {
     return CheckpointResult.newBuilder()
         .setIsSuccess(true)
         .setMsg("Successfully checkpointed group " + tuple.getKey())
-        .setPathToCheckpoint(tmpFolderPath + "/" + tuple.getKey() + ".groupcp")
+        .setPathToCheckpoint(getGroupCheckpointFile(groupId).toString())
         .build();
   }
 
   @Override
-  public GroupCheckpoint loadGroupCheckpoint(final String groupId) throws IOException {
+  public GroupCheckpoint loadSavedGroupState(final String groupId) throws IOException {
     // Load the file.
     final File storedFile = getGroupCheckpointFile(groupId);
-    final DataFileReader<GroupCheckpoint> dataFileReader =
-        new DataFileReader<GroupCheckpoint>(storedFile, datumReader);
+    final DataFileReader<GroupCheckpoint> dataFileReader = new DataFileReader<>(storedFile, groupCheckpointDatumReader);
     GroupCheckpoint mgc = null;
     mgc = dataFileReader.next(mgc);
     if (mgc != null) {
@@ -142,5 +183,18 @@ public final class DefaultGroupCheckpointStore implements GroupCheckpointStore {
       LOG.log(Level.WARNING, "Checkpoint file not found or error during loading. groupId is " + groupId);
     }
     return mgc;
+  }
+
+  @Override
+  public List<AvroDag> loadSavedQueries(final List<String> queryIdList) throws IOException {
+    final List<AvroDag> savedQueries = new ArrayList<>();
+    for (final String queryId : queryIdList) {
+      final File storedFile = getQueryStoreFile(queryId);
+      final DataFileReader<AvroDag> dataFileReader = new DataFileReader<>(storedFile, avroDagDatumReader);
+      AvroDag avroDag = null;
+      avroDag = dataFileReader.next(avroDag);
+      savedQueries.add(avroDag);
+    }
+    return savedQueries;
   }
 }

--- a/mist-core/src/main/java/edu/snu/mist/core/task/stores/GroupCheckpointStore.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/stores/GroupCheckpointStore.java
@@ -16,12 +16,14 @@
 package edu.snu.mist.core.task.stores;
 
 import edu.snu.mist.core.task.groupaware.Group;
+import edu.snu.mist.formats.avro.AvroDag;
 import edu.snu.mist.formats.avro.CheckpointResult;
 import edu.snu.mist.formats.avro.GroupCheckpoint;
 import org.apache.reef.io.Tuple;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 import java.io.IOException;
+import java.util.List;
 
 @DefaultImplementation(DefaultGroupCheckpointStore.class)
 public interface GroupCheckpointStore {
@@ -30,12 +32,26 @@ public interface GroupCheckpointStore {
    * Saves a GroupCheckpoint.
    * @param tuple the groupId and Group
    */
-  CheckpointResult saveGroupCheckpoint(Tuple<String, Group> tuple);
+  CheckpointResult checkpointGroupStates(Tuple<String, Group> tuple);
 
   /**
    * Loads a GroupCheckpoint with the given groupId.
    * @param groupId
    * @return
    */
-  GroupCheckpoint loadGroupCheckpoint(String groupId) throws IOException;
+  GroupCheckpoint loadSavedGroupState(String groupId) throws IOException;
+
+  /**
+   * Save the given query to the disk.
+   * @param avroDag
+   * @return
+   */
+  boolean saveQuery(AvroDag avroDag);
+
+  /**
+   * Load the avro dags from the group.
+   * @param groupIdList
+   * @return
+   */
+  List<AvroDag> loadSavedQueries(List<String> groupIdList) throws IOException;
 }

--- a/mist-core/src/test/java/edu/snu/mist/core/task/DefaultDagGeneratorImplTest.java
+++ b/mist-core/src/test/java/edu/snu/mist/core/task/DefaultDagGeneratorImplTest.java
@@ -95,6 +95,7 @@ public final class DefaultDagGeneratorImplTest {
     final AvroDag.Builder avroDagBuilder = AvroDag.newBuilder();
     final AvroDag avroChainedDag = avroDagBuilder
         .setAppId(TestParameters.SUPER_GROUP_ID)
+        .setQueryId(TestParameters.QUERY_ID)
         .setJarPaths(new ArrayList<>())
         .setAvroVertices(serializedDag.getKey())
         .setEdges(serializedDag.getValue())

--- a/mist-core/src/test/java/edu/snu/mist/core/task/QueryManagerTest.java
+++ b/mist-core/src/test/java/edu/snu/mist/core/task/QueryManagerTest.java
@@ -38,7 +38,6 @@ import edu.snu.mist.core.task.utils.TestWithCountDownSink;
 import edu.snu.mist.formats.avro.AvroDag;
 import edu.snu.mist.formats.avro.Direction;
 import junit.framework.Assert;
-import org.apache.reef.io.Tuple;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.JavaConfigurationBuilder;
@@ -140,21 +139,21 @@ public final class QueryManagerTest {
     // Fake operator chain dag of QueryManager
     final AvroDag fakeAvroDag = new AvroDag();
     //fakeAvroDag.setSuperGroupId("testGroup");
-    final Tuple<String, AvroDag> tuple = new Tuple<>(queryId, fakeAvroDag);
+    //final Tuple<String, AvroDag> tuple = new Tuple<>(queryId, fakeAvroDag);
 
     // Construct execution dag
-    constructExecutionDag(tuple, executionDag, src, sink1, sink2);
+    constructExecutionDag(executionDag, src, sink1, sink2);
 
     // Create mock DagGenerator. It returns the above  execution dag
     final ConfigDagGenerator configDagGenerator = mock(ConfigDagGenerator.class);
     final DAG<ConfigVertex, MISTEdge> configDag = mock(DAG.class);
-    when(configDagGenerator.generate(tuple.getValue())).thenReturn(configDag);
+    when(configDagGenerator.generate(fakeAvroDag)).thenReturn(configDag);
     final DagGenerator dagGenerator = mock(DagGenerator.class);
     //when(dagGenerator.generate(configDag, tuple.getValue().getJarFilePaths())).thenReturn(executionDag);
 
     // Build QueryManager
-    final QueryManager queryManager = queryManagerBuild(tuple, configDagGenerator, dagGenerator, injector);
-    queryManager.create(tuple);
+    final QueryManager queryManager = queryManagerBuild(fakeAvroDag, configDagGenerator, dagGenerator, injector);
+    queryManager.create(fakeAvroDag);
 
     // Wait until all of the outputs are generated
     countDownAllOutputs.await();
@@ -192,8 +191,7 @@ public final class QueryManagerTest {
    * Construct execution dag.
    * Creates operators and adds source, dag vertices, edges and sinks to dag.
    */
-  private void constructExecutionDag(final Tuple<String, AvroDag> tuple,
-                                     final ExecutionDag executionDag,
+  private void constructExecutionDag(final ExecutionDag executionDag,
                                      final PhysicalSource src,
                                      final PhysicalSink sink1,
                                      final PhysicalSink sink2) {

--- a/mist-core/src/test/java/edu/snu/mist/core/task/QueryManagerTest.java
+++ b/mist-core/src/test/java/edu/snu/mist/core/task/QueryManagerTest.java
@@ -246,13 +246,13 @@ public final class QueryManagerTest {
    * QueryManager Builder.
    * It receives inputs tuple, physicalPlanGenerator, injector then makes query manager.
    */
-  private QueryManager queryManagerBuild(final Tuple<String, AvroDag> tuple,
+  private QueryManager queryManagerBuild(final AvroDag avroDag,
                                          final ConfigDagGenerator configDagGenerator,
                                          final DagGenerator dagGenerator,
                                          final Injector injector) throws Exception {
     // Create mock PlanStore. It returns true and the above logical plan
     final QueryInfoStore planStore = mock(QueryInfoStore.class);
-    when(planStore.load(tuple.getKey())).thenReturn(tuple.getValue());
+    //when(planStore.load(avroDag.getQueryId()).thenReturn(avroDag);
 
     // Create QueryManager
     injector.bindVolatileInstance(ConfigDagGenerator.class, configDagGenerator);

--- a/mist-core/src/test/java/edu/snu/mist/core/task/checkpointing/GroupRecoveryTest.java
+++ b/mist-core/src/test/java/edu/snu/mist/core/task/checkpointing/GroupRecoveryTest.java
@@ -128,9 +128,11 @@ public class GroupRecoveryTest {
     final Tuple<List<AvroVertex>, List<Edge>> initialAvroOpChainDag = query.getAvroOperatorDag();
 
     final String appId = "testApp";
+    final String queryId = "testQuery";
     final AvroDag.Builder avroDagBuilder = AvroDag.newBuilder();
     final AvroDag avroDag = avroDagBuilder
         .setAppId(appId)
+        .setQueryId(queryId)
         .setJarPaths(new ArrayList<>())
         .setAvroVertices(initialAvroOpChainDag.getKey())
         .setEdges(initialAvroOpChainDag.getValue())
@@ -148,9 +150,9 @@ public class GroupRecoveryTest {
 
     final QueryManager queryManager = injector.getInstance(QueryManager.class);
 
-    final Tuple<String, AvroDag> tuple = new Tuple<>("testQuery", avroDag);
+    //final Tuple<String, AvroDag> tuple = new Tuple<>("testQuery", avroDag);
     queryManager.createApplication(appId, Arrays.asList(""));
-    queryManager.create(tuple);
+    queryManager.create(avroDag);
 
     // Wait until all sources connect to stream generator
     sourceCountDownLatch1.await();

--- a/mist-core/src/test/java/edu/snu/mist/core/task/stores/QueryInfoStoreTest.java
+++ b/mist-core/src/test/java/edu/snu/mist/core/task/stores/QueryInfoStoreTest.java
@@ -103,12 +103,14 @@ public class QueryInfoStoreTest {
     final AvroDag.Builder avroDagBuilder = AvroDag.newBuilder();
     final AvroDag avroDag1 = avroDagBuilder
         .setAppId(TestParameters.SUPER_GROUP_ID)
+        .setQueryId(TestParameters.QUERY_ID)
         .setJarPaths(paths)
         .setAvroVertices(serializedDag.getKey())
         .setEdges(serializedDag.getValue())
         .build();
     final AvroDag avroDag2 = avroDagBuilder
         .setAppId(TestParameters.SUPER_GROUP_ID)
+        .setQueryId(TestParameters.QUERY_ID)
         .setJarPaths(paths)
         .setAvroVertices(serializedDag.getKey())
         .setEdges(serializedDag.getValue())

--- a/mist-core/src/test/java/edu/snu/mist/core/utils/TestParameters.java
+++ b/mist-core/src/test/java/edu/snu/mist/core/utils/TestParameters.java
@@ -35,6 +35,7 @@ public final class TestParameters {
   public static final int SINK_PORT = 13667;
   public static final String TOPIC = "mqttTopic";
   public static final String SUPER_GROUP_ID = "test-group";
+  public static final String QUERY_ID = "test-query";
 
   public static final SourceConfiguration LOCAL_TEXT_SOCKET_SOURCE_CONF =
       TextSocketSourceConfiguration.newBuilder()


### PR DESCRIPTION
This PR resolves #1034, #1033 via
* Separate query configurations / query states storing
* Checkpointing only query states on checkpoint events
* Re-design necessary schemas & method implementation
* Enable query recovery only from the query configurations for recovery without checkpointing

Closes #1034. Closes #1033.