### PR TITLE
[MIST-1168] Prevent auto scaling when recovery is ongoing

### DIFF
--- a/mist-core/src/main/java/edu/snu/mist/core/master/recovery/DistributedRecoveryScheduler.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/recovery/DistributedRecoveryScheduler.java
@@ -165,4 +165,9 @@ public final class DistributedRecoveryScheduler implements RecoveryScheduler {
     }
   }
 
+  @Override
+  public boolean isRecoveryOngoing() {
+    return isRecoveryOngoing.get();
+  }
+
 }

--- a/mist-core/src/main/java/edu/snu/mist/core/master/recovery/RecoveryScheduler.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/recovery/RecoveryScheduler.java
@@ -46,4 +46,10 @@ public interface RecoveryScheduler {
    */
   List<String> pullRecoverableGroups(String taskHostname);
 
+  /**
+   * Checks whether the recovery is currently ongoing or not.
+   * @return true if recovery is current ongoing / false if not
+   */
+  boolean isRecoveryOngoing();
+
 }

--- a/mist-core/src/main/java/edu/snu/mist/core/master/recovery/SingleNodeRecoveryScheduler.java
+++ b/mist-core/src/main/java/edu/snu/mist/core/master/recovery/SingleNodeRecoveryScheduler.java
@@ -153,4 +153,9 @@ public final class SingleNodeRecoveryScheduler implements RecoveryScheduler {
       return new ArrayList<>(allocatedGroups);
     }
   }
+
+  @Override
+  public boolean isRecoveryOngoing() {
+    return isRecoveryOngoing.get();
+  }
 }


### PR DESCRIPTION
This PR resolves #1168 via

* Create a method that checks ongoing recovery in `RecoveryScheduler`.
* Checks whether the recovery is currently ongoing or not in `PeriodicDynamicScalingManager`.