### PR TITLE
[MIST-1074] Remove checkpointing turned off log message

### DIFF
--- a/mist-core/src/main/java/edu/snu/mist/core/sources/EventGeneratorImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/sources/EventGeneratorImpl.java
@@ -125,8 +125,6 @@ public abstract class EventGeneratorImpl<I, V> implements EventGenerator<I> {
           outputEmitter.emitCheckpoint(new MistCheckpointEvent());
         }
       }, checkpointPeriod, checkpointPeriod, timeUnit);
-    } else {
-      LOG.log(Level.INFO, "checkpointing is not turned on");
     }
   }
 

--- a/mist-core/src/main/java/edu/snu/mist/core/task/checkpointing/DefaultCheckpointManagerImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/checkpointing/DefaultCheckpointManagerImpl.java
@@ -18,6 +18,7 @@ package edu.snu.mist.core.task.checkpointing;
 import edu.snu.mist.common.graph.AdjacentListDAG;
 import edu.snu.mist.common.graph.DAG;
 import edu.snu.mist.common.graph.MISTEdge;
+import edu.snu.mist.core.sources.parameters.PeriodicCheckpointPeriod;
 import edu.snu.mist.core.task.ConfigVertex;
 import edu.snu.mist.core.task.ExecutionVertex;
 import edu.snu.mist.core.task.QueryManager;
@@ -25,6 +26,7 @@ import edu.snu.mist.core.task.groupaware.*;
 import edu.snu.mist.core.task.stores.GroupCheckpointStore;
 import edu.snu.mist.formats.avro.*;
 import org.apache.reef.io.Tuple;
+import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
 import java.io.FileNotFoundException;
@@ -63,17 +65,27 @@ public final class DefaultCheckpointManagerImpl implements CheckpointManager {
    */
   private final QueryManager queryManager;
 
+  /**
+   * The checkpoint period.
+   */
+  private final long checkpointPeriod;
+
   @Inject
   private DefaultCheckpointManagerImpl(final ApplicationMap applicationMap,
                                        final GroupMap groupMap,
                                        final GroupCheckpointStore groupCheckpointStore,
                                        final GroupAllocationTableModifier groupAllocationTableModifier,
-                                       final QueryManager queryManager) {
+                                       final QueryManager queryManager,
+                                       @Parameter(PeriodicCheckpointPeriod.class) final long checkpointPeriod) {
     this.applicationMap = applicationMap;
     this.groupMap = groupMap;
     this.checkpointStore = groupCheckpointStore;
     this.groupAllocationTableModifier = groupAllocationTableModifier;
     this.queryManager = queryManager;
+    this.checkpointPeriod = checkpointPeriod;
+    if (checkpointPeriod == 0) {
+      LOG.log(Level.INFO, "checkpointing is not turned on");
+    }
   }
 
   @Override

--- a/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/GroupAwareQueryManagerImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/GroupAwareQueryManagerImpl.java
@@ -140,6 +140,9 @@ public final class GroupAwareQueryManagerImpl implements QueryManager {
     this.applicationMap = applicationMap;
     this.groupMap = groupMap;
     this.checkpointPeriod = checkpointPeriod;
+    if (checkpointPeriod == 0) {
+      LOG.log(Level.INFO, "checkpointing is not turned on");
+    }
   }
 
   /**

--- a/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/GroupAwareQueryManagerImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/GroupAwareQueryManagerImpl.java
@@ -140,9 +140,6 @@ public final class GroupAwareQueryManagerImpl implements QueryManager {
     this.applicationMap = applicationMap;
     this.groupMap = groupMap;
     this.checkpointPeriod = checkpointPeriod;
-    if (checkpointPeriod == 0) {
-      LOG.log(Level.INFO, "checkpointing is not turned on");
-    }
   }
 
   /**


### PR DESCRIPTION
This PR resolves #1074.

The logging message appears only when the `GroupAwareQueryManager` is initialized.

Closes #1074.