### PR TITLE
[MIST-1162] Fix uncaught exception on RecoveryStarter

### DIFF
--- a/mist-core/src/main/java/edu/snu/mist/core/master/recovery/RecoveryStarter.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/recovery/RecoveryStarter.java
@@ -75,6 +75,7 @@ public final class RecoveryStarter implements Runnable {
       LOG.log(Level.INFO, "Recovery is finished in {0} ms...", System.currentTimeMillis() - startTime);
     } catch (final AvroRemoteException | InterruptedException e) {
       e.printStackTrace();
+      throw new RuntimeException("Failed to start recovery...");
     }
   }
 }


### PR DESCRIPTION
This PR closes #1162 via

* Catch `AvroRemoteException` and `InterruptedException` in `RecoveryStarter`.