### PR TITLE
[MIST-1051] Fix returning null Task

### DIFF
--- a/mist-client/src/main/java/edu/snu/mist/client/MISTDefaultExecutionEnvironmentImpl.java
+++ b/mist-client/src/main/java/edu/snu/mist/client/MISTDefaultExecutionEnvironmentImpl.java
@@ -53,6 +53,9 @@ public final class MISTDefaultExecutionEnvironmentImpl implements MISTExecutionE
    */
   private final Map<String, Tuple<NettyTransceiver, ClientToTaskMessage>> taskConnectionMap;
 
+  /**
+   * Checks whether master is ready or not.
+   */
   private final AtomicBoolean isMasterReady;
 
   /**

--- a/mist-client/src/main/java/edu/snu/mist/client/MISTDefaultExecutionEnvironmentImpl.java
+++ b/mist-client/src/main/java/edu/snu/mist/client/MISTDefaultExecutionEnvironmentImpl.java
@@ -78,7 +78,7 @@ public final class MISTDefaultExecutionEnvironmentImpl implements MISTExecutionE
   @Override
   public APIQueryControlResult submitQuery(final MISTQuery queryToSubmit) throws IOException {
 
-    // Ready master
+    // Wait until the master is ready
     while (!isMasterReady.get()) {
       isMasterReady.set(proxyToMaster.isReady());
       try {

--- a/mist-client/src/main/java/edu/snu/mist/client/MISTExecutionEnvironment.java
+++ b/mist-client/src/main/java/edu/snu/mist/client/MISTExecutionEnvironment.java
@@ -16,7 +16,6 @@
 package edu.snu.mist.client;
 
 import edu.snu.mist.formats.avro.JarUploadResult;
-import org.apache.avro.AvroRemoteException;
 
 import java.io.IOException;
 import java.util.List;
@@ -32,7 +31,7 @@ public interface MISTExecutionEnvironment extends AutoCloseable {
    * @return the result of the query submission.
    * @throws IOException an exception occurs when connecting with MIST and serializing the jar files.
    */
