### PR TITLE
[MIST-1104] Decouple initial Group creation from Application creation

### DIFF
--- a/mist-core/src/main/java/edu/snu/mist/core/task/QueryManager.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/QueryManager.java
@@ -18,6 +18,7 @@ package edu.snu.mist.core.task;
 import edu.snu.mist.common.graph.DAG;
 import edu.snu.mist.common.graph.MISTEdge;
 import edu.snu.mist.core.task.groupaware.ApplicationInfo;
+import edu.snu.mist.core.task.groupaware.Group;
 import edu.snu.mist.core.task.groupaware.GroupAwareQueryManagerImpl;
 import edu.snu.mist.formats.avro.AvroDag;
 import edu.snu.mist.formats.avro.QueryCheckpoint;
@@ -67,6 +68,12 @@ public interface QueryManager extends AutoCloseable {
    */
   ApplicationInfo createApplication(String appId,
                                     List<String> jarFilePath) throws InjectionException;
+
+  /**
+   * Create a new group for the given application.
+   * @return
+   */
+  Group createGroup(ApplicationInfo applicationInfo) throws InjectionException;
 
   /**
    * Deletes the query corresponding to the queryId submitted by client.

--- a/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/ApplicationInfo.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/ApplicationInfo.java
@@ -67,17 +67,17 @@ public interface ApplicationInfo {
   List<String> getJarFilePath();
 
   /**
-   * Get the query starter for this group.
+   * Get the query starter for this application.
    */
   QueryStarter getQueryStarter();
 
   /**
-   * Get the query remover for this group.
+   * Get the query remover for this application.
    */
   QueryRemover getQueryRemover();
 
   /**
-   * Get the execution dags for this group.
+   * Get the execution dags for this application.
    */
   ExecutionDags getExecutionDags();
 

--- a/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/ApplicationInfo.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/ApplicationInfo.java
@@ -15,8 +15,11 @@
  */
 package edu.snu.mist.core.task.groupaware;
 
+import edu.snu.mist.core.task.ExecutionDags;
 import edu.snu.mist.core.task.QueryRemover;
 import edu.snu.mist.core.task.QueryStarter;
+import edu.snu.mist.core.task.merging.ConfigExecutionVertexMap;
+import edu.snu.mist.core.task.merging.QueryIdConfigDagMap;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 import java.util.List;
@@ -72,4 +75,19 @@ public interface ApplicationInfo {
    * Get the query remover for this group.
    */
   QueryRemover getQueryRemover();
+
+  /**
+   * Get the execution dags for this group.
+   */
+  ExecutionDags getExecutionDags();
+
+  /**
+   * Get the map for query Ids and ConfigDags.
+   */
+  QueryIdConfigDagMap getQueryIdConfigDagMap();
+
+  /**
+   * Get the map for Config Vertices and their corresponding Execution Vertices.
+   */
+  ConfigExecutionVertexMap getConfigExecutionVertexMap();
 }

--- a/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/DefaultApplicationInfoImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/DefaultApplicationInfoImpl.java
@@ -15,10 +15,13 @@
  */
 package edu.snu.mist.core.task.groupaware;
 
+import edu.snu.mist.core.task.ExecutionDags;
 import edu.snu.mist.core.task.QueryRemover;
 import edu.snu.mist.core.task.QueryStarter;
 import edu.snu.mist.core.task.groupaware.parameters.ApplicationIdentifier;
 import edu.snu.mist.core.task.groupaware.parameters.JarFilePath;
+import edu.snu.mist.core.task.merging.ConfigExecutionVertexMap;
+import edu.snu.mist.core.task.merging.QueryIdConfigDagMap;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
@@ -48,6 +51,11 @@ public final class DefaultApplicationInfoImpl implements ApplicationInfo {
   private final String appId;
 
   /**
+   * The execution dags for this application.
+   */
+  private final ExecutionDags executionDags;
+
+  /**
    * A query starter.
    */
   private final QueryStarter queryStarter;
@@ -57,16 +65,32 @@ public final class DefaultApplicationInfoImpl implements ApplicationInfo {
    */
   private final QueryRemover queryRemover;
 
+  /**
+   * The map for query Ids and ConfigDags.
+   */
+  private final QueryIdConfigDagMap queryIdConfigDagMap;
+
+  /**
+   * The map for Config Vertices and their corresponding Execution Vertices.
+   */
+  private final ConfigExecutionVertexMap configExecutionVertexMap;
+
   @Inject
   private DefaultApplicationInfoImpl(@Parameter(ApplicationIdentifier.class) final String appId,
                                      @Parameter(JarFilePath.class) final String jarFilePath,
+                                     final ExecutionDags executionDags,
                                      final QueryStarter queryStarter,
-                                     final QueryRemover queryRemover) {
+                                     final QueryRemover queryRemover,
+                                     final QueryIdConfigDagMap queryIdConfigDagMap,
+                                     final ConfigExecutionVertexMap configExecutionVertexMap) {
     this.groups = new LinkedList<>();
     this.jarFilePath = Arrays.asList(jarFilePath);
     this.appId = appId;
+    this.executionDags = executionDags;
     this.queryStarter = queryStarter;
     this.queryRemover = queryRemover;
+    this.queryIdConfigDagMap = queryIdConfigDagMap;
+    this.configExecutionVertexMap = configExecutionVertexMap;
   }
 
   @Override
@@ -103,6 +127,11 @@ public final class DefaultApplicationInfoImpl implements ApplicationInfo {
   }
 
   @Override
+  public ExecutionDags getExecutionDags() {
+    return executionDags;
+  }
+
+  @Override
   public QueryStarter getQueryStarter() {
     return queryStarter;
   }
@@ -110,5 +139,15 @@ public final class DefaultApplicationInfoImpl implements ApplicationInfo {
   @Override
   public QueryRemover getQueryRemover() {
     return queryRemover;
+  }
+
+  @Override
+  public QueryIdConfigDagMap getQueryIdConfigDagMap() {
+    return queryIdConfigDagMap;
+  }
+
+  @Override
+  public ConfigExecutionVertexMap getConfigExecutionVertexMap() {
+    return configExecutionVertexMap;
   }
 }

--- a/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/DefaultGroupImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/DefaultGroupImpl.java
@@ -175,8 +175,8 @@ final class DefaultGroupImpl implements Group {
   }
 
   @Override
-  public void setApplicationInfo(final ApplicationInfo mGroup) {
-    applicationInfo = mGroup;
+  public void setApplicationInfo(final ApplicationInfo applicationInfo) {
+    this.applicationInfo = applicationInfo;
   }
 
   @Override

--- a/mist-core/src/test/java/edu/snu/mist/core/task/checkpointing/GroupRecoveryTest.java
+++ b/mist-core/src/test/java/edu/snu/mist/core/task/checkpointing/GroupRecoveryTest.java
@@ -33,6 +33,7 @@ import edu.snu.mist.core.parameters.TaskHostname;
 import edu.snu.mist.core.sinks.Sink;
 import edu.snu.mist.core.sources.parameters.PeriodicCheckpointPeriod;
 import edu.snu.mist.core.task.*;
+import edu.snu.mist.core.task.groupaware.ApplicationInfo;
 import edu.snu.mist.core.task.groupaware.GroupAwareQueryManagerImpl;
 import edu.snu.mist.core.task.groupaware.GroupIdRequestor;
 import edu.snu.mist.core.task.groupaware.TaskStatsUpdater;
@@ -154,7 +155,8 @@ public class GroupRecoveryTest {
     final CheckpointManager checkpointManager = injector.getInstance(CheckpointManager.class);
     final QueryManager queryManager = injector.getInstance(QueryManager.class);
 
-    queryManager.createApplication(appId, Arrays.asList(""));
+    final ApplicationInfo appInfo = queryManager.createApplication(appId, Arrays.asList(""));
+    queryManager.createGroup(appInfo);
     queryManager.create(avroDag);
 
     // Wait until all sources connect to stream generator
@@ -162,7 +164,6 @@ public class GroupRecoveryTest {
 
     final ExecutionDags executionDags = checkpointManager.getApplication(appId).getGroups().get(0).getExecutionDags();
     Assert.assertEquals(executionDags.values().size(), 1);
-    final ExecutionDag executionDag = executionDags.values().iterator().next();
 
     // 1st stage. Push inputs to all sources and see if the results are proper.
     SRC0INPUT1.forEach(textMessageStreamGenerator1::write);


### PR DESCRIPTION
This PR resolves #1104 by : 
- creating a `createGroup()` method in `QueryManager` interface
- also binds necessary instances (that belong to `ApplicationInfo` level) to the group (`ExecutionDags`, `QueryIdConfigDagMap`, `ConfigExecutionVertexMap`)

Closes #1104