### PR TITLE
[MIST-1060] Fix bug on setting up Master-To-Task Proxy

### DIFF
--- a/mist-core/src/main/java/edu/snu/mist/core/master/TaskStatsMap.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/TaskStatsMap.java
@@ -25,11 +25,15 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * The shared map which contains information about MistTask stats.
  */
 public final class TaskStatsMap {
+
+  private static final Logger LOG = Logger.getLogger(TaskStatsMap.class.getName());
 
   /**
    * The map which contains task info for each task.
@@ -65,6 +69,8 @@ public final class TaskStatsMap {
   }
 
   public void updateTaskStats(final String taskHostname, final TaskStats updatedTaskStats) {
+    LOG.log(Level.INFO, "Updated task stats: Task {0}, Load {1}",
+        new Object[]{taskHostname, updatedTaskStats.getTaskLoad()});
     innerMap.replace(taskHostname, updatedTaskStats);
   }
 

--- a/mist-core/src/main/java/edu/snu/mist/core/rpc/DefaultDriverToMasterMessageImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/rpc/DefaultDriverToMasterMessageImpl.java
@@ -19,7 +19,7 @@ import edu.snu.mist.core.master.ProxyToTaskMap;
 import edu.snu.mist.core.master.TaskStatsMap;
 import edu.snu.mist.core.master.TaskStatsUpdater;
 import edu.snu.mist.core.master.allocation.QueryAllocationManager;
-import edu.snu.mist.core.parameters.ClientToTaskPort;
+import edu.snu.mist.core.parameters.MasterToTaskPort;
 import edu.snu.mist.core.parameters.TaskInfoGatherPeriod;
 import edu.snu.mist.formats.avro.DriverToMasterMessage;
 import edu.snu.mist.formats.avro.IPAddress;
@@ -78,7 +78,7 @@ public final class DefaultDriverToMasterMessageImpl implements DriverToMasterMes
                                            final ProxyToTaskMap proxyToTaskMap,
                                            final TaskStatsMap taskStatsMap,
                                            @Parameter(TaskInfoGatherPeriod.class) final long taskInfoGatherTerm,
-                                           @Parameter(ClientToTaskPort.class) final int masterToTaskPort) {
+                                           @Parameter(MasterToTaskPort.class) final int masterToTaskPort) {
     this.queryAllocationManager = queryAllocationManager;
     this.proxyToTaskMap = proxyToTaskMap;
     this.taskStatsMap = taskStatsMap;


### PR DESCRIPTION
This PR closes #1060 via
* Use the correct `NamedParameter` on `MasterToTaskMessage` port number
* Add logging on task load update