### PR TITLE
[MIST-1062] Fix the problem of not updating task loads

### DIFF
--- a/mist-core/src/main/java/edu/snu/mist/core/rpc/DefaultMasterToTaskMessageImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/rpc/DefaultMasterToTaskMessageImpl.java
@@ -60,6 +60,7 @@ public final class DefaultMasterToTaskMessageImpl implements MasterToTaskMessage
           group.getGroupId(),
           GroupStats.newBuilder()
               .setGroupLoad(group.getLoad())
+              .setGroupId(group.getGroupId())
               .setAppId(group.getApplicationInfo().getApplicationId())
               .setGroupQueryNum(group.getQueries().size())
               .build());


### PR DESCRIPTION
This PR resolves #1062 via
* Setting missing `groupId` when sending `GroupStats`.