### PR TITLE
[MIST-1052] Use String hostname for identifying MistTask

### DIFF
--- a/mist-client/src/main/java/edu/snu/mist/client/MISTQueryControl.java
+++ b/mist-client/src/main/java/edu/snu/mist/client/MISTQueryControl.java
@@ -62,7 +62,7 @@ public final class MISTQueryControl {
     ClientToTaskMessage proxyToTask = TASK_PROXY_MAP.get(taskAddress);
     if (proxyToTask == null) {
       final NettyTransceiver clientToTask = new NettyTransceiver(
-          new InetSocketAddress(taskAddress.getHostAddress().toString(), taskAddress.getPort()));
+          new InetSocketAddress(taskAddress.getHostAddress(), taskAddress.getPort()));
       final ClientToTaskMessage proxy = SpecificRequestor.getClient(ClientToTaskMessage.class, clientToTask);
       TASK_PROXY_MAP.putIfAbsent(taskAddress, proxy);
       proxyToTask = TASK_PROXY_MAP.get(taskAddress);

--- a/mist-common/src/main/avro/driver_to_master_msg.avpr
+++ b/mist-common/src/main/avro/driver_to_master_msg.avpr
@@ -21,21 +21,6 @@
   "namespace": "edu.snu.mist.formats.avro",
   "protocol": "DriverToMasterMessage",
   "types":[
-    {
-      "name": "IPAddress",
-      "type": "record",
-      "fields":
-      [
-        {
-          "name": "hostAddress",
-          "type": "string"
-        },
-        {
-          "name": "port",
-          "type": "int"
-        }
-      ]
-    }
   ],
   "messages":
   {
@@ -44,8 +29,8 @@
       "request":
       [
         {
-          "name": "taskAddress",
-          "type": "IPAddress"
+          "name": "taskHostname",
+          "type": "string"
         }
       ],
       "response": "boolean"
@@ -55,8 +40,8 @@
       "request":
       [
         {
-          "name": "taskAddress",
-          "type": "IPAddress"
+          "name": "taskHostname",
+          "type": "string"
         }
       ],
       "response": "boolean"
@@ -71,8 +56,8 @@
       "request":
       [
         {
-          "name": "taskAddress",
-          "type": "IPAddress"
+          "name": "taskHostname",
+          "type": "string"
         }
       ],
       "response": "boolean"

--- a/mist-core/src/main/java/edu/snu/mist/core/driver/MistDriver.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/driver/MistDriver.java
@@ -314,6 +314,7 @@ public final class MistDriver {
         masterConfBuilder.bindNamedParameter(SharedStorePath.class, String.valueOf(mistDriverConfigs
             .getSharedStorePath()));
         masterConfBuilder.bindNamedParameter(MasterToTaskPort.class, String.valueOf(masterToTaskPort));
+        masterConfBuilder.bindNamedParameter(ClientToTaskPort.class, String.valueOf(clientToTaskPort));
         masterConfBuilder.bindNamedParameter(ClientToMasterPort.class, String.valueOf(clientToMasterPort));
         masterConfBuilder.bindNamedParameter(TaskToMasterPort.class, String.valueOf(taskToMasterPort));
         masterConfBuilder.bindNamedParameter(DriverToMasterPort.class, String.valueOf(driverToMasterPort));
@@ -367,8 +368,8 @@ public final class MistDriver {
         final String taskHostAddress = runningTask.getActiveContext().getEvaluatorDescriptor().getNodeDescriptor()
             .getInetSocketAddress().getHostName();
         try {
-          proxyToMaster.addTask(new IPAddress(taskHostAddress, mistDriverConfigs.getClientToTaskPort()));
-          proxyToMaster.setupMasterToTaskConn(new IPAddress(taskHostAddress, mistDriverConfigs.getMasterToTaskPort()));
+          proxyToMaster.addTask(taskHostAddress);
+          proxyToMaster.setupMasterToTaskConn(taskHostAddress);
           if (runningTaskNum.incrementAndGet() == mistDriverConfigs.getNumTasks()) {
             // Notify that all the tasks are running now... Start gathering task information from master.
             proxyToMaster.taskSetupFinished();

--- a/mist-core/src/main/java/edu/snu/mist/core/driver/MistDriver.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/driver/MistDriver.java
@@ -272,7 +272,7 @@ public final class MistDriver {
       // All the active contexts are now submitted
       if (activeContextCounter.incrementAndGet() == 1 + mistDriverConfigs.getNumTasks()) {
         // Get Master host address
-        final String masterHostAddress =
+        final String masterHostname =
             masterContext.getEvaluatorDescriptor().getNodeDescriptor().getInetSocketAddress().getHostName();
         final int clientToMasterPort = mistDriverConfigs.getClientToMasterPort();
         final int taskToMasterPort = mistDriverConfigs.getTaskToMasterPort();
@@ -283,7 +283,7 @@ public final class MistDriver {
         final JavaConfigurationBuilder masterConfBuilder = tang.newConfigurationBuilder();
         for (final ActiveContext taskContext: mistTaskContextQueue) {
           // Task configurations
-          final String taskHostAddress =
+          final String taskHostname =
               taskContext.getEvaluatorDescriptor().getNodeDescriptor().getInetSocketAddress().getHostName();
           // Task configuration
           final Configuration taskConfiguration = TaskConfiguration.CONF
@@ -294,15 +294,15 @@ public final class MistDriver {
           final JavaConfigurationBuilder taskConfBuilder = tang.newConfigurationBuilder();
           taskConfBuilder.bindNamedParameter(ClientToTaskPort.class, String.valueOf(clientToTaskPort));
           masterConfBuilder.bindSetEntry(TaskHostSet.class,
-              taskHostAddress);
+              taskHostname);
           taskConfBuilder.bindNamedParameter(MasterToTaskPort.class, String.valueOf(masterToTaskPort));
-          taskConfBuilder.bindNamedParameter(MasterHostAddress.class, masterHostAddress);
-          LOG.info("Set master host address: " + masterHostAddress);
+          taskConfBuilder.bindNamedParameter(MasterHostname.class, masterHostname);
+          LOG.info("Set master host address: " + masterHostname);
           taskConfBuilder.bindNamedParameter(TaskToMasterPort.class, String.valueOf(taskToMasterPort));
           taskConfBuilder.bindImplementation(MasterToTaskMessage.class, DefaultMasterToTaskMessageImpl.class);
           taskConfBuilder.bindNamedParameter(SharedStorePath.class, String.valueOf(mistDriverConfigs
               .getSharedStorePath()));
-          taskConfBuilder.bindNamedParameter(TaskHostAddress.class, taskHostAddress);
+          taskConfBuilder.bindNamedParameter(TaskHostname.class, taskHostname);
           // Store task configuration.
           mistTaskConfQueue.add(Configurations.merge(
               nameResolverConf,
@@ -351,12 +351,12 @@ public final class MistDriver {
           taskCount += 1;
         }
         // Establish driver-to-master connection.
-        final String masterHostAddress = runningTask.getActiveContext().getEvaluatorDescriptor().getNodeDescriptor()
+        final String masterHostname = runningTask.getActiveContext().getEvaluatorDescriptor().getNodeDescriptor()
             .getInetSocketAddress().getHostName();
         final int driverToMasterPort = mistDriverConfigs.getDriverToMasterPort();
         // Master is running. Setup avro connection between driver and master.
         try {
-          final NettyTransceiver driverToMaster = new NettyTransceiver(new InetSocketAddress(masterHostAddress,
+          final NettyTransceiver driverToMaster = new NettyTransceiver(new InetSocketAddress(masterHostname,
               driverToMasterPort));
           proxyToMaster = SpecificRequestor.getClient(DriverToMasterMessage.class, driverToMaster);
         } catch (final IOException e) {
@@ -365,11 +365,11 @@ public final class MistDriver {
         }
       } else {
         // The running task is MistTask.
-        final String taskHostAddress = runningTask.getActiveContext().getEvaluatorDescriptor().getNodeDescriptor()
+        final String taskHostname = runningTask.getActiveContext().getEvaluatorDescriptor().getNodeDescriptor()
             .getInetSocketAddress().getHostName();
         try {
-          proxyToMaster.addTask(taskHostAddress);
-          proxyToMaster.setupMasterToTaskConn(taskHostAddress);
+          proxyToMaster.addTask(taskHostname);
+          proxyToMaster.setupMasterToTaskConn(taskHostname);
           if (runningTaskNum.incrementAndGet() == mistDriverConfigs.getNumTasks()) {
             // Notify that all the tasks are running now... Start gathering task information from master.
             proxyToMaster.taskSetupFinished();

--- a/mist-core/src/main/java/edu/snu/mist/core/master/ProxyToTaskMap.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/ProxyToTaskMap.java
@@ -15,7 +15,6 @@
  */
 package edu.snu.mist.core.master;
 
-import edu.snu.mist.formats.avro.IPAddress;
 import edu.snu.mist.formats.avro.MasterToTaskMessage;
 
 import javax.inject.Inject;
@@ -29,18 +28,18 @@ import java.util.concurrent.ConcurrentMap;
  */
 public final class ProxyToTaskMap {
 
-  private ConcurrentMap<IPAddress, MasterToTaskMessage> innerMap;
+  private ConcurrentMap<String, MasterToTaskMessage> innerMap;
 
   @Inject
   private ProxyToTaskMap() {
     this.innerMap = new ConcurrentHashMap<>();
   }
 
-  public void addNewProxy(final IPAddress taskAddress, final MasterToTaskMessage proxyToTask) {
-    innerMap.put(taskAddress, proxyToTask);
+  public void addNewProxy(final String taskHostname, final MasterToTaskMessage proxyToTask) {
+    innerMap.put(taskHostname, proxyToTask);
   }
 
-  public Set<Map.Entry<IPAddress, MasterToTaskMessage>> entrySet() {
+  public Set<Map.Entry<String, MasterToTaskMessage>> entrySet() {
     return innerMap.entrySet();
   }
 }

--- a/mist-core/src/main/java/edu/snu/mist/core/master/allocation/AbstractQueryAllocationManager.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/allocation/AbstractQueryAllocationManager.java
@@ -16,7 +16,6 @@
 package edu.snu.mist.core.master.allocation;
 
 import edu.snu.mist.core.master.TaskInfo;
-import edu.snu.mist.formats.avro.IPAddress;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -29,19 +28,19 @@ public abstract class AbstractQueryAllocationManager implements QueryAllocationM
   /**
    * The map which contains task info for each task.
    */
-  protected final ConcurrentMap<IPAddress, TaskInfo> taskInfoMap;
+  protected final ConcurrentMap<String, TaskInfo> taskInfoMap;
 
   protected AbstractQueryAllocationManager() {
     this.taskInfoMap = new ConcurrentHashMap<>();
   }
 
   @Override
-  public TaskInfo getTaskInfo(final IPAddress taskAddress) {
+  public TaskInfo getTaskInfo(final String taskAddress) {
     return taskInfoMap.get(taskAddress);
   }
 
   @Override
-  public TaskInfo addTaskInfo(final IPAddress taskAddress, final TaskInfo taskInfo) {
+  public TaskInfo addTaskInfo(final String taskAddress, final TaskInfo taskInfo) {
     return taskInfoMap.putIfAbsent(taskAddress, taskInfo);
   }
 }

--- a/mist-core/src/main/java/edu/snu/mist/core/master/allocation/QueryAllocationManager.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/allocation/QueryAllocationManager.java
@@ -36,12 +36,12 @@ public interface QueryAllocationManager {
    * @param taskInfo
    * @return
    */
-  TaskInfo addTaskInfo(final IPAddress taskAddress, final TaskInfo taskInfo);
+  TaskInfo addTaskInfo(final String taskAddress, final TaskInfo taskInfo);
 
   /**
    * Returns task info for the given address.
    * @param taskAddress
    * @return
    */
-  TaskInfo getTaskInfo(final IPAddress taskAddress);
+  TaskInfo getTaskInfo(final String taskAddress);
 }

--- a/mist-core/src/main/java/edu/snu/mist/core/parameters/MasterHostname.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/parameters/MasterHostname.java
@@ -21,6 +21,6 @@ import org.apache.reef.tang.annotations.NamedParameter;
 /**
  * The Mist master host address.
  */
-@NamedParameter(doc = "The mist master host address")
-public class MasterHostAddress implements Name<String> {
+@NamedParameter(doc = "The mist master host name")
+public class MasterHostname implements Name<String> {
 }

--- a/mist-core/src/main/java/edu/snu/mist/core/parameters/TaskHostname.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/parameters/TaskHostname.java
@@ -21,6 +21,6 @@ import org.apache.reef.tang.annotations.NamedParameter;
 /**
  * The host address of mist task.
  */
-@NamedParameter(doc = "The host address of mist task.", default_value = "127.0.0.1")
-public class TaskHostAddress implements Name<String> {
+@NamedParameter(doc = "The host name of mist task.", default_value = "127.0.0.1")
+public class TaskHostname implements Name<String> {
 }

--- a/mist-core/src/main/java/edu/snu/mist/core/shared/MQTTSharedResource.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/shared/MQTTSharedResource.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.mist.core.shared;
 
-import edu.snu.mist.core.parameters.TaskHostAddress;
+import edu.snu.mist.core.parameters.TaskHostname;
 import edu.snu.mist.core.shared.parameters.*;
 import edu.snu.mist.core.sources.MQTTDataGenerator;
 import edu.snu.mist.core.sources.MQTTSubscribeClient;
@@ -128,7 +128,7 @@ public final class MQTTSharedResource implements MQTTResource {
       @Parameter(MaxInflightMqttEventNum.class) final int maxInflightMqttEventNumParam,
       @Parameter(MqttSourceKeepAliveSec.class) final int mqttSourceKeepAliveSec,
       @Parameter(MqttSinkKeepAliveSec.class) final int mqttSinkKeepAliveSec,
-      @Parameter(TaskHostAddress.class) final String taskHostname) {
+      @Parameter(TaskHostname.class) final String taskHostname) {
     this.brokerSubscriberMap = new HashMap<>();
     this.subscriberSourceNumMap = new HashMap<>();
     this.brokerPublisherMap = new HashMap<>();

--- a/mist-core/src/main/java/edu/snu/mist/core/task/MistTask.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/MistTask.java
@@ -16,7 +16,7 @@
 package edu.snu.mist.core.task;
 
 import edu.snu.mist.core.parameters.ClientToTaskPort;
-import edu.snu.mist.core.parameters.MasterHostAddress;
+import edu.snu.mist.core.parameters.MasterHostname;
 import edu.snu.mist.core.parameters.MasterToTaskPort;
 import edu.snu.mist.core.parameters.TaskToMasterPort;
 import edu.snu.mist.core.rpc.AvroUtils;
@@ -81,7 +81,7 @@ public final class MistTask implements Task {
                    final CheckpointManager checkpointManager,
                    @Parameter(MasterToTaskPort.class) final int masterToTaskPort,
                    @Parameter(ClientToTaskPort.class) final int clientToTaskPort,
-                   @Parameter(MasterHostAddress.class) final String masterHostAddress,
+                   @Parameter(MasterHostname.class) final String masterHostAddress,
                    @Parameter(TaskToMasterPort.class) final int taskToMasterPort,
                    final MasterToTaskMessage masterToTaskMessage,
                    final ClientToTaskMessage clientToTaskMessage) throws InjectionException, IOException {

--- a/mist-core/src/test/java/edu/snu/mist/core/master/QueryAllocationManagerTest.java
+++ b/mist-core/src/test/java/edu/snu/mist/core/master/QueryAllocationManagerTest.java
@@ -18,7 +18,6 @@ package edu.snu.mist.core.master;
 import edu.snu.mist.core.master.allocation.ApplicationAwareQueryAllocationManager;
 import edu.snu.mist.core.master.allocation.QueryAllocationManager;
 import edu.snu.mist.core.parameters.OverloadedTaskThreshold;
-import edu.snu.mist.formats.avro.IPAddress;
 import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.InjectionException;
@@ -35,8 +34,8 @@ public final class QueryAllocationManagerTest {
     final Injector injector = Tang.Factory.getTang().newInjector();
     final QueryAllocationManager manager = injector.getInstance(ApplicationAwareQueryAllocationManager.class);
     final double overloadedTaskThreshold = injector.getNamedInstance(OverloadedTaskThreshold.class);
-    final IPAddress task1 = new IPAddress("task1", 8888);
-    final IPAddress task2 = new IPAddress("task2", 8888);
+    final String task1 = "task1";
+    final String task2 = "task2";
     final TaskInfo task1Info = new TaskInfo();
     final TaskInfo task2Info = new TaskInfo();
 
@@ -45,14 +44,14 @@ public final class QueryAllocationManagerTest {
     task2Info.setCpuLoad(0.5);
     final String appId = "app_1";
     // task1 load = 0.0, task2 load = 0.5. task1 should be selected.
-    Assert.assertEquals(task1, manager.getAllocatedTask(appId));
+    Assert.assertEquals(task1, manager.getAllocatedTask(appId).getHostAddress());
 
     task1Info.setCpuLoad(0.7);
     // app_1 is already allocated to task1 and task1 is not overloaded. So, task1 should be selected.
-    Assert.assertEquals(task1, manager.getAllocatedTask(appId));
+    Assert.assertEquals(task1, manager.getAllocatedTask(appId).getHostAddress());
 
     task1Info.setCpuLoad(overloadedTaskThreshold + 0.01);
     // task1 is overloaded now. task2 should be selected.
-    Assert.assertEquals(task2, manager.getAllocatedTask(appId));
+    Assert.assertEquals(task2, manager.getAllocatedTask(appId).getHostAddress());
   }
 }


### PR DESCRIPTION
This PR resolves #1052 via

* Use String hostname for identifying MistTask instead of IPAddress