### PR TITLE
[MIST-1135] Implement HTTP API for using a backup server

### DIFF
--- a/mist-core/pom.xml
+++ b/mist-core/pom.xml
@@ -70,6 +70,13 @@ limitations under the License.
             <scope>test</scope>
         </dependency>
 
+        <!-- JSON -->
+        <dependency>
+            <groupId>com.googlecode.json-simple</groupId>
+            <artifactId>json-simple</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+
         <!-- MQTT -->
         <dependency>
             <groupId>org.eclipse.paho</groupId>

--- a/mist-core/src/main/java/edu/snu/mist/core/replay/EventReplayResult.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/replay/EventReplayResult.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.core.replay;
+
+import org.apache.reef.io.Tuple;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A class that contains the success status and the messages of event replay requests.
+ */
+public final class EventReplayResult {
+
+  private final boolean success;
+
+  private final Map<String, Map<String, List<Tuple<Long, MqttMessage>>>> brokerAndTopicMqttMsgMap;
+
+  public EventReplayResult(final boolean success,
+                           final Map<String, Map<String, List<Tuple<Long, MqttMessage>>>> brokerAndTopicMqttMsgMap) {
+    this.success = success;
+    this.brokerAndTopicMqttMsgMap = brokerAndTopicMqttMsgMap;
+  }
+
+  public boolean isSuccess() {
+    return success;
+  }
+
+  public Map<String, Map<String, List<Tuple<Long, MqttMessage>>>> getBrokerAndTopicMqttMessageMap() {
+    return brokerAndTopicMqttMsgMap;
+  }
+}

--- a/mist-core/src/main/java/edu/snu/mist/core/replay/EventReplayResult.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/replay/EventReplayResult.java
@@ -19,28 +19,31 @@ import org.apache.reef.io.Tuple;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 
 import java.util.List;
