### PR TITLE
[MIST-1126] Improve group splitting and merging

### DIFF
--- a/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/DefaultGroupImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/DefaultGroupImpl.java
@@ -24,13 +24,14 @@ import edu.snu.mist.core.task.*;
 import edu.snu.mist.core.task.groupaware.eventprocessor.EventProcessor;
 import edu.snu.mist.core.task.merging.ConfigExecutionVertexMap;
 import edu.snu.mist.core.task.merging.QueryIdConfigDagMap;
-import edu.snu.mist.formats.avro.*;
+import edu.snu.mist.formats.avro.GroupCheckpoint;
+import edu.snu.mist.formats.avro.QueryCheckpoint;
+import edu.snu.mist.formats.avro.StateWithTimestamp;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -153,10 +154,6 @@ final class DefaultGroupImpl implements Group {
     synchronized (queryList) {
       queryList.remove(query);
     }
-    if (activeQueryQueue.remove(query)) {
-      numActiveSubGroup.decrementAndGet();
-    }
-
   }
 
   @Override
@@ -220,19 +217,19 @@ final class DefaultGroupImpl implements Group {
   }
 
   private long elapsedTime(final long startTime) {
-    return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+    return System.currentTimeMillis() - startTime;
   }
 
   @Override
   public int processAllEvent(final long timeout) {
     int numProcessedEvent = 0;
     Query query = activeQueryQueue.poll();
-    final long startTime = System.nanoTime();
+    final long startTime = System.currentTimeMillis();
 
     while (query != null) {
 
+      numActiveSubGroup.decrementAndGet();
       if (query.setProcessingFromReady()) {
-        numActiveSubGroup.decrementAndGet();
 
         final int processedEvent = query.processAllEvent();
 
@@ -242,8 +239,6 @@ final class DefaultGroupImpl implements Group {
         numProcessedEvent += processedEvent;
 
         query.setReady();
-      } else {
-        activeQueryQueue.add(query);
       }
 
       // Reschedule this group if it still has events to process

--- a/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/GroupAllocationTableModifierImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/GroupAllocationTableModifierImpl.java
@@ -207,17 +207,15 @@ public final class GroupAllocationTableModifierImpl implements GroupAllocationTa
             case REBALANCE:
               loadUpdater.update();
               //isolatedGroupReassigner.reassignIsolatedGroups();
+              //groupMerger.groupMerging();
 
-              // 1. merging first
-              groupMerger.groupMerging();
-
-              // 2. reassignment
+              // 1. reassignment and merging
               groupRebalancer.triggerRebalancing();
 
-              // 3. split groups
+              // 2. split groups
               groupSplitter.splitGroup();
 
-              // 4. update the task stats to master
+              // 3. update the task stats to master
               taskStatsUpdater.updateTaskStatsToMaster(groupAllocationTable);
               break;
             case ISOLATION:

--- a/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/eventprocessor/AffinityEventProcessor.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/eventprocessor/AffinityEventProcessor.java
@@ -47,6 +47,7 @@ public final class AffinityEventProcessor implements EventProcessor {
     this.thread = thread;
     this.id = id;
     this.runnable = runnable;
+    runnable.setEventProcessor(this);
   }
 
   public void close() throws Exception {

--- a/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/eventprocessor/AffinityEventProcessorFactory.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/eventprocessor/AffinityEventProcessorFactory.java
@@ -15,7 +15,9 @@
  */
 package edu.snu.mist.core.task.groupaware.eventprocessor;
 
+import edu.snu.mist.core.task.groupaware.parameters.ProcessingTimeout;
 import net.openhft.affinity.AffinityThreadFactory;
+import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -42,9 +44,15 @@ public final class AffinityEventProcessorFactory implements EventProcessorFactor
    */
   private final AffinityThreadFactory affinityThreadFactory;
 
+  /**
+   * Processing timeout.
+   */
+  private final long timeout;
   @Inject
-  private AffinityEventProcessorFactory(final NextGroupSelectorFactory nextGroupSelectorFactory) {
+  private AffinityEventProcessorFactory(final NextGroupSelectorFactory nextGroupSelectorFactory,
+                                        @Parameter(ProcessingTimeout.class) final long timeout) {
     this.nextGroupSelectorFactory = nextGroupSelectorFactory;
+    this.timeout = timeout;
     this.affinityThreadFactory = new AffinityThreadFactory("Afnty");
     LOG.info("AffinityEventProcessorFactory start");
   }
@@ -52,7 +60,7 @@ public final class AffinityEventProcessorFactory implements EventProcessorFactor
   @Override
   public EventProcessor newEventProcessor() {
     final NextGroupSelector nextGroupSelector = nextGroupSelectorFactory.newInstance();
-    final AffinityRunnable runnable = new AffinityRunnable(nextGroupSelector);
+    final AffinityRunnable runnable = new AffinityRunnable(nextGroupSelector, timeout);
     final Thread thread = affinityThreadFactory.newThread(runnable);
     return new AffinityEventProcessor(id.getAndIncrement(), thread, runnable);
   }

--- a/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/parameters/ProcessingTimeout.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/parameters/ProcessingTimeout.java
@@ -18,6 +18,6 @@ package edu.snu.mist.core.task.groupaware.parameters;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
-@NamedParameter(doc = "The default processing timeout (ms)", short_name = "processing_timeout", default_value = "200")
+@NamedParameter(doc = "The default processing timeout (ms)", short_name = "processing_timeout", default_value = "1000")
 public final class ProcessingTimeout implements Name<Long> {
 }

--- a/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/rebalancer/DefaultGroupRebalancerImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/groupaware/rebalancer/DefaultGroupRebalancerImpl.java
@@ -15,14 +15,15 @@
  */
 package edu.snu.mist.core.task.groupaware.rebalancer;
 
+import edu.snu.mist.core.task.Query;
 import edu.snu.mist.core.task.groupaware.Group;
 import edu.snu.mist.core.task.groupaware.GroupAllocationTable;
+import edu.snu.mist.core.task.groupaware.eventprocessor.EventProcessor;
 import edu.snu.mist.core.task.groupaware.eventprocessor.parameters.GroupRebalancingPeriod;
 import edu.snu.mist.core.task.groupaware.eventprocessor.parameters.OverloadedThreshold;
+import edu.snu.mist.core.task.groupaware.eventprocessor.parameters.UnderloadedThreshold;
 import edu.snu.mist.core.task.groupaware.parameters.DefaultGroupLoad;
 import edu.snu.mist.core.task.groupaware.parameters.GroupPinningTime;
-import edu.snu.mist.core.task.groupaware.eventprocessor.EventProcessor;
-import edu.snu.mist.core.task.groupaware.eventprocessor.parameters.UnderloadedThreshold;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
@@ -120,6 +121,60 @@ public final class DefaultGroupRebalancerImpl implements GroupRebalancer {
     LOG.info(sb.toString());
   }
 
+  private boolean merge(final Group highLoadGroup,
+                        final Collection<Group> highLoadGroups,
+                        final EventProcessor highLoadThread,
+                        final Group lowLoadGroup) {
+    double incLoad = 0.0;
+
+    synchronized (highLoadGroup.getApplicationInfo().getGroups()) {
+      highLoadGroup.getApplicationInfo().getGroups().remove(highLoadGroup);
+      highLoadGroup.getApplicationInfo().numGroups().decrementAndGet();
+    }
+
+    synchronized (highLoadGroup.getQueries()) {
+      for (final Query query : highLoadGroup.getQueries()) {
+        lowLoadGroup.addQuery(query);
+        incLoad += query.getLoad();
+      }
+    }
+
+    // memory barrier
+    synchronized (lowLoadGroup.getQueries()) {
+      highLoadGroups.remove(highLoadGroup);
+      highLoadGroup.setEventProcessor(null);
+    }
+
+    // Update overloaded thread load
+    highLoadThread.setLoad(highLoadThread.getLoad() - incLoad);
+
+    // Update underloaded thread load
+    lowLoadGroup.setLoad(lowLoadGroup.getLoad() + incLoad);
+    lowLoadGroup.getEventProcessor().setLoad(lowLoadGroup.getEventProcessor().getLoad() + incLoad);
+
+    // Add one more
+    lowLoadGroup.getEventProcessor().addActiveGroup(lowLoadGroup);
+
+    LOG.log(Level.INFO, "Merge {0} from {1} to {2}",
+        new Object[]{highLoadGroup, highLoadThread, lowLoadGroup.getEventProcessor()});
+    return true;
+  }
+
+
+  private Group findLowestLoadThreadSplittedGroup(final Group highLoadGroup) {
+    Group g = null;
+    double threadLoad = Double.MAX_VALUE;
+
+    for (final Group hg : highLoadGroup.getApplicationInfo().getGroups()) {
+      if (hg.getEventProcessor().getLoad() < threadLoad) {
+        g = hg;
+        threadLoad = hg.getEventProcessor().getLoad();
+      }
+    }
+
+    return g;
+  }
+
   private void moveGroup(final Group highLoadGroup,
                          final Collection<Group> highLoadGroups,
                          final EventProcessor highLoadThread,
@@ -127,16 +182,12 @@ public final class DefaultGroupRebalancerImpl implements GroupRebalancer {
                          final PriorityQueue<EventProcessor> underloadedThreads) {
     final double groupLoad = highLoadGroup.getLoad();
 
-    highLoadThread.removeActiveGroup(highLoadGroup);
+    //highLoadThread.removeActiveGroup(highLoadGroup);
     final Collection<Group> lowLoadGroups =
         groupAllocationTable.getValue(lowLoadThread);
 
     lowLoadGroups.add(highLoadGroup);
     highLoadGroup.setEventProcessor(lowLoadThread);
-
-    while (highLoadThread.removeActiveGroup(highLoadGroup)) {
-      // remove all elements
-    }
 
     highLoadGroups.remove(highLoadGroup);
 
@@ -225,8 +276,8 @@ public final class DefaultGroupRebalancerImpl implements GroupRebalancer {
                 >= TimeUnit.SECONDS.toMillis(groupPinningTime)) {
               final double groupLoad = highLoadGroup.getLoad();
 
+              // Just rebalance
               if (!highLoadGroup.isSplited()) {
-                // Rebalance!!!
                 if (highLoadThread.getLoad() - groupLoad >= targetLoad) {
                   final EventProcessor peek = underloadedThreads.peek();
                   if (peek.getLoad() + groupLoad <= targetLoad) {
@@ -239,6 +290,24 @@ public final class DefaultGroupRebalancerImpl implements GroupRebalancer {
                     if (rebNum >= TimeUnit.MILLISECONDS.toSeconds(rebalancingPeriod)) {
                       break;
                     }
+                  }
+                }
+              } else {
+                // Merge splitted group
+                // 1. find the thread that has the lowest load among threads that hold the splitted groups
+                final Group lowLoadGroup = findLowestLoadThreadSplittedGroup(highLoadGroup);
+                // 2. Check we can move the high load group to the low load thread group
+                if (lowLoadGroup != null && lowLoadGroup != highLoadGroup &&
+                    highLoadGroup.getEventProcessor().getLoad() - groupLoad >= targetLoad &&
+                    lowLoadGroup.getEventProcessor().getLoad() + groupLoad <= targetLoad) {
+                    // 3. merge!
+                  if (merge(highLoadGroup, highLoadGroups, highLoadThread, lowLoadGroup)) {
+                    rebNum += 1;
+                    highLoadGroups.remove(highLoadGroup);
+                  }
+                  // Prevent lots of groups from being reassigned
+                  if (rebNum >= TimeUnit.MILLISECONDS.toSeconds(rebalancingPeriod)) {
+                    break;
                   }
                 }
               }


### PR DESCRIPTION
This PR resolves #1126 by 
* merging groups in the rebalancing process 
* moving at most half of groups in a group while splitting groups 
* fixing several issues (event processor timeout)