### PR TITLE
 [MIST-1103] CheckpointManager DeleteGroup deletes all groups

### DIFF
--- a/mist-core/src/main/java/edu/snu/mist/core/task/checkpointing/DefaultCheckpointManagerImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/checkpointing/DefaultCheckpointManagerImpl.java
@@ -158,7 +158,7 @@ public final class DefaultCheckpointManagerImpl implements CheckpointManager {
     }
     applicationMap.remove(groupId);
     groupAllocationTableModifier.addEvent(
-        new WritingEvent(WritingEvent.EventType.GROUP_REMOVE_ALL, null));
+        new WritingEvent(WritingEvent.EventType.GROUP_REMOVE, group));
   }
 
   @Override

--- a/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/ApplicationInfo.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/ApplicationInfo.java
@@ -50,6 +50,12 @@ public interface ApplicationInfo {
   boolean addGroup(Group group);
 
   /**
+   * Remove a group.
+   * @param group group
+   */
+  void removeGroup(Group group);
+
+  /**
    * The number of groups.
    */
   AtomicInteger numGroups();

--- a/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/ApplicationInfo.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/ApplicationInfo.java
@@ -45,12 +45,14 @@ public interface ApplicationInfo {
 
   /**
    * Add a group.
+   * This method must be called by SingleWriterThread of GroupAllocationTableModifier.
    * @param group group
    */
   boolean addGroup(Group group);
 
   /**
    * Remove a group.
+   * This method must be called by SingleWriterThread of GroupAllocationTableModifier.
    * @param group group
    */
   void removeGroup(Group group);

--- a/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/DefaultApplicationInfoImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/DefaultApplicationInfoImpl.java
@@ -112,6 +112,12 @@ public final class DefaultApplicationInfoImpl implements ApplicationInfo {
   }
 
   @Override
+  public void removeGroup(final Group group) {
+    groups.remove(group);
+    numGroups.decrementAndGet();
+  }
+
+  @Override
   public AtomicInteger numGroups() {
     return numGroups;
   }

--- a/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/GroupAllocationTableModifierImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/GroupAllocationTableModifierImpl.java
@@ -188,8 +188,10 @@ public final class GroupAllocationTableModifierImpl implements GroupAllocationTa
             }
             case GROUP_REMOVE: {
               final Group group = (Group) event.getValue();
-              removeGroupInWriterThread(group);
+              final ApplicationInfo applicationInfo = group.getApplicationInfo();
               groupMap.remove(group.getGroupId());
+              applicationInfo.removeGroup(group);
+              removeGroupInWriterThread(group);
               break;
             }
             case GROUP_REMOVE_ALL: {

--- a/mist-core/src/main/java/edu/snu/mist/core/task/merging/MergeAwareQueryRemover.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/merging/MergeAwareQueryRemover.java
@@ -88,7 +88,6 @@ public final class MergeAwareQueryRemover implements QueryRemover {
     // TODO:[MIST-590] We need to improve this code for concurrent modification
     synchronized (srcAndDagMap) {
       // Delete the query plan from queryIdConfigDagMap
-      System.out.println(queryIdConfigDagMap.getKeys().size());
       final DAG<ConfigVertex, MISTEdge> configDag = queryIdConfigDagMap.remove(queryId);
       // Delete vertices
       final Collection<ConfigVertex> vertices = configDag.getVertices();

--- a/mist-core/src/main/java/edu/snu/mist/core/task/merging/MergeAwareQueryRemover.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/merging/MergeAwareQueryRemover.java
@@ -88,6 +88,7 @@ public final class MergeAwareQueryRemover implements QueryRemover {
     // TODO:[MIST-590] We need to improve this code for concurrent modification
     synchronized (srcAndDagMap) {
       // Delete the query plan from queryIdConfigDagMap
+      System.out.println(queryIdConfigDagMap.getKeys().size());
       final DAG<ConfigVertex, MISTEdge> configDag = queryIdConfigDagMap.remove(queryId);
       // Delete vertices
       final Collection<ConfigVertex> vertices = configDag.getVertices();


### PR DESCRIPTION
This PR resolves #1103 by
- adding a `removeGroup()` method to the `ApplicationInfo` interface, which does the opposite of the `addGroup()` method
- removing the `Group` from the `ApplicationInfo` in the `GROUP_REMOVE` case in `GroupAllocationTableModifierImpl`

Closes #1103