### PR TITLE
[MIST-1141] Fix IllegalArgumentException on OverloadedTaskThreshold

### DIFF
--- a/mist-core/src/main/java/edu/snu/mist/core/configs/MistCommandLineOptions.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/configs/MistCommandLineOptions.java
@@ -79,7 +79,6 @@ public final class MistCommandLineOptions {
         .registerShortNameOfClass(IdleTaskLoadThreshold.class)
         .registerShortNameOfClass(MaxTaskNum.class)
         .registerShortNameOfClass(MinTaskNum.class)
-        .registerShortNameOfClass(OverloadedTaskLoadThreshold.class)
         .registerShortNameOfClass(ScaleInGracePeriod.class)
         .registerShortNameOfClass(ScaleInIdleTaskRatio.class)
         .registerShortNameOfClass(ScaleOutGracePeriod.class)


### PR DESCRIPTION
This PR Resolves #1141 via

* Fix redundant named parameter binding in MistCommandLineOptions.