### PR TITLE
[MIST-1037] Fix the problem of task load update

### DIFF
--- a/mist-core/src/main/java/edu/snu/mist/core/driver/MistDriver.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/driver/MistDriver.java
@@ -367,6 +367,7 @@ public final class MistDriver {
             .getInetSocketAddress().getHostName();
         try {
           proxyToMaster.addTask(new IPAddress(taskHostAddress, mistDriverConfigs.getClientToTaskPort()));
+          proxyToMaster.setupMasterToTaskConn(new IPAddress(taskHostAddress, mistDriverConfigs.getMasterToTaskPort()));
           if (runningTaskNum.incrementAndGet() == mistDriverConfigs.getNumTasks()) {
             // Notify that all the tasks are running now... Start gathering task information from master.
             proxyToMaster.taskSetupFinished();

--- a/mist-core/src/main/java/edu/snu/mist/core/master/TaskLoadUpdater.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/TaskLoadUpdater.java
@@ -41,10 +41,14 @@ public class TaskLoadUpdater implements Runnable {
    */
   private final QueryAllocationManager queryAllocationManager;
 
+  private final int clientToTaskPort;
+
   public TaskLoadUpdater(final ProxyToTaskMap proxyToTaskMap,
-                         final QueryAllocationManager queryAllocationManager) {
+                         final QueryAllocationManager queryAllocationManager,
+                         final int clientToTaskPort) {
     this.proxyToTaskMap = proxyToTaskMap;
     this.queryAllocationManager = queryAllocationManager;
+    this.clientToTaskPort = clientToTaskPort;
   }
 
   @Override
@@ -54,9 +58,10 @@ public class TaskLoadUpdater implements Runnable {
       try {
         final MasterToTaskMessage proxyToTask = entry.getValue();
         final double updatedCpuLoad = (Double) proxyToTask.getTaskLoad();
-        final TaskInfo taskInfo = queryAllocationManager.getTaskInfo(entry.getKey());
+        final TaskInfo taskInfo = queryAllocationManager.getTaskInfo(
+            new IPAddress(entry.getKey().getHostAddress(), clientToTaskPort));
         taskInfo.setCpuLoad(updatedCpuLoad);
-        LOG.log(Level.INFO, "Task {0} updated its load: {1}", new Object[]{entry.getValue(), updatedCpuLoad});
+        LOG.log(Level.INFO, "Task {0} updated its load: {1}", new Object[]{entry.getKey().toString(), updatedCpuLoad});
       } catch (final AvroRemoteException e) {
         LOG.log(Level.INFO, "Remote error occured during connecting to task " + entry.getKey().toString());
       }


### PR DESCRIPTION
This PR resolves #1037 via
* Add missing master-to-task setup connection.
* Fix bugs in retrieving `taskInfo` in `MistMaster`