### PR TITLE
[MIST-1033] Recovery queries with no checkpoints

### DIFF
--- a/mist-core/src/main/java/edu/snu/mist/core/task/checkpointing/CheckpointManager.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/checkpointing/CheckpointManager.java
@@ -38,10 +38,18 @@ public interface CheckpointManager {
 
   /**
    * Store the given query to the disk.
-   * @param avroDag
+   * @param avroDag The avro dag to be stored.
+   * @param group The group.
    * @return
    */
-  boolean storeQuery(AvroDag avroDag);
+  boolean storeQuery(Group group, AvroDag avroDag);
+
+  /**
+   * Create the group query information file.
+   * @param group the group.
+   * @return success / fail
+   */
+  boolean createGroupQueryInfoFile(Group group);
 
   /**
    * Checkpoint a single group.

--- a/mist-core/src/main/java/edu/snu/mist/core/task/stores/DefaultGroupCheckpointStore.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/stores/DefaultGroupCheckpointStore.java
@@ -35,9 +35,14 @@ import org.apache.reef.io.Tuple;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -89,10 +94,17 @@ public final class DefaultGroupCheckpointStore implements GroupCheckpointStore {
     return new File(tmpFolderPath, sb.toString());
   }
 
+  private File getGroupQueryInfoFile(final String groupId) {
+    final StringBuilder sb = new StringBuilder(groupId);
+    sb.append(".querylist");
+    return new File(tmpFolderPath, sb.toString());
+  }
+
   @Override
-  public boolean saveQuery(final AvroDag avroDag) {
+  public boolean saveQuery(final Group group, final AvroDag avroDag) {
     final String queryId = avroDag.getQueryId();
     try {
+      // Store dag to a separate file.
       final File storedFile = getQueryStoreFile(queryId);
       if (storedFile.exists()) {
         storedFile.delete();
@@ -102,7 +114,17 @@ public final class DefaultGroupCheckpointStore implements GroupCheckpointStore {
       dataFileWriter.create(avroDag.getSchema(), storedFile);
       dataFileWriter.append(avroDag);
       dataFileWriter.close();
+      // Update the group query info file.
+      final String groupId = group.getGroupId();
+      final File groupQueryInfoFile = getGroupQueryInfoFile(groupId);
+      if (!groupQueryInfoFile.exists()) {
+        throw new IllegalStateException("Group query info file is not created!");
+      }
       LOG.log(Level.INFO, "Query {0} has been stored to disk.", queryId);
+      final BufferedWriter writer = Files.newBufferedWriter(groupQueryInfoFile.toPath(), StandardOpenOption.WRITE,
+          StandardOpenOption.APPEND);
+      writer.write(queryId + ",");
+      writer.close();
       return true;
     } catch (final Exception e) {
       e.printStackTrace();
@@ -168,6 +190,32 @@ public final class DefaultGroupCheckpointStore implements GroupCheckpointStore {
       LOG.log(Level.WARNING, "Checkpoint file not found or error during loading. groupId is " + groupId);
     }
     return mgc;
+  }
+
+  @Override
+  public List<String> loadSaveGroupQueryInfo(final String groupId) throws IOException {
+    final File groupQueryInfoFile = getGroupQueryInfoFile(groupId);
+    final BufferedReader reader = Files.newBufferedReader(groupQueryInfoFile.toPath());
+
+    final String line = reader.readLine();
+    final String trimmedLine = line.substring(0, line.lastIndexOf(','));
+    return Arrays.asList(trimmedLine.split(","));
+  }
+
+  @Override
+  public boolean createGroupQueryInfoFile(final Group group) {
+    final String groupId = group.getGroupId();
+    final File queryInfoFile = getGroupQueryInfoFile(group.getGroupId());
+    try {
+      if (queryInfoFile.exists()) {
+        queryInfoFile.delete();
+        LOG.log(Level.INFO, "Group query info deleted for groupId: {0}", groupId);
+      }
+      return queryInfoFile.createNewFile();
+    } catch (final IOException e) {
+      e.printStackTrace();
+      return false;
+    }
   }
 
   @Override

--- a/mist-core/src/main/java/edu/snu/mist/core/task/stores/GroupCheckpointStore.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/stores/GroupCheckpointStore.java
@@ -43,12 +43,28 @@ public interface GroupCheckpointStore {
   GroupCheckpoint loadSavedGroupState(String groupId) throws IOException;
 
   /**
+   * Load a saved group query info.
+   * @param groupId groupId.
+   * @return the list of queries in the group.
+   * @throws IOException
+   */
+  List<String> loadSaveGroupQueryInfo(String groupId) throws IOException;
+
+  /**
    * Save the given query to the disk.
    *
-   * @param avroDag
-   * @return
+   * @param group the group of the dag
+   * @param avroDag the avro dag to be stored
+   * @return success / fail
    */
-  boolean saveQuery(AvroDag avroDag);
+  boolean saveQuery(Group group, AvroDag avroDag);
+
+  /**
+   * Creates the group query info file.
+   * @param group the group
+   * @return success / fail
+   */
+  boolean createGroupQueryInfoFile(Group group);
 
   /**
    * Load the avro dags from the group.


### PR DESCRIPTION
This PR solves #1033 via

* Store submitted query lists for each group.
* Read query list file instead of checkpoint file when recovering queries.