### PR TITLE
[MIST-1132] Add plugin for adding generated sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,24 @@ limitations under the License.
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>target/generated-sources</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This PR resolves #1132 via

* Add build-helper-maven-plugin for adding generated sources.