-  APIQueryControlResult submitQuery(MISTQuery queryToSubmit)  throws AvroRemoteException, IOException;
+  APIQueryControlResult submitQuery(MISTQuery queryToSubmit)  throws IOException;
 
   /**
    * Submit jar files for the application.

--- a/mist-client/src/test/java/edu/snu/mist/client/utils/MockMasterServer.java
+++ b/mist-client/src/test/java/edu/snu/mist/client/utils/MockMasterServer.java
@@ -39,6 +39,11 @@ public class MockMasterServer implements ClientToMasterMessage {
   }
 
   @Override
+  public boolean isReady() throws AvroRemoteException {
+    return true;
+  }
+
+  @Override
   public JarUploadResult uploadJarFiles(final List<ByteBuffer> jarFiles) {
     return JarUploadResult.newBuilder()
         .setIsSuccess(true)

--- a/mist-common/src/main/avro/client_to_master_msg.avpr
+++ b/mist-common/src/main/avro/client_to_master_msg.avpr
@@ -99,6 +99,11 @@
   ],
   "messages":
   {
+    "isReady": /* Check whether MistMaster is ready to receive query submission */
+    {
+      "request": [],
+      "response": "boolean"
+    },
     "uploadJarFiles":
     {
       "request":

--- a/mist-core/src/main/java/edu/snu/mist/core/master/MasterSetupFinished.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/MasterSetupFinished.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.core.master;
+
+import javax.inject.Inject;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A class that represents whether mist master is ready to receive query submission or not.
+ */
+public final class MasterSetupFinished {
+
+  private final AtomicBoolean ready;
+
+  @Inject
+  private MasterSetupFinished() {
+    this.ready = new AtomicBoolean(false);
+  }
+
+  public void setFinished() {
+    ready.set(true);
+  }
+
+  public boolean isFinished() {
+    return ready.get();
+  }
+}

--- a/mist-core/src/main/java/edu/snu/mist/core/rpc/DefaultClientToMasterMessageImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/rpc/DefaultClientToMasterMessageImpl.java
@@ -16,6 +16,7 @@
 package edu.snu.mist.core.rpc;
 
 import edu.snu.mist.core.master.ApplicationCodeManager;
+import edu.snu.mist.core.master.MasterSetupFinished;
 import edu.snu.mist.core.master.allocation.QueryAllocationManager;
 import edu.snu.mist.formats.avro.ClientToMasterMessage;
 import edu.snu.mist.formats.avro.JarUploadResult;
@@ -44,13 +45,23 @@ public final class DefaultClientToMasterMessageImpl implements ClientToMasterMes
    */
   private final ApplicationCodeManager appCodeManager;
 
-
+  /**
+   * A variable that represents master setup is finished or not.
+   */
+  private final MasterSetupFinished masterSetupFinished;
 
   @Inject
   private DefaultClientToMasterMessageImpl(final QueryAllocationManager queryAllocationManager,
-                                           final ApplicationCodeManager appCodeManager) {
+                                           final ApplicationCodeManager appCodeManager,
+                                           final MasterSetupFinished masterSetupFinished) {
     this.queryAllocationManager = queryAllocationManager;
     this.appCodeManager = appCodeManager;
+    this.masterSetupFinished = masterSetupFinished;
+  }
+
+  @Override
+  public boolean isReady() throws AvroRemoteException {
+    return masterSetupFinished.isFinished();
   }
 
   @Override

--- a/mist-core/src/main/java/edu/snu/mist/core/rpc/DefaultDriverToMasterMessageImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/rpc/DefaultDriverToMasterMessageImpl.java
@@ -15,6 +15,7 @@
  */
 package edu.snu.mist.core.rpc;
 
+import edu.snu.mist.core.master.MasterSetupFinished;
 import edu.snu.mist.core.master.ProxyToTaskMap;
 import edu.snu.mist.core.master.TaskStatsMap;
 import edu.snu.mist.core.master.TaskStatsUpdater;
@@ -73,18 +74,25 @@ public final class DefaultDriverToMasterMessageImpl implements DriverToMasterMes
    */
   private final TaskStatsMap taskStatsMap;
 
+  /**
+   * A variable that represents master setup is finished or not.
+   */
+  private final MasterSetupFinished masterSetupFinished;
+
   @Inject
   private DefaultDriverToMasterMessageImpl(final QueryAllocationManager queryAllocationManager,
                                            final ProxyToTaskMap proxyToTaskMap,
                                            final TaskStatsMap taskStatsMap,
                                            @Parameter(TaskInfoGatherPeriod.class) final long taskInfoGatherTerm,
-                                           @Parameter(MasterToTaskPort.class) final int masterToTaskPort) {
+                                           @Parameter(MasterToTaskPort.class) final int masterToTaskPort,
+                                           final MasterSetupFinished masterSetupFinished) {
     this.queryAllocationManager = queryAllocationManager;
     this.proxyToTaskMap = proxyToTaskMap;
     this.taskStatsMap = taskStatsMap;
     this.taskInfoGatherTerm = taskInfoGatherTerm;
     this.taskInfoGatherer = Executors.newSingleThreadScheduledExecutor();
     this.masterToTaskPort = masterToTaskPort;
+    this.masterSetupFinished = masterSetupFinished;
   }
 
   @Override
@@ -114,6 +122,7 @@ public final class DefaultDriverToMasterMessageImpl implements DriverToMasterMes
         0,
         taskInfoGatherTerm,
         TimeUnit.MILLISECONDS);
+    masterSetupFinished.setFinished();
     return null;
   }
 


### PR DESCRIPTION
This PR resolves #1051 
* by creating `isReady` method in Mist client and waiting until MistMaster is ready to receive query submission