-import java.util.Map;
 
 /**
- * A class that contains the success status and the messages of event replay requests.
+ * A class that contains the success status and the messages related to a topic of an event replay request.
  */
 public final class EventReplayResult {
 
   private final boolean success;
 
-  private final Map<String, Map<String, List<Tuple<Long, MqttMessage>>>> brokerAndTopicMqttMsgMap;
+  /**
+   * The returned events for replay.
+   * The tuple is consisted of the timestamp and the MqttMessage.
+   */
+  private final List<Tuple<Long, MqttMessage>> mqttMessages;
 
   public EventReplayResult(final boolean success,
-                           final Map<String, Map<String, List<Tuple<Long, MqttMessage>>>> brokerAndTopicMqttMsgMap) {
+                           final List<Tuple<Long, MqttMessage>> mqttMessages) {
     this.success = success;
-    this.brokerAndTopicMqttMsgMap = brokerAndTopicMqttMsgMap;
+    this.mqttMessages = mqttMessages;
   }
 
   public boolean isSuccess() {
     return success;
   }
 
-  public Map<String, Map<String, List<Tuple<Long, MqttMessage>>>> getBrokerAndTopicMqttMessageMap() {
-    return brokerAndTopicMqttMsgMap;
+  public List<Tuple<Long, MqttMessage>> getMqttMessages() {
+    return mqttMessages;
   }
 }

--- a/mist-core/src/main/java/edu/snu/mist/core/replay/EventReplayUtils.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/replay/EventReplayUtils.java
@@ -244,10 +244,10 @@ public final class EventReplayUtils {
    *        "timestamp": (timestamp)
    *        }'
    */
-  public static boolean removeOnCheckpoint(final String replayAddress, final int replayPort,
+  public static boolean removeOnCheckpoint(final String replayServerAddress, final int replayServerPort,
                                            final String brokerURI, final String topic, final long timestamp) {
     try {
-      final URL url = new URL(getReplayServerUrl(replayAddress, replayPort) + "/checkpoint");
+      final URL url = new URL(getReplayServerUrl(replayServerAddress, replayServerPort) + "/checkpoint");
       final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
       conn.setRequestMethod("POST");
       conn.setRequestProperty("Content-Type", "application/json");

--- a/mist-core/src/main/java/edu/snu/mist/core/replay/EventReplayUtils.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/replay/EventReplayUtils.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.core.replay;
+
+import org.apache.reef.io.Tuple;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * This class is used for replaying events with the replay server.
+ * It sends REST API calls to the replay server.
+ * The server must support these functions accordingly.
+ */
+public final class EventReplayUtils {
+
+  private static final Logger LOG = Logger.getLogger(EventReplayUtils.class.getName());
+
+  private EventReplayUtils() {
+    // empty constructor
+  }
+
+  /**
+   * Sends a POST to make an mqtt connection and subscribe request topic.
+   * This method is the equivalent to :
+   * > curl -X POST http://(replayAddress):(replayPort)/subscribe \
+   *     -H 'Content-Type: application/json' \
+   *     -d '{
+   *        "address": "(address)",
+   *        "port": (port),
+   *        "topic": "(topic)"
+   *        }'
+   * @return true on success, else false
+   */
+  public static boolean subscribe(final String replayAddress, final int replayPort,
+                                  final String address, final int port, final String topic) {
+    try {
+      final URL url = new URL(getReplayServerUrl(replayAddress, replayPort) + "/subscribe");
+      final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+      conn.setRequestMethod("POST");
+      conn.setRequestProperty("Content-Type", "application/json");
+      conn.setDoOutput(true);
+
+      final OutputStreamWriter writer = new OutputStreamWriter(conn.getOutputStream(), "UTF-8");
+      writer.write(getSubscribeRequestBody(address, port, topic));
+      writer.close();
+
+      if (conn.getResponseCode() != 200) {
+        LOG.log(Level.WARNING, "Failed : HTTP error code is {0}. Failure Response message : {1}",
+            new Object[]{conn.getResponseCode(), conn.getResponseMessage()});
+
+        // End the connection.
+        conn.disconnect();
+        return false;
+      }
+
+      // End the connection.
+      conn.disconnect();
+      return true;
+    } catch (Exception e) {
+      e.printStackTrace();
+      return false;
+    }
+  }
+
+  /**
+   * Sends a GET to retrieve data within a timestamp period.
+   * This method is the equivalent to :
+   * > curl -X GET http://(replayAddress):(replayPort)/replay \
+   *     -H 'Content-Type: application/json'
+   */
+  public static EventReplayResult replay(final String replayAddress,
+                                         final int replayPort) {
+    return replay(replayAddress, replayPort, -1, -1);
+  }
+
+  /**
+   * Sends a GET to retrieve data within a timestamp period.
+   * This method is the equivalent to :
+   * > curl -X GET http://(replayAddress):(replayPort)/replay/(startTimestamp) \
+   *     -H 'Content-Type: application/json'
+   */
+  public static EventReplayResult replay(final String replayAddress,
+                                         final int replayPort,
+                                         final long startTimestamp) {
+    return replay(replayAddress, replayPort, startTimestamp, -1);
+  }
+
+  /**
+   * Sends a GET to retrieve data within a timestamp period.
+   * This method is the equivalent to :
+   * > curl -X GET http://(replayAddress):(replayPort)/replay/(startTimestamp)/(endTimestamp) \
+   *     -H 'Content-Type: application/json'
+   */
+  public static EventReplayResult replay(final String replayAddress,
+                                         final int replayPort,
+                                         final long startTimestamp,
+                                         final long endTimestamp) {
+    try {
+      final String urlString = getReplayServerUrl(replayAddress, replayPort) + "/replay";
+      final URL url;
+
+      if (startTimestamp == -1) {
+        url = new URL(urlString);
+      } else {
+        if (endTimestamp == -1) {
+          url = new URL(urlString + "/" + startTimestamp);
+        } else {
+          url = new URL(urlString + "/" + startTimestamp + "/" + endTimestamp);
+        }
+      }
+
+      final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+      conn.setRequestMethod("GET");
+      conn.setRequestProperty("Content-Type", "application/json");
+
+      if (conn.getResponseCode() != 200) {
+        LOG.log(Level.WARNING, "Failed : HTTP error code is {0}. Failure Response message : {1}",
+            new Object[]{conn.getResponseCode(), conn.getResponseMessage()});
+
+        // End the connection.
+        conn.disconnect();
+        return new EventReplayResult(false, null);
+      }
+
+      // Get the output from the server
+      final BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+      StringBuilder concatenatedOutput = new StringBuilder();
+      String tmpOutput;
+
+      LOG.log(Level.INFO, "Starting to get events to replay from the server.");
+      while ((tmpOutput = br.readLine()) != null) {
+        concatenatedOutput.append(tmpOutput);
+      }
+      br.close();
+
+      final JSONParser parser = new JSONParser();
+      final JSONObject resultObject = (JSONObject) parser.parse(concatenatedOutput.toString());
+
+      // The map that has a broker(address:port) as a key, and a list of events as a value.
+      final Map<String, Object> brokerEventMap;
+      Object uncastBrokerEventMap = resultObject.get("result");
+      if (uncastBrokerEventMap instanceof Map) {
+        brokerEventMap = (Map<String, Object>) uncastBrokerEventMap;
+      } else {
+        LOG.log(Level.WARNING, "Backup server does not return the broker and events as expected.");
+        return new EventReplayResult(false, null);
+      }
+
+      // The map that has a broker(address:port) as a key, and a list of events as a value.
+      final Map<String, Map<String, List<Tuple<Long, MqttMessage>>>> brokerMqttMessageMap = new HashMap<>();
+      for (Map.Entry<String, Object> entry : brokerEventMap.entrySet()) {
+        final JSONArray eventList = (JSONArray) entry.getValue();
+        final Map<String, List<Tuple<Long, MqttMessage>>> mqttMessages = new HashMap<>();
+        for (final Object eventObject : eventList) {
+          final JSONArray event = (JSONArray) eventObject;
+          final String topic = event.get(1).toString();
+          final MqttMessage mqttMessage = new MqttMessage(event.get(2).toString().getBytes());
+          List<Tuple<Long, MqttMessage>> timestampAndMqttMessageList = mqttMessages.get(topic);
+          if (timestampAndMqttMessageList == null) {
+            timestampAndMqttMessageList = new ArrayList<>();
+            mqttMessages.put(topic, timestampAndMqttMessageList);
+          }
+          timestampAndMqttMessageList.add(new Tuple<>(Long.valueOf(event.get(0).toString()), mqttMessage));
+        }
+        brokerMqttMessageMap.put(entry.getKey(), mqttMessages);
+      }
+
+      // End the connection.
+      conn.disconnect();
+      return new EventReplayResult(true, brokerMqttMessageMap);
+    } catch (Exception e) {
+      LOG.log(Level.WARNING, "No server was found, or another error has occurred.");
+      return new EventReplayResult(false, null);
+    }
+  }
+
+  /**
+   * Removes the data with timestamps faster than the current time.
+   * This method is the equivalent to :
+   * > curl -X GET http://(replayAddress):(replayPort)/checkpoint \
+   *     -H 'Content-Type: application/json'
+   */
+  public static boolean removeOnCheckpoint(final String replayAddress, final int replayPort) {
+    return removeOnCheckpoint(replayAddress, replayPort, -1);
+  }
+
+
+  /**
+   * Removes the data with timestamps faster than the given timestamp.
+   * This method is the equivalent to :
+   * > curl -X GET http://(replayAddress):(replayPort)/checkpoint \
+   *     -H 'Content-Type: application/json' \
+   *     -d '{
+   *        "timestamp": "(timestamp)"
+   *        }'
+   */
+  public static boolean removeOnCheckpoint(final String replayAddress, final int replayPort, final long timestamp) {
+    try {
+      final URL url = new URL(getReplayServerUrl(replayAddress, replayPort) + "/checkpoint");
+      final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+      conn.setRequestMethod("POST");
+      conn.setRequestProperty("Content-Type", "application/json");
+      conn.setDoOutput(true);
+
+      if (timestamp != -1L) {
+        final OutputStreamWriter writer = new OutputStreamWriter(conn.getOutputStream(), "UTF-8");
+        writer.write("{\"timestamp\": \"" + timestamp + "\"}");
+        writer.close();
+      }
+
+      if (conn.getResponseCode() != 200) {
+        LOG.log(Level.WARNING, "Failed : HTTP error code is {0}. Failure Response message : {1}",
+            new Object[]{conn.getResponseCode(), conn.getResponseMessage()});
+
+        // End the connection.
+        conn.disconnect();
+        return false;
+      }
+
+      // The returned content can be ignored.
+
+      // End the connection.
+      conn.disconnect();
+      return true;
+    } catch (Exception e) {
+      e.printStackTrace();
+      return false;
+    }
+  }
+
+  private static String getReplayServerUrl(final String replayAddress, final int replayPort) {
+    return "http://" + replayAddress + ":" + replayPort;
+  }
+
+  private static String getSubscribeRequestBody(final String address, final int port, final String topic) {
+    return "{\"address\": \"" + address + "\", \"port\": " +  port + ", \"topic\": \"" + topic + "\"}";
+  }
+}

--- a/mist-core/src/main/java/edu/snu/mist/core/replay/EventReplayUtils.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/replay/EventReplayUtils.java
@@ -46,7 +46,7 @@ public final class EventReplayUtils {
   /**
    * Sends a POST to make an mqtt connection and subscribe request topic.
    * This method is the equivalent to :
-   * > curl -X POST http://(replayAddress):(replayPort)/subscribe \
+   * > curl -X POST http://(replayServerAddress):(replayServerPort)/subscribe \
    *     -H 'Content-Type: application/json' \
    *     -d '{
    *        "brokerAddress": "(brokerAddress)",
@@ -55,10 +55,10 @@ public final class EventReplayUtils {
    *        }'
    * @return true on success, else false
    */
-  public static boolean subscribe(final String replayAddress, final int replayPort,
+  public static boolean subscribe(final String replayServerAddress, final int replayServerPort,
                                   final String brokerAddress, final int brokerPort, final String topic) {
     try {
-      final URL url = new URL(getReplayServerUrl(replayAddress, replayPort) + "/subscribe");
+      final URL url = new URL(getReplayServerUrl(replayServerAddress, replayServerPort) + "/subscribe");
       final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
       conn.setRequestMethod("POST");
       conn.setRequestProperty("Content-Type", "application/json");
@@ -95,24 +95,24 @@ public final class EventReplayUtils {
   /**
    * Sends a GET to retrieve data within a timestamp period.
    * This method is the equivalent to :
-   * > curl -X GET http://(replayAddress):(replayPort)/replay \
+   * > curl -X GET http://(replayServerAddress):(replayServerPort)/replay \
    *     -H 'Content-Type: application/json' \
    *     -d '{
    *        "brokerURI": "(brokerURI)",
    *        "topic": "(topic)"
    *        }'
    */
-  public static EventReplayResult replay(final String replayAddress,
-                                         final int replayPort,
+  public static EventReplayResult replay(final String replayServerAddress,
+                                         final int replayServerPort,
                                          final String brokerURI,
                                          final String topic) {
-    return replay(replayAddress, replayPort, brokerURI, topic, -1, -1);
+    return replay(replayServerAddress, replayServerPort, brokerURI, topic, -1, -1);
   }
 
   /**
    * Sends a GET to retrieve data within a timestamp period.
    * This method is the equivalent to :
-   * > curl -X GET http://(replayAddress):(replayPort)/replay \
+   * > curl -X GET http://(replayServerAddress):(replayServerPort)/replay \
    *     -H 'Content-Type: application/json' \
    *     -d '{
    *        "brokerURI": "(brokerURI)",
@@ -120,18 +120,18 @@ public final class EventReplayUtils {
    *        "startTimestamp": (startTimestamp)
    *        }'
    */
-  public static EventReplayResult replay(final String replayAddress,
-                                         final int replayPort,
+  public static EventReplayResult replay(final String replayServerAddress,
+                                         final int replayServerPort,
                                          final String brokerURI,
                                          final String topic,
                                          final long startTimestamp) {
-    return replay(replayAddress, replayPort, brokerURI, topic, startTimestamp, -1);
+    return replay(replayServerAddress, replayServerPort, brokerURI, topic, startTimestamp, -1);
   }
 
   /**
    * Sends a GET to retrieve data within a timestamp period.
    * This method is the equivalent to :
-   * > curl -X GET http://(replayAddress):(replayPort)/replay \
+   * > curl -X GET http://(replayServerAddress):(replayServerPort)/replay \
    *     -H 'Content-Type: application/json' \
    *     -d '{
    *        "brokerURI": "(brokerURI)",
@@ -140,14 +140,14 @@ public final class EventReplayUtils {
    *        "endTimestamp": (endTimestamp)
    *        }'
    */
-  public static EventReplayResult replay(final String replayAddress,
-                                         final int replayPort,
+  public static EventReplayResult replay(final String replayServerAddress,
+                                         final int replayServerPort,
                                          final String brokerURI,
                                          final String topic,
                                          final long startTimestamp,
                                          final long endTimestamp) {
     try {
-      final String urlString = getReplayServerUrl(replayAddress, replayPort) + "/replay";
+      final String urlString = getReplayServerUrl(replayServerAddress, replayServerPort) + "/replay";
       final URL url = new URL(urlString);
 
       final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
@@ -220,23 +220,23 @@ public final class EventReplayUtils {
   /**
    * Removes the data with timestamps faster than the current time.
    * This method is the equivalent to :
-   * > curl -X GET http://(replayAddress):(replayPort)/checkpoint \
+   * > curl -X GET http://(replayServerAddress):(replayServerPort)/checkpoint \
    *     -H 'Content-Type: application/json' \
    *     -d '{
    *        "brokerURI": "(brokerURI)",
    *        "topic": "(topic)"
    *        }'
    */
-  public static boolean removeOnCheckpoint(final String replayAddress, final int replayPort,
+  public static boolean removeOnCheckpoint(final String replayServerAddress, final int replayServerPort,
                                            final String brokerURI, final String topic) {
-    return removeOnCheckpoint(replayAddress, replayPort, brokerURI, topic, -1);
+    return removeOnCheckpoint(replayServerAddress, replayServerPort, brokerURI, topic, -1);
   }
 
 
   /**
    * Removes the data with timestamps faster than the given timestamp.
    * This method is the equivalent to :
-   * > curl -X GET http://(replayAddress):(replayPort)/checkpoint \
+   * > curl -X GET http://(replayServerAddress):(replayServerPort)/checkpoint \
    *     -H 'Content-Type: application/json' \
    *     -d '{
    *        "brokerURI": "(brokerURI)",
@@ -286,7 +286,7 @@ public final class EventReplayUtils {
     }
   }
 
-  private static String getReplayServerUrl(final String replayAddress, final int replayPort) {
-    return "http://" + replayAddress + ":" + replayPort;
+  private static String getReplayServerUrl(final String replayServerAddress, final int replayServerPort) {
+    return "http://" + replayServerAddress + ":" + replayServerPort;
   }
 }

--- a/mist-core/src/main/java/edu/snu/mist/core/replay/package-info.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/replay/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * A package that contains classes regarding event replaying.
+ */
+package edu.snu.mist.core.replay;

--- a/mist-core/src/test/java/edu/snu/mist/core/replay/EventReplayUtilsTest.java
+++ b/mist-core/src/test/java/edu/snu/mist/core/replay/EventReplayUtilsTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.core.replay;
+
+import edu.snu.mist.core.utils.MqttUtils;
+import io.moquette.server.Server;
+import org.apache.reef.io.Tuple;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public final class EventReplayUtilsTest {
+
+  @Test
+  public void testSubscribeAndReplay() throws IOException, MqttException, InterruptedException {
+    try {
+      final int replayPortNum = 26523;
+      final String localAddress = "127.0.0.1";
+      final String topic1 = "source/user/gps";
+      final String topic2 = "source/user/heartbeat";
+      final String topic3 = "source/user/doorClosed";
+      final String payload1 = "{\"word\": \"aaa\", \"start_timestamp\": 1}";
+      final String payload2 = "{\"word\": \"bbb\", \"start_timestamp\": 2}";
+      final String payload3 = "{\"word\": \"ccc\", \"start_timestamp\": 3}";
+      final String payload4 = "{\"word\": \"ddd\", \"start_timestamp\": 4}";
+      final String payload5 = "{\"word\": \"eee\", \"start_timestamp\": 5}";
+      final String payload6 = "{\"word\": \"eee\", \"start_timestamp\": 6}";
+      final MockReplayServer server = new MockReplayServer(replayPortNum);
+      final Server mqttBroker = MqttUtils.createMqttBroker();
+      final MqttClient pubClient = new MqttClient(MqttUtils.BROKER_URI, "testPubClient");
+
+      final Thread serverThread = new Thread(new Runnable() {
+        @Override
+        public void run() {
+          server.startServer();
+        }
+      });
+      serverThread.start();
+
+      // Wait for the socket to open.
+      Thread.sleep(1000);
+      while (server.isClosed()) {
+        Thread.sleep(100);
+      }
+      Assert.assertTrue(!server.isClosed());
+
+      // Have the local replay server subscribe to topics 1~3.
+      EventReplayUtils.subscribe(localAddress, replayPortNum,
+          MqttUtils.HOST, Integer.parseInt(MqttUtils.PORT), topic1);
+      EventReplayUtils.subscribe(localAddress, replayPortNum,
+          MqttUtils.HOST, Integer.parseInt(MqttUtils.PORT), topic2);
+      EventReplayUtils.subscribe(localAddress, replayPortNum,
+          MqttUtils.HOST, Integer.parseInt(MqttUtils.PORT), topic3);
+
+      // Add mqtt events to the mock server.
+      pubClient.connect();
+      pubClient.publish(topic1, new MqttMessage(payload1.getBytes()));
+      pubClient.publish(topic1, new MqttMessage(payload2.getBytes()));
+      pubClient.publish(topic1, new MqttMessage(payload3.getBytes()));
+      pubClient.publish(topic2, new MqttMessage(payload4.getBytes()));
+      pubClient.publish(topic2, new MqttMessage(payload4.getBytes()));
+      pubClient.publish(topic3, new MqttMessage(payload5.getBytes()));
+      pubClient.publish(topic2, new MqttMessage(payload6.getBytes()));
+      Thread.sleep(1000);
+
+      // Fetch all events by using the replay method.
+      final EventReplayResult result1 = EventReplayUtils.replay(localAddress, replayPortNum);
+      final Map<String, Map<String, List<Tuple<Long, MqttMessage>>>> result1Map =
+          result1.getBrokerAndTopicMqttMessageMap();
+      Assert.assertEquals(1, result1Map.size());
+
+      final Map<String, List<Tuple<Long, MqttMessage>>> result1BrokerMap = result1Map.get(MqttUtils.BROKER_URI);
+      Assert.assertEquals(3, result1BrokerMap.size());
+      final List<Tuple<Long, MqttMessage>> topic1Events = result1BrokerMap.get(topic1);
+      Assert.assertEquals(3, topic1Events.size());
+      final List<Tuple<Long, MqttMessage>> topic2Events = result1BrokerMap.get(topic2);
+      Assert.assertEquals(3, topic2Events.size());
+      final List<Tuple<Long, MqttMessage>> topic3Events = result1BrokerMap.get(topic3);
+      Assert.assertEquals(1, topic3Events.size());
+
+      // Fetch events from timestamp 3L ~ 5L using the replay method.
+      final EventReplayResult result2 = EventReplayUtils.replay(localAddress, replayPortNum, 3L, 5L);
+      final Map<String, Map<String, List<Tuple<Long, MqttMessage>>>> result2Map =
+          result2.getBrokerAndTopicMqttMessageMap();
+      Assert.assertEquals(1, result2Map.size());
+
+      final Map<String, List<Tuple<Long, MqttMessage>>> result2BrokerMap = result2Map.get(MqttUtils.BROKER_URI);
+      Assert.assertEquals(3, result2BrokerMap.size());
+      final List<Tuple<Long, MqttMessage>> topic1Events2 = result2BrokerMap.get(topic1);
+      Assert.assertEquals(1, topic1Events2.size());
+      final List<Tuple<Long, MqttMessage>> topic2Events2 = result2BrokerMap.get(topic2);
+      Assert.assertEquals(2, topic2Events2.size());
+      final List<Tuple<Long, MqttMessage>> topic3Events2 = result2BrokerMap.get(topic3);
+      Assert.assertEquals(1, topic3Events2.size());
+
+      // Remove events from the server using the checkpoint method,
+      // and check if it has been properly removed by using the replay method.
+      EventReplayUtils.removeOnCheckpoint(localAddress, replayPortNum, 5L);
+      Thread.sleep(500);
+      final EventReplayResult result3 = EventReplayUtils.replay(localAddress, replayPortNum);
+      final Map<String, Map<String, List<Tuple<Long, MqttMessage>>>> result3Map =
+          result3.getBrokerAndTopicMqttMessageMap();
+      System.out.println(result3Map);
+      Assert.assertEquals(1, result3Map.size());
+      final Map<String, List<Tuple<Long, MqttMessage>>> result3BrokerMap = result3Map.get(MqttUtils.BROKER_URI);
+      Assert.assertEquals(1, result3BrokerMap.size());
+      final List<Tuple<Long, MqttMessage>> topic2Events3 = result3BrokerMap.get(topic2);
+      Assert.assertEquals(1, topic2Events3.size());
+
+      // Disconnect and close all clients and servers.
+      pubClient.disconnect();
+      server.closeServer();
+      mqttBroker.stopServer();
+    } catch (final Exception e) {
+      e.printStackTrace();
+      throw e;
+    }
+  }
+}

--- a/mist-core/src/test/java/edu/snu/mist/core/replay/EventReplayUtilsTest.java
+++ b/mist-core/src/test/java/edu/snu/mist/core/replay/EventReplayUtilsTest.java
@@ -30,8 +30,11 @@ import java.util.Map;
 
 public final class EventReplayUtilsTest {
 
+  /**
+   * This test tests the subscribe, replay, and removeOnCheckpoint APIs of the EventReplayUtils class.
+   */
   @Test
-  public void testSubscribeAndReplay() throws IOException, MqttException, InterruptedException {
+  public void testUtils() throws IOException, MqttException, InterruptedException {
     try {
       final int replayPortNum = 26523;
       final String localAddress = "127.0.0.1";

--- a/mist-core/src/test/java/edu/snu/mist/core/replay/MockReplayServer.java
+++ b/mist-core/src/test/java/edu/snu/mist/core/replay/MockReplayServer.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.mist.core.replay;
+
+import edu.snu.mist.core.utils.MqttUtils;
+import org.apache.htrace.fasterxml.jackson.core.type.TypeReference;
+import org.apache.htrace.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
+import org.eclipse.paho.client.mqttv3.MqttCallback;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.json.simple.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class MockReplayServer {
+
+  private static final Logger LOG = Logger.getLogger(MockReplayServer.class.getName());
+
+  /**
+   * The port number of this mock replay server.
+   */
+  private int portNum;
+
+  /**
+   * The server socket of this server.
+   */
+  private ServerSocket serverSocket;
+
+  /**
+   * The broker address and stored events.
+   */
+  private Map<String, List<List<Object>>> brokerEventListMap;
+
+  /**
+   * The Mqtt client to subscribe to the broker.
+   */
+  private MqttClient subClient;
+
+  public MockReplayServer(final int portNum) {
+    this.portNum = portNum;
+    this.brokerEventListMap = new HashMap<>();
+  }
+
+  /**
+   * Method to start and run the server.
+   */
+  public void startServer() {
+    try {
+      subClient = new MqttClient(MqttUtils.BROKER_URI, "testSubClient");
+
+      serverSocket = new ServerSocket(portNum);
+      LOG.log(Level.INFO, "The mock server was successfully started.");
+      while (!serverSocket.isClosed()) {
+        // If the socket is "close"d by another thread, the accept() method throws a SocketException.
+        final Socket client = serverSocket.accept();
+        // Get input and output streams to talk to the client.
+        final BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(client.getInputStream()));
+        final PrintWriter printWriter = new PrintWriter(client.getOutputStream(), true);
+
+        // Parse the input.
+        String request = bufferedReader.readLine(); // The request line, such as "GET /replay HTTP/1.1".
+        String[] requestParam = request.split(" ");
+        String url = requestParam[1];
+        if (url.startsWith("/replay")) {
+          handleReplay(url, printWriter);
+        } else if (url.equals("/checkpoint")) {
+          handleCheckpoint(bufferedReader, printWriter);
+        } else if (url.equals("/subscribe")) {
+          handleSubscribe(bufferedReader, printWriter);
+        }
+        Thread.sleep(1000);
+        bufferedReader.close();
+        printWriter.close();
+      }
+    } catch (final SocketException e) {
+      LOG.log(Level.INFO, "The mock server was closed.");
+    } catch (final Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  /**
+   * Method to close the server.
+   */
+  public void closeServer() {
+    try {
+      if (subClient.isConnected()) {
+        subClient.disconnect();
+      }
+      serverSocket.close();
+    } catch (final Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  /**
+   * A method to handle replay requests.
+   */
+  private void handleReplay(final String url,
+                           final PrintWriter printWriter) throws IOException {
+    sendHeader(printWriter);
+
+    // Send the mqtt messages according to the url parameters.
+    final String[] urlParams = url.substring(1).split("/");
+    final Map<String, Map<String, List<List<Object>>>> eventMap = new HashMap<>();
+    if (urlParams.length == 1) {
+      // replay all events
+      eventMap.put("result", brokerEventListMap);
+    } else if (urlParams.length >= 2) {
+      // The starting timestamp.
+      final Long startTimestamp = Long.parseLong(urlParams[1]);
+      Long endTimestamp = null;
+      if (urlParams.length == 3) {
+        endTimestamp = Long.parseLong(urlParams[2]);
+      }
+      final Map<String, List<List<Object>>> filteredBrokerEventListMap = new HashMap<>();
+      for (final Map.Entry<String, List<List<Object>>> entry : brokerEventListMap.entrySet()) {
+        final String brokerAddress = entry.getKey();
+        final List<List<Object>> allEvents = entry.getValue();
+        final List<List<Object>> filteredEvents = new ArrayList<>();
+        for (final List<Object> event : allEvents) {
+          final Long timestamp = (Long) event.get(0);
+          if (timestamp >= startTimestamp) {
+            if (endTimestamp == null) {
+              filteredEvents.add(event);
+            } else if (timestamp <= endTimestamp) {
+              filteredEvents.add(event);
+            }
+          }
+        }
+        filteredBrokerEventListMap.put(brokerAddress, filteredEvents);
+      }
+      eventMap.put("result", filteredBrokerEventListMap);
+    }
+    // Output the finished JSON response.
+    JSONObject.writeJSONString(eventMap, printWriter);
+    printWriter.flush();
+  }
+
+  /**
+   * A method to handle checkpoint requests.
+   */
+  private void handleCheckpoint(final BufferedReader bufferedReader,
+                                final PrintWriter printWriter) {
+    try {
+      sendHeader(printWriter);
+      String currentLine = bufferedReader.readLine();
+      while (currentLine != null && !currentLine.equals("")) {
+        currentLine = bufferedReader.readLine();
+      }
+      // The line after the empty line is the body.
+      currentLine = bufferedReader.readLine();
+      final ObjectMapper mapper = new ObjectMapper();
+      final Map<String, String> contentMap = mapper.readValue(currentLine,
+          new TypeReference<Map<String, String>>() {
+          });
+      final Long checkpointTimestamp = Long.parseLong(contentMap.get("timestamp"));
+      for (final Map.Entry<String, List<List<Object>>> me : brokerEventListMap.entrySet()) {
+        final List<List<Object>> newEventList = new ArrayList<>();
+        final List<List<Object>> eventList = me.getValue();
+        for (final List<Object> event : eventList) {
+          final Long eventTimestamp = (Long) event.get(0);
+          if (eventTimestamp > checkpointTimestamp) {
+            newEventList.add(event);
+          }
+        }
+        if (newEventList.size() == 0) {
+          brokerEventListMap.remove(me.getKey());
+        } else {
+          brokerEventListMap.put(me.getKey(), newEventList);
+        }
+      }
+    } catch (final Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  /**
+   * A method to handle subscribe reqeusts.
+   */
+  private void handleSubscribe(final BufferedReader bufferedReader,
+                              final PrintWriter printWriter) {
+    try {
+      sendHeader(printWriter);
+      String currentLine = bufferedReader.readLine();
+      while (currentLine != null && !currentLine.equals("")) {
+        currentLine = bufferedReader.readLine();
+      }
+      // The line after the empty line is the body.
+      currentLine = bufferedReader.readLine();
+      final ObjectMapper mapper = new ObjectMapper();
+      final Map<String, String> contentMap = mapper.readValue(currentLine,
+          new TypeReference<Map<String, String>>() { });
+
+      if (!subClient.isConnected()) {
+        subClient.connect();
+        subClient.setCallback(new TestMqttSubscriber());
+      }
+      subClient.subscribe(contentMap.get("topic"));
+    } catch (final Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  /**
+   * Add an event to this replay server.
+   */
+  private void addEvent(final Long timestamp,
+                        final String topic,
+                        final String mqttMessage) {
+    final List<Object> newEvent = new ArrayList<>();
+    newEvent.add(timestamp);
+    newEvent.add(topic);
+    final StringBuilder message = new StringBuilder();
+    message.append("{\"text\": ");
+    message.append("\"" + mqttMessage + "\", ");
+    message.append("\"start_timestamp\": ");
+    message.append(timestamp.toString() + "}");
+    newEvent.add(message.toString());
+    List<List<Object>> eventList = brokerEventListMap.getOrDefault(MqttUtils.BROKER_URI, new ArrayList<>());
+    eventList.add(newEvent);
+    brokerEventListMap.put(MqttUtils.BROKER_URI, eventList);
+  }
+
+  public boolean isClosed() {
+    return serverSocket.isClosed();
+  }
+
+  /**
+   * Send a header that indicates success.
+   */
+  private void sendHeader(final PrintWriter printWriter) {
+    final StringBuilder header = new StringBuilder();
+    header.append("HTTP/1.1 200 OK\n");
+    header.append("Content-Type: application/json\n");
+    printWriter.write(header.toString());
+    printWriter.println();
+  }
+
+  /**
+   * Mqtt subscriber that is used in the sink test.
+   */
+  private final class TestMqttSubscriber implements MqttCallback {
+    @Override
+    public void connectionLost(final Throwable cause) {
+      // do nothing
+    }
+
+    @Override
+    public void messageArrived(final String topic, final MqttMessage message) throws Exception {
+      final ObjectMapper mapper = new ObjectMapper();
+      final Map<String, String> payloadMap = mapper.readValue(new String(message.getPayload()),
+          new TypeReference<Map<String, String>>() { });
+      final Long timestamp = Long.parseLong(payloadMap.get("start_timestamp"));
+      final String word = payloadMap.get("word");
+      addEvent(timestamp, topic, word);
+    }
+
+    @Override
+    public void deliveryComplete(final IMqttDeliveryToken token) {
+      // do nothing
+    }
+  }
+}

--- a/mist-core/src/test/java/edu/snu/mist/core/replay/package-info.java
+++ b/mist-core/src/test/java/edu/snu/mist/core/replay/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * This package contains test cases of replaying.
+ */
+package edu.snu.mist.core.replay;


### PR DESCRIPTION
This PR addresses #1135 by:
- adding json-simple to the MIST core's pom.xml, for parsing to and from JSON objects
- adding a EventReplayUtils class with the API (replay, checkpoint, subscribe)
- MockReplayServer, which can be used as a fully functioning replay server
- EventReplayUtilsTest, that is used for testing the EventReplayUtils class

Closes #1135