### PR TITLE
[MIST-1112] Fix possible null exception in Group Checkpointing

### DIFF
--- a/mist-core/src/main/java/edu/snu/mist/core/operators/OneStreamStateHandlerOperator.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/operators/OneStreamStateHandlerOperator.java
@@ -68,7 +68,7 @@ public abstract class OneStreamStateHandlerOperator extends OneStreamOperator im
   }
 
   @Override
-  public long getMaxAvailableTimestamp(final long checkpointTimestamp) {
+  public Long getMaxAvailableTimestamp(final long checkpointTimestamp) {
     if (checkpointMap.containsKey(checkpointTimestamp)) {
       return checkpointTimestamp;
     } else {

--- a/mist-core/src/main/java/edu/snu/mist/core/operators/StateHandler.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/operators/StateHandler.java
@@ -36,7 +36,7 @@ public interface StateHandler {
    * Get the state timestamp that is the maximum state timestamp among the state timestamps
    * less than or equal to the given checkpointTimestamp.
    */
-  long getMaxAvailableTimestamp(long checkpointTimestamp);
+  Long getMaxAvailableTimestamp(long checkpointTimestamp);
 
   /**
    * Remove the states with timestamps less than or equal to the given timestamp.

--- a/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/DefaultGroupImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/DefaultGroupImpl.java
@@ -375,13 +375,18 @@ final class DefaultGroupImpl implements Group {
     for (final ConfigVertex cv : configDag.getVertices()) {
       final ExecutionVertex ev = configExecutionVertexMap.get(cv);
       Map<String, Object> state = null;
-      long checkpointTimestamp = 0L;
+      Long checkpointTimestamp = 0L;
       if (ev.getType() == ExecutionVertex.Type.OPERATOR) {
         final Operator op = ((DefaultPhysicalOperatorImpl) ev).getOperator();
         if (op instanceof StateHandler) {
           final StateHandler stateHandler = (StateHandler) op;
           checkpointTimestamp = stateHandler.getMaxAvailableTimestamp(groupTimestamp.getValue());
-          state = StateSerializer.serializeStateMap(stateHandler.getOperatorState(checkpointTimestamp));
+          if (checkpointTimestamp == null) {
+            state = new HashMap<>();
+            checkpointTimestamp = 0L;
+          } else {
+            state = StateSerializer.serializeStateMap(stateHandler.getOperatorState(checkpointTimestamp));
+          }
         }
       }
       stateWithTimestampMap.put(cv.getId(), StateWithTimestamp.newBuilder()


### PR DESCRIPTION
This PR resolves #1112.
It puts an empty state if `getMaxAvailableTimestamp` returns null.

Closes #1112