### PR TITLE
[MIST-1166] Handling recovery with no failed groups

### DIFF
--- a/mist-core/src/main/java/edu/snu/mist/core/master/recovery/DistributedRecoveryScheduler.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/recovery/DistributedRecoveryScheduler.java
@@ -99,17 +99,13 @@ public final class DistributedRecoveryScheduler implements RecoveryScheduler {
 
   @Override
   public synchronized void startRecovery(final Map<String, GroupStats> failedGroups) {
+    if (failedGroups.isEmpty()) {
+      isRecoveryOngoing.set(false);
+      return;
+    }
     if (!isRecoveryOngoing.compareAndSet(false, true)) {
       throw new IllegalStateException("Internal Error : startRecovery() is called while other recovery process is " +
           "already running!");
-    }
-    if (failedGroups.isEmpty()) {
-      // Release the possibly awaiting thread when the failed groups are empty.
-      lock.lock();
-      isRecoveryOngoing.set(true);
-      recoveryFinished.signalAll();
-      lock.unlock();
-      return;
     }
     LOG.log(Level.INFO, "Start distributed recovery on failed groups: {0}", failedGroups.keySet());
     recoveryGroups.putAll(failedGroups);

--- a/mist-core/src/main/java/edu/snu/mist/core/master/recovery/DistributedRecoveryScheduler.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/recovery/DistributedRecoveryScheduler.java
@@ -103,6 +103,14 @@ public final class DistributedRecoveryScheduler implements RecoveryScheduler {
       throw new IllegalStateException("Internal Error : startRecovery() is called while other recovery process is " +
           "already running!");
     }
+    if (failedGroups.isEmpty()) {
+      // Release the possibly awaiting thread when the failed groups are empty.
+      lock.lock();
+      isRecoveryOngoing.set(true);
+      recoveryFinished.signalAll();
+      lock.unlock();
+      return;
+    }
     LOG.log(Level.INFO, "Start distributed recovery on failed groups: {0}", failedGroups.keySet());
     recoveryGroups.putAll(failedGroups);
     final List<MasterToTaskMessage> proxyToRecoveryTaskList = new ArrayList<>();

--- a/mist-core/src/main/java/edu/snu/mist/core/master/recovery/DistributedRecoveryScheduler.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/recovery/DistributedRecoveryScheduler.java
@@ -100,7 +100,7 @@ public final class DistributedRecoveryScheduler implements RecoveryScheduler {
   @Override
   public synchronized void startRecovery(final Map<String, GroupStats> failedGroups) {
     if (failedGroups.isEmpty()) {
-      isRecoveryOngoing.set(false);
+      LOG.log(Level.INFO, "No groups to recover...");
       return;
     }
     if (!isRecoveryOngoing.compareAndSet(false, true)) {

--- a/mist-core/src/main/java/edu/snu/mist/core/master/recovery/SingleNodeRecoveryScheduler.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/recovery/SingleNodeRecoveryScheduler.java
@@ -84,7 +84,7 @@ public final class SingleNodeRecoveryScheduler implements RecoveryScheduler {
   @Override
   public synchronized void startRecovery(final Map<String, GroupStats> failedGroups) {
     if (failedGroups.isEmpty()) {
-      isRecoveryOngoing.set(false);
+      LOG.log(Level.INFO, "No groups to recover...");
       return;
     }
     if (!isRecoveryOngoing.compareAndSet(false, true)) {

--- a/mist-core/src/main/java/edu/snu/mist/core/master/recovery/SingleNodeRecoveryScheduler.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/recovery/SingleNodeRecoveryScheduler.java
@@ -87,6 +87,14 @@ public final class SingleNodeRecoveryScheduler implements RecoveryScheduler {
       throw new IllegalStateException("Internal Error : startRecovery() is called while other recovery process is " +
           "already running!");
     }
+    if (failedGroups.isEmpty()) {
+      // Release the possibly awaiting thread when the failed groups are empty.
+      lock.lock();
+      isRecoveryOngoing.set(true);
+      recoveryFinished.signalAll();
+      lock.unlock();
+      return;
+    }
     LOG.log(Level.INFO, "Start recovery on failed groups: {0}", failedGroups.keySet());
     recoveryGroups.putAll(failedGroups);
     MasterToTaskMessage proxyToRecoveryTask;


### PR DESCRIPTION
This PR closes #1166 via

* Set conditional variable when there is no failed groups in `RecoveryScheduler`.