### PR TITLE
[MIST-1161] Fix ClassNotFoundException on state deserialization

### DIFF
--- a/mist-core/src/main/java/edu/snu/mist/core/task/StateSerializer.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/StateSerializer.java
@@ -17,8 +17,10 @@ package edu.snu.mist.core.task;
 
 import edu.snu.mist.common.SerializeUtils;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.Serializable;
 import java.nio.ByteBuffer;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -67,13 +69,16 @@ public final class StateSerializer {
    */
   private static ByteBuffer serializeState(final Object obj) throws RuntimeException {
     try {
+      final String serializedString = SerializeUtils.serializeToString((Serializable) obj);
+      return ByteBuffer.wrap(Base64.getEncoder().encode(serializedString.getBytes()));
+      /**
       try (final ByteArrayOutputStream b = new ByteArrayOutputStream()) {
         try (final ObjectOutputStream o = new ObjectOutputStream(b)) {
           o.writeObject(obj);
           o.flush();
         }
         return ByteBuffer.wrap(b.toByteArray());
-      }
+      }**/
     } catch (final IOException e) {
       LOG.log(Level.SEVERE, "An exception occured while serializing the state.");
       e.printStackTrace();

--- a/mist-core/src/main/java/edu/snu/mist/core/task/StateSerializer.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/StateSerializer.java
@@ -81,6 +81,10 @@ public final class StateSerializer {
     }
   }
 
+  public static Map<String, Object> deserializeStateMap(final Map<String, Object> serializedStateMap) {
+    return deserializeStateMap(serializedStateMap, null);
+  }
+
   /**
    * Receives a Map<String, ByteBuffer>, deserializes the values, and returns it.
    * @param serializedStateMap
@@ -116,7 +120,11 @@ public final class StateSerializer {
     final byte[] bytes = new byte[byteBuffer.remaining()];
     byteBuffer.get(bytes);
     try {
-      return SerializeUtils.deserializeFromString(new String(bytes), classLoader);
+      if (classLoader != null) {
+        return SerializeUtils.deserializeFromString(new String(bytes), classLoader);
+      } else {
+        return SerializeUtils.deserializeFromString(new String(bytes));
+      }
       /**
       try (final ByteArrayInputStream b = new ByteArrayInputStream(bytes)) {
         try (final ObjectInputStream o = new ObjectInputStream(b)) {

--- a/mist-core/src/main/java/edu/snu/mist/core/task/StateSerializer.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/StateSerializer.java
@@ -20,7 +20,6 @@ import edu.snu.mist.common.SerializeUtils;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -70,7 +69,7 @@ public final class StateSerializer {
   private static ByteBuffer serializeState(final Object obj) throws RuntimeException {
     try {
       final String serializedString = SerializeUtils.serializeToString((Serializable) obj);
-      return ByteBuffer.wrap(Base64.getEncoder().encode(serializedString.getBytes()));
+      return ByteBuffer.wrap(serializedString.getBytes());
       /**
       try (final ByteArrayOutputStream b = new ByteArrayOutputStream()) {
         try (final ObjectOutputStream o = new ObjectOutputStream(b)) {

--- a/mist-core/src/main/java/edu/snu/mist/core/task/StateSerializer.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/StateSerializer.java
@@ -15,6 +15,8 @@
  */
 package edu.snu.mist.core.task;
 
+import edu.snu.mist.common.SerializeUtils;
+
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -84,14 +86,15 @@ public final class StateSerializer {
    * @param serializedStateMap
    * @return the deserialized StateMap
    */
-  public static Map<String, Object> deserializeStateMap(final Map<String, Object> serializedStateMap)
+  public static Map<String, Object> deserializeStateMap(final Map<String, Object> serializedStateMap,
+                                                        final ClassLoader classLoader)
       throws RuntimeException {
     final Map<String, Object> result = new HashMap<>();
     for (final Map.Entry<String, Object> mapEntry : serializedStateMap.entrySet()) {
       final Object state = mapEntry.getValue();
       if (state instanceof ByteBuffer) {
         try {
-          final Object deserializedState = deserializeState((ByteBuffer)state);
+          final Object deserializedState = deserializeState((ByteBuffer)state, classLoader);
           result.put(mapEntry.getKey(), deserializedState);
         } catch (final RuntimeException e) {
           throw e;
@@ -108,15 +111,18 @@ public final class StateSerializer {
    * @param byteBuffer
    * @return the deserialized state
    */
-  private static Object deserializeState(final ByteBuffer byteBuffer) throws RuntimeException {
+  private static Object deserializeState(final ByteBuffer byteBuffer,
+                                         final ClassLoader classLoader) throws RuntimeException {
     final byte[] bytes = new byte[byteBuffer.remaining()];
     byteBuffer.get(bytes);
     try {
+      return SerializeUtils.deserializeFromString(new String(bytes), classLoader);
+      /**
       try (final ByteArrayInputStream b = new ByteArrayInputStream(bytes)) {
         try (final ObjectInputStream o = new ObjectInputStream(b)) {
           return o.readObject();
         }
-      }
+      }**/
     } catch (final Exception e) {
       LOG.log(Level.SEVERE, "An exception occured while deserializing the state.");
       e.printStackTrace();

--- a/mist-core/src/main/java/edu/snu/mist/core/task/StateSerializer.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/StateSerializer.java
@@ -70,14 +70,6 @@ public final class StateSerializer {
     try {
       final String serializedString = SerializeUtils.serializeToString((Serializable) obj);
       return ByteBuffer.wrap(serializedString.getBytes());
-      /**
-      try (final ByteArrayOutputStream b = new ByteArrayOutputStream()) {
-        try (final ObjectOutputStream o = new ObjectOutputStream(b)) {
-          o.writeObject(obj);
-          o.flush();
-        }
-        return ByteBuffer.wrap(b.toByteArray());
-      }**/
     } catch (final IOException e) {
       LOG.log(Level.SEVERE, "An exception occured while serializing the state.");
       e.printStackTrace();
@@ -129,12 +121,6 @@ public final class StateSerializer {
       } else {
         return SerializeUtils.deserializeFromString(new String(bytes));
       }
-      /**
-      try (final ByteArrayInputStream b = new ByteArrayInputStream(bytes)) {
-        try (final ObjectInputStream o = new ObjectInputStream(b)) {
-          return o.readObject();
-        }
-      }**/
     } catch (final Exception e) {
       LOG.log(Level.SEVERE, "An exception occured while deserializing the state.");
       e.printStackTrace();

--- a/mist-core/src/main/java/edu/snu/mist/core/task/merging/DefaultExecutionVertexGeneratorImpl.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/task/merging/DefaultExecutionVertexGeneratorImpl.java
@@ -70,7 +70,7 @@ final class DefaultExecutionVertexGeneratorImpl implements ExecutionVertexGenera
             physicalObjectGenerator.newOperator(conf, classLoader));
         if (configVertex.getState().size() != 0) {
           ((StateHandler) operator.getOperator()).setState(
-              StateSerializer.deserializeStateMap(configVertex.getState()));
+              StateSerializer.deserializeStateMap(configVertex.getState(), classLoader));
         }
         if (configVertex.getLatestCheckpointTimestamp() != 0) {
           ((StateHandler) operator.getOperator()).setRecoveredTimestamp(


### PR DESCRIPTION
This PR closes #1161 via

* Adding external class loaders for deserialization.
* Use internal `SerializeUtils` when (de)serializing the states.