### PR TITLE
[MIST-1142] Increase the time limit for testNettyTextSink

### DIFF
--- a/mist-core/src/test/java/edu/snu/mist/core/sinks/NettyTextSinkTest.java
+++ b/mist-core/src/test/java/edu/snu/mist/core/sinks/NettyTextSinkTest.java
@@ -62,7 +62,7 @@ public final class NettyTextSinkTest {
    * It creates 4 sinks and send outputs to output receiver.
    * @throws Exception
    */
-  @Test(timeout = 4000L)
+  @Test(timeout = 10000L)
   public void testNettyTextSink() throws Exception {
     final int numSinks = 4;
     final List<String> outputStream = Arrays.asList(


### PR DESCRIPTION
This PR resolves #1142 via

* Increasing the time limit for `testNettyTextSink()`